### PR TITLE
Tier Limits

### DIFF
--- a/backend/crates/server/src/fhir_client/middleware/mod.rs
+++ b/backend/crates/server/src/fhir_client/middleware/mod.rs
@@ -14,6 +14,7 @@ pub mod operations;
 pub mod rate_limit;
 pub mod set_artifact_tenant;
 pub mod storage;
+pub mod subscription_tier_limit;
 pub mod transaction;
 pub mod validation;
 

--- a/backend/crates/server/src/fhir_client/middleware/subscription_tier_limit.rs
+++ b/backend/crates/server/src/fhir_client/middleware/subscription_tier_limit.rs
@@ -3,6 +3,8 @@
 use crate::fhir_client::{
     ServerCTX,
     middleware::{ServerMiddlewareContext, ServerMiddlewareNext, ServerMiddlewareOutput},
+    subscription_limits::resource_limits::{TenantResourceLimit, get_tenant_resource_limit},
+    utilities::request_to_resource_type,
 };
 use haste_fhir_client::{
     FHIRClient,
@@ -12,6 +14,7 @@ use haste_fhir_client::{
 
 use haste_fhir_model::r4::generated::terminology::IssueType;
 use haste_fhir_operation_error::OperationOutcomeError;
+use haste_jwt::claims::SubscriptionTier;
 
 use std::sync::Arc;
 
@@ -19,6 +22,26 @@ pub struct Middleware {}
 impl Middleware {
     pub fn new() -> Self {
         Middleware {}
+    }
+}
+
+fn get_request_limit(
+    subscription_tier: &SubscriptionTier,
+    request: &FHIRRequest,
+) -> Result<TenantResourceLimit, OperationOutcomeError> {
+    match request {
+        FHIRRequest::Update(_) | FHIRRequest::Create(_) => {
+            let Some(resource_type) = request_to_resource_type(request) else {
+                return Err(OperationOutcomeError::fatal(
+                    IssueType::Exception(None),
+                    "Unable to determine resource type for request".to_string(),
+                ));
+            };
+
+            Ok(get_tenant_resource_limit(subscription_tier, &resource_type))
+        }
+
+        _ => Ok(TenantResourceLimit::Unlimited),
     }
 }
 
@@ -42,7 +65,47 @@ impl<
                 ));
             };
 
-            next(state, context).await
+            let request_limit =
+                get_request_limit(&context.ctx.user.subscription_tier, &context.request)?;
+
+            match request_limit {
+                TenantResourceLimit::Count(resource_type, limit) => {
+                    let result = context
+                        .ctx
+                        .client
+                        .search_type(context.ctx.clone(), resource_type.clone(), "?_total=accurate".try_into().map_err(|e|{
+                            tracing::error!("Failed to construct search query for subscription tier limit middleware: {}", e);
+
+                            OperationOutcomeError::fatal(
+                                IssueType::Exception(None),
+                                "Failed to construct search query for subscription tier limit middleware".to_string(),
+                            )
+                        })?)
+                        .await?;
+
+                    let total = result.total.and_then(|total| total.value).ok_or_else(|| {
+                        OperationOutcomeError::fatal(
+                            IssueType::Exception(None),
+                            "Failed to retrieve total count for resource type".to_string(),
+                        )
+                    })?;
+
+                    if total >= (limit as u64) {
+                        return Err(OperationOutcomeError::error(
+                            IssueType::TooCostly(None),
+                            format!(
+                                "Request exceeds the limit of '{}' for resource type '{}' for subscription tier {:?}",
+                                limit,
+                                resource_type.as_ref(),
+                                context.ctx.user.subscription_tier
+                            ),
+                        ));
+                    }
+
+                    next(state, context).await
+                }
+                TenantResourceLimit::Unlimited => return next(state, context).await,
+            }
         })
     }
 }

--- a/backend/crates/server/src/fhir_client/middleware/subscription_tier_limit.rs
+++ b/backend/crates/server/src/fhir_client/middleware/subscription_tier_limit.rs
@@ -1,0 +1,48 @@
+/// For meta resources that require compute intensive operations we want to be able to limit access based on the users subscription tier.
+///  This middleware enforces those limits.
+use crate::fhir_client::{
+    ServerCTX,
+    middleware::{ServerMiddlewareContext, ServerMiddlewareNext, ServerMiddlewareOutput},
+};
+use haste_fhir_client::{
+    FHIRClient,
+    middleware::MiddlewareChain,
+    request::{FHIRRequest, FHIRResponse},
+};
+
+use haste_fhir_model::r4::generated::terminology::IssueType;
+use haste_fhir_operation_error::OperationOutcomeError;
+
+use std::sync::Arc;
+
+pub struct Middleware {}
+impl Middleware {
+    pub fn new() -> Self {
+        Middleware {}
+    }
+}
+
+impl<
+    State: Send + Sync + Clone + 'static,
+    Client: FHIRClient<Arc<ServerCTX<Client>>, OperationOutcomeError> + 'static,
+> MiddlewareChain<State, Arc<ServerCTX<Client>>, FHIRRequest, FHIRResponse, OperationOutcomeError>
+    for Middleware
+{
+    fn call(
+        &self,
+        state: State,
+        context: ServerMiddlewareContext<Client>,
+        next: Option<Arc<ServerMiddlewareNext<Client, State>>>,
+    ) -> ServerMiddlewareOutput<Client> {
+        Box::pin(async move {
+            let Some(next) = next else {
+                return Err(OperationOutcomeError::fatal(
+                    IssueType::Exception(None),
+                    "No next middleware found".to_string(),
+                ));
+            };
+
+            next(state, context).await
+        })
+    }
+}

--- a/backend/crates/server/src/fhir_client/mod.rs
+++ b/backend/crates/server/src/fhir_client/mod.rs
@@ -422,6 +422,7 @@ impl<
                 config: config.config,
             }),
             middleware: Middleware::new(vec![
+                Box::new(middleware::subscription_tier_limit::Middleware::new()),
                 Box::new(middleware::rate_limit::Middleware::new()),
                 Box::new(middleware::auth_z::scope_check::SMARTScopeAccessMiddleware::new()),
                 Box::new(middleware::auth_z::access_control::AccessControlMiddleware::new()),

--- a/backend/crates/server/src/fhir_client/subscription_limits/resource_limits.rs
+++ b/backend/crates/server/src/fhir_client/subscription_limits/resource_limits.rs
@@ -6,33 +6,51 @@ use haste_jwt::claims::SubscriptionTier;
 /// Hardcoding limits for now
 
 #[derive(Clone)]
-pub enum Limit {
-    #[allow(dead_code)]
-    Count(usize),
+pub enum TenantResourceLimit {
+    Count(ResourceType, usize),
     Unlimited,
 }
 
-static SUBSCRIPTION_LIMITS: LazyLock<HashMap<SubscriptionTier, HashMap<ResourceType, Limit>>> =
-    LazyLock::new(|| {
-        let mut limits = HashMap::new();
+static FREE_TIER_OPERATION_LIMITS: usize = 0;
+static FREE_TIER_SUBSCRIPTION_LIMITS: usize = 0;
+static FREE_TIER_SEARCH_PARAMETER_LIMITS: usize = 0;
 
-        let mut free_tier_limits = HashMap::new();
-        free_tier_limits.insert(ResourceType::OperationDefinition, Limit::Count(0));
-        free_tier_limits.insert(ResourceType::Subscription, Limit::Count(0));
-        free_tier_limits.insert(ResourceType::SearchParameter, Limit::Count(0));
+static SUBSCRIPTION_LIMITS: LazyLock<
+    HashMap<SubscriptionTier, HashMap<ResourceType, TenantResourceLimit>>,
+> = LazyLock::new(|| {
+    let mut limits = HashMap::new();
 
-        limits.insert(SubscriptionTier::Free, free_tier_limits);
+    let mut free_tier_limits = HashMap::new();
+    free_tier_limits.insert(
+        ResourceType::OperationDefinition,
+        TenantResourceLimit::Count(
+            ResourceType::OperationDefinition,
+            FREE_TIER_OPERATION_LIMITS,
+        ),
+    );
+    free_tier_limits.insert(
+        ResourceType::Subscription,
+        TenantResourceLimit::Count(ResourceType::Subscription, FREE_TIER_SUBSCRIPTION_LIMITS),
+    );
+    free_tier_limits.insert(
+        ResourceType::SearchParameter,
+        TenantResourceLimit::Count(
+            ResourceType::SearchParameter,
+            FREE_TIER_SEARCH_PARAMETER_LIMITS,
+        ),
+    );
 
-        limits
-    });
+    limits.insert(SubscriptionTier::Free, free_tier_limits);
 
-#[allow(dead_code)]
-pub fn get_subscription_resource_limit(
+    limits
+});
+
+pub fn get_tenant_resource_limit(
     tier: &SubscriptionTier,
     resource_type: &ResourceType,
-) -> Limit {
+) -> TenantResourceLimit {
     SUBSCRIPTION_LIMITS
         .get(tier)
         .and_then(|resource_limits| resource_limits.get(resource_type).cloned())
-        .unwrap_or(Limit::Unlimited)
+        .unwrap_or(TenantResourceLimit::Unlimited)
 }


### PR DESCRIPTION
Middleware to enforce limits for meta resource types.

For types such as SearchParameter do not want low tiers to be able to create these resources. This can impact performance significantly.