### PR TITLE
Separate search parameter json schema into separate tool

### DIFF
--- a/backend/crates/server/src/mcp/operations/list_tools.rs
+++ b/backend/crates/server/src/mcp/operations/list_tools.rs
@@ -17,6 +17,9 @@ use haste_repository::Repository;
 use serde_json::json;
 use std::sync::Arc;
 
+pub const R4_SEARCH_TOOL_NAME: &str = "fhir_r4_search";
+pub const GET_SEARCH_PARAMETERS_TOOL_NAME: &str = "fhir_r4_get_search_parameters";
+
 pub fn search_tool_parameters(
     capability_search_params: &Vec<CapabilityStatementRestResourceSearchParam>,
 ) -> serde_json::Value {
@@ -52,7 +55,10 @@ pub fn search_tool_parameters(
         }
     }
 
-    serde_json::Value::Object(properties)
+    json!({
+        "type": "object",
+        "properties": serde_json::Value::Object(properties),
+    })
 }
 
 fn generate_search_schema(capabilities: &CapabilityStatement) -> Tool {
@@ -75,30 +81,16 @@ fn generate_search_schema(capabilities: &CapabilityStatement) -> Tool {
               let resource_type: Option<String> = rc.type_.as_ref().into();
               resource_type.unwrap_or_default()
           }).collect::<Vec<String>>(),
-        }
+        },
+        "search_parameters": {
+          "type": "object",
+          "description": format!(
+            "Search parameters for the FHIR resource type being queried. Use the '{}' tool to discover available search parameters for each resource type.",
+           GET_SEARCH_PARAMETERS_TOOL_NAME),
+        },
       },
-      "required": ["resourceType"],
-      "oneOf" : resource_capabilities.iter().map(|rc| {
-          let resource_type: Option<String> = rc.type_.as_ref().into();
-          let resource_type = resource_type.unwrap_or_default();
-          json!({
-              "if": {
-                  "properties": {
-                      "resourceType": { "const": resource_type }
-                  }
-              },
-              "then": {
-                  "properties": {
-                      "search_parameters": {
-                          "type": "object",
-                          "properties": search_tool_parameters(
-                              rc.searchParam.as_ref().unwrap_or(&vec![])
-                          ),
-                      }
-                  }
-              }
-          })
-      }).collect::<Vec<serde_json::Value>>()
+      "required": ["resourceType"]
+
     });
 
     Tool {
@@ -110,11 +102,54 @@ fn generate_search_schema(capabilities: &CapabilityStatement) -> Tool {
         icons: vec![],
         input_schema,
         meta: None,
-        name: "fhir_r4_search".to_string(),
+        name: R4_SEARCH_TOOL_NAME.to_string(),
         output_schema: Some(haste_sd_to_json_schema::bundle_of_resource(json!({
             "type": "object"
         }))),
-        title: Some("fhir_r4_search".to_string()),
+        title: Some(R4_SEARCH_TOOL_NAME.to_string()),
+    }
+}
+
+fn generate_get_search_parameters_tool(capabilities: &CapabilityStatement) -> Tool {
+    let default_ = vec![];
+    let resource_capabilities = capabilities
+        .rest
+        .as_ref()
+        .unwrap_or(&default_)
+        .into_iter()
+        .filter_map(|r| r.resource.as_ref())
+        .flatten()
+        .collect::<Vec<_>>();
+
+    let input_schema = json!({
+      "type": "object",
+      "properties": {
+        "resourceType": {
+          "type": "string",
+          "enum": resource_capabilities.iter().map(|rc| {
+              let resource_type: Option<String> = rc.type_.as_ref().into();
+              resource_type.unwrap_or_default()
+          }).collect::<Vec<String>>(),
+        },
+      },
+      "required": ["resourceType"]
+    });
+
+    Tool {
+        annotations: None,
+        description: Some(format!(
+            "Tool to get available search parameters for a given FHIR Resource Type",
+        )),
+        execution: None,
+        icons: vec![],
+        input_schema,
+        meta: None,
+        name: GET_SEARCH_PARAMETERS_TOOL_NAME.to_string(),
+        output_schema: Some(json!({
+            "type": "object",
+            "description": "JSON Schema describing the available search parameters for the specified FHIR Resource Type",
+        })),
+        title: Some(GET_SEARCH_PARAMETERS_TOOL_NAME.to_string()),
     }
 }
 
@@ -128,9 +163,10 @@ pub async fn list_tools<
 ) -> Result<ListToolsResult, MCPError<serde_json::Value>> {
     let capabilities = ctx.client.capabilities(ctx.clone()).await?;
     let search_tool = generate_search_schema(&capabilities);
+    let get_search_parameters_tool = generate_get_search_parameters_tool(&capabilities);
 
     Ok(ListToolsResult {
-        tools: vec![search_tool],
+        tools: vec![search_tool, get_search_parameters_tool],
         meta: None,
         next_cursor: None,
     })

--- a/backend/crates/server/src/mcp/operations/tools_call.rs
+++ b/backend/crates/server/src/mcp/operations/tools_call.rs
@@ -2,6 +2,9 @@ use crate::{
     fhir_client::ServerCTX,
     mcp::{
         error::{MCPError, MCPErrorDetail},
+        operations::{
+            GET_SEARCH_PARAMETERS_TOOL_NAME, R4_SEARCH_TOOL_NAME, search_tool_parameters,
+        },
         request::CallToolRequest,
         schemas::schema_2025_11_25::{CallToolResult, ContentBlock, TextContent, TextContentMeta},
     },
@@ -29,8 +32,8 @@ pub async fn tools_call<
     ctx: Arc<ServerCTX<Repo, Search, Terminology>>,
     request: CallToolRequest,
 ) -> Result<CallToolResult, MCPError<serde_json::Value>> {
-    let content: String = match request.params.name.as_str() {
-        "fhir_r4_search" => {
+    match request.params.name.as_str() {
+        R4_SEARCH_TOOL_NAME => {
             let FHIRSearchArguments {
                 resource_type,
                 search_parameters,
@@ -80,37 +83,84 @@ pub async fn tools_call<
                 )
             })?;
 
-            result
+            Ok(CallToolResult {
+                structured_content: Some(
+                    serde_json::from_str::<serde_json::Value>(&result).map_err(|e| {
+                        OperationOutcomeError::error(
+                            IssueType::Processing(None),
+                            format!("Failed to parse search result JSON: '{}'", e.to_string()),
+                        )
+                    })?,
+                ),
+                content: vec![ContentBlock::TextContent(TextContent {
+                    annotations: None,
+                    meta: Some(TextContentMeta {}),
+                    text: result,
+                    type_: "text".to_string(),
+                })],
+                is_error: Some(false),
+                meta: None,
+            })
         }
-        _ => {
-            return Err(MCPError {
-                id: request.id.clone(),
-                jsonrpc: "2.0".to_string(),
-                error: MCPErrorDetail {
-                    code: 400,
-                    message: "Unknown tool name".to_string(),
-                    data: None,
-                },
-            });
-        }
-    };
 
-    Ok(CallToolResult {
-        structured_content: Some(serde_json::from_str::<serde_json::Value>(&content).map_err(
-            |e| {
-                OperationOutcomeError::error(
-                    IssueType::Processing(None),
-                    format!("Failed to parse search result JSON: '{}'", e.to_string()),
-                )
+        GET_SEARCH_PARAMETERS_TOOL_NAME => {
+            let capabilities = ctx.client.capabilities(ctx.clone()).await?;
+            let resource_capability_statment = capabilities
+                .rest
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|rest| rest.resource)
+                .flatten()
+                .find(|r| {
+                    let rc_type: Option<String> = r.type_.as_ref().into();
+                    rc_type.unwrap_or_default()
+                        == request
+                            .params
+                            .arguments
+                            .as_ref()
+                            .and_then(|args| args.get("resourceType"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                });
+
+            let Some(resource_capability_statment_params) = resource_capability_statment
+                .as_ref()
+                .and_then(|rc| rc.searchParam.as_ref())
+            else {
+                return Err(MCPError {
+                    id: request.id.clone(),
+                    jsonrpc: "2.0".to_string(),
+                    error: MCPErrorDetail {
+                        code: 400,
+                        message: "Invalid resourceType could not find search parameters"
+                            .to_string(),
+                        data: None,
+                    },
+                });
+            };
+
+            let parameters = search_tool_parameters(resource_capability_statment_params);
+
+            Ok(CallToolResult {
+                content: vec![ContentBlock::TextContent(TextContent {
+                    annotations: None,
+                    meta: Some(TextContentMeta {}),
+                    text: serde_json::to_string(&parameters).unwrap_or_default(),
+                    type_: "text".to_string(),
+                })],
+                structured_content: Some(parameters),
+                is_error: Some(false),
+                meta: None,
+            })
+        }
+        _ => Err(MCPError {
+            id: request.id.clone(),
+            jsonrpc: "2.0".to_string(),
+            error: MCPErrorDetail {
+                code: 400,
+                message: "Unknown tool name".to_string(),
+                data: None,
             },
-        )?),
-        content: vec![ContentBlock::TextContent(TextContent {
-            annotations: None,
-            meta: Some(TextContentMeta {}),
-            text: content,
-            type_: "text".to_string(),
-        })],
-        is_error: Some(false),
-        meta: None,
-    })
+        }),
+    }
 }


### PR DESCRIPTION
fhir_r4_search tool no longer contains all schema information for search parameters. Instead a separate tool can be used that generates the json schema allowed for a given resource types search parameters at fhir_r4_get_search_parameters.

fhir_r4_search tool became too bloated and llms don't seem to be able to handle complex json schemas well.