### PR TITLE
Search API span projects

### DIFF
--- a/backend/crates/artifacts/src/search_parameters.rs
+++ b/backend/crates/artifacts/src/search_parameters.rs
@@ -10,7 +10,7 @@ pub enum ArtifactError {
     InvalidResource(String),
 }
 
-pub struct SearchParametersIndex {
+struct SearchParametersIndex {
     by_url: HashMap<String, Arc<SearchParameter>>,
     by_resource_type: HashMap<String, HashMap<String, Arc<SearchParameter>>>,
 }

--- a/backend/crates/fhir-search/src/elastic_search/mod.rs
+++ b/backend/crates/fhir-search/src/elastic_search/mod.rs
@@ -32,6 +32,7 @@ struct SearchEntryPrivate {
     pub id: Vec<ResourceId>,
     pub resource_type: Vec<ResourceType>,
     pub version_id: Vec<VersionId>,
+    pub project: Vec<ProjectId>,
 }
 
 #[derive(OperationOutcomeError, Debug)]
@@ -213,11 +214,12 @@ impl SearchEngine for ElasticSearchEngine {
         &self,
         fhir_version: &SupportedFHIRVersions,
         tenant: &TenantId,
-        project: &ProjectId,
+        projects: &[&ProjectId],
         search_request: &SearchRequest,
         options: Option<SearchOptions>,
     ) -> Result<SearchReturn, haste_fhir_operation_error::OperationOutcomeError> {
-        let query = search::build_elastic_search_query(tenant, project, &search_request, &options)?;
+        let query =
+            search::build_elastic_search_query(tenant, projects, &search_request, &options)?;
 
         let search_response = self
             .client
@@ -249,6 +251,7 @@ impl SearchEngine for ElasticSearchEngine {
                     id: hit.fields.id.pop().unwrap(),
                     resource_type: hit.fields.resource_type.pop().unwrap(),
                     version_id: hit.fields.version_id.pop().unwrap(),
+                    project: hit.fields.project.pop().unwrap(),
                 })
                 .collect(),
         })

--- a/backend/crates/fhir-search/src/elastic_search/search/mod.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/mod.rs
@@ -232,7 +232,7 @@ fn get_parameters<'a>(request: &'a SearchRequest) -> &'a ParsedParameters {
 
 pub fn build_elastic_search_query(
     tenant: &TenantId,
-    project: &ProjectId,
+    projects: &[&ProjectId],
     request: &SearchRequest,
     options: &Option<SearchOptions>,
 ) -> Result<serde_json::Value, QueryBuildError> {
@@ -363,14 +363,21 @@ pub fn build_elastic_search_query(
         }
     }));
 
-    clauses.push(json! ({
-        "match": {
-            "project": project.as_ref()
+    // Allow Span of multiple projects for search.
+    clauses.push(json!({
+        "bool": {
+            "should": projects.iter().map(|project| {
+                json!({
+                    "match": {
+                        "project": project.as_ref()
+                    }
+                })
+            }).collect::<Vec<_>>()
         }
     }));
 
     let query = json!({
-        "fields": ["version_id", "id", "resource_type"],
+        "fields": ["version_id", "id", "resource_type", "project"],
         "size": size,
         "track_total_hits": show_total,
         "_source": false,

--- a/backend/crates/fhir-search/src/lib.rs
+++ b/backend/crates/fhir-search/src/lib.rs
@@ -26,6 +26,7 @@ pub struct SearchEntry {
     pub id: ResourceId,
     pub resource_type: ResourceType,
     pub version_id: VersionId,
+    pub project: ProjectId,
 }
 
 pub struct SearchReturn {
@@ -44,7 +45,7 @@ pub trait SearchEngine: Send + Sync {
         &self,
         fhir_version: &SupportedFHIRVersions,
         tenant: &TenantId,
-        project: &ProjectId,
+        projects: &[&ProjectId],
         search_request: &SearchRequest,
         options: Option<SearchOptions>,
     ) -> impl Future<Output = Result<SearchReturn, OperationOutcomeError>> + Send + Sync;

--- a/backend/crates/server/src/auth_n/oidc/routes/token.rs
+++ b/backend/crates/server/src/auth_n/oidc/routes/token.rs
@@ -378,7 +378,7 @@ async fn find_users_access_policy_version_ids<Search: SearchEngine>(
         .search(
             &SupportedFHIRVersions::R4,
             &tenant,
-            &project,
+            &[&project],
             &SearchRequest::Type(FHIRSearchTypeRequest {
                 resource_type: ResourceType::AccessPolicyV2,
                 parameters: ParsedParameters::new(vec![ParsedParameter::Resource(Parameter {

--- a/backend/crates/server/src/fhir_client/middleware/storage.rs
+++ b/backend/crates/server/src/fhir_client/middleware/storage.rs
@@ -189,7 +189,7 @@ impl<
                             .search(
                                 &context.ctx.fhir_version,
                                 &context.ctx.tenant,
-                                &context.ctx.project,
+                                &[&context.ctx.project],
                                 &delete_search_request,
                                 None,
                             )
@@ -387,7 +387,7 @@ impl<
                             .search(
                                 &context.ctx.fhir_version,
                                 &context.ctx.tenant,
-                                &context.ctx.project,
+                                &[&context.ctx.project],
                                 &SearchRequest::Type(FHIRSearchTypeRequest {
                                     resource_type: update_request.resource_type.clone(),
                                     parameters: ParsedParameters::new(
@@ -527,7 +527,7 @@ impl<
                             .search(
                                 &context.ctx.fhir_version,
                                 &context.ctx.tenant,
-                                &context.ctx.project,
+                                &[&context.ctx.project],
                                 &search_request,
                                 None,
                             )
@@ -564,7 +564,7 @@ impl<
                             .search(
                                 &context.ctx.fhir_version,
                                 &context.ctx.tenant,
-                                &context.ctx.project,
+                                &[&context.ctx.project],
                                 &search_request,
                                 None,
                             )

--- a/backend/crates/server/src/load_artifacts.rs
+++ b/backend/crates/server/src/load_artifacts.rs
@@ -213,7 +213,7 @@ pub async fn get_all_sds<Repo: Repository, Search: SearchEngine>(
         .search(
             &SupportedFHIRVersions::R4,
             &TenantId::System,
-            &ProjectId::System,
+            &[&ProjectId::System],
             &SearchRequest::Type(sd_search),
             Some(SearchOptions { count_limit: false }),
         )
@@ -254,7 +254,7 @@ pub async fn get_all_sps<Repo: Repository, Search: SearchEngine>(
         .search(
             &SupportedFHIRVersions::R4,
             &TenantId::System,
-            &ProjectId::System,
+            &[&ProjectId::System],
             &SearchRequest::Type(sp_search),
             Some(SearchOptions { count_limit: false }),
         )


### PR DESCRIPTION
Initial piece so can support spanning projects. This is mostly to begin work allowing users to create their own profiles and (SPs but will gate this). Because we have core set of  meta resources that live on system projects search would need to span both the users current project and the system project in these cases.