### PR TITLE
Modify Search for Filter cache

### DIFF
--- a/backend/crates/fhir-search/src/elastic_search/search/clauses/date.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/clauses/date.rs
@@ -24,7 +24,7 @@ pub fn date(
                     "path": search_param.url.value.as_ref().unwrap(),
                     "query": {
                         "bool": {
-                            "must": [
+                            "filter": [
                                 {
                                     "range": {
                                         search_param.url.value.as_ref().unwrap().to_string() + ".start": {

--- a/backend/crates/fhir-search/src/elastic_search/search/clauses/reference.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/clauses/reference.rs
@@ -33,7 +33,7 @@ pub fn reference(
                             "path": search_param.url.value.as_ref().unwrap(),
                             "query": {
                                 "bool": {
-                                    "must": [
+                                    "filter": [
                                         {
                                             "match": {
                                                 search_param.url.value.as_ref().unwrap().to_string() + ".resource_type": {

--- a/backend/crates/fhir-search/src/elastic_search/search/clauses/token.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/clauses/token.rs
@@ -47,7 +47,7 @@ pub fn token(
                                 "bool": {
                                     matching_type.clone(): [{
                                         "bool": {
-                                            "must": [
+                                            "filter": [
                                                 {
                                                     "match": {
                                                         search_param.url.value.as_ref().unwrap().to_string() + ".code": {

--- a/backend/crates/fhir-search/src/elastic_search/search/mod.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/mod.rs
@@ -316,7 +316,7 @@ pub fn build_elastic_search_query(
         "from": offset,
         "query": {
             "bool": {
-                "must": clauses
+                "filter": clauses
             }
         },
         "sort": sort,


### PR DESCRIPTION
Utilize filter instead of match for scoring. Allows ES to cache results for boolean filters.