### PR TITLE
Migrate memory parameter resolver to search crate and use artifacts just for embedding

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2132,6 +2132,7 @@ dependencies = [
  "haste-jwt",
  "haste-reflect",
  "haste-repository",
+ "moka",
  "serde",
  "serde_json",
  "tokio",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1987,7 +1987,6 @@ name = "haste-artifacts"
 version = "0.12.0"
 dependencies = [
  "haste-fhir-model",
- "haste-fhir-search",
  "haste-fhir-serialization-json",
  "haste-jwt",
  "rust-embed",
@@ -2125,6 +2124,7 @@ version = "0.12.0"
 dependencies = [
  "chrono",
  "elasticsearch",
+ "haste-artifacts",
  "haste-fhir-client",
  "haste-fhir-model",
  "haste-fhir-operation-error",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -74,6 +74,7 @@ reqwest = "0.13"
 walkdir = "2.5.0"
 quote = "1.0.40"
 sentry = "0.46.2"
+moka = "0.12.15"
 
 [dependencies]
 reqwest = { workspace = true }

--- a/backend/crates/artifacts/Cargo.toml
+++ b/backend/crates/artifacts/Cargo.toml
@@ -12,7 +12,6 @@ haste-fhir-model = { path = "../fhir-model", version = "0.*", features = [
     "sqlx",
 ] }
 haste-fhir-serialization-json = { path = "../fhir-serialization-json", version = "0.*" }
-haste-fhir-search = { path = "../fhir-search", version = "0.*" }
 rust-embed = { version = "8.9.0", features = [
     "compression",
     "include-exclude",

--- a/backend/crates/artifacts/src/lib.rs
+++ b/backend/crates/artifacts/src/lib.rs
@@ -1,8 +1,6 @@
-use haste_fhir_model::r4::generated::resources::Resource;
+use haste_fhir_model::r4::generated::resources::{Resource, SearchParameter};
 use rust_embed::Embed;
 use std::sync::LazyLock;
-
-pub mod search_parameters;
 
 fn flatten_if_bundle(resource: Resource) -> Vec<Box<Resource>> {
     match resource {
@@ -40,3 +38,33 @@ fn load_resources() -> Vec<Box<Resource>> {
 struct EmbededResourceAssets;
 
 pub static ARTIFACT_RESOURCES: LazyLock<Vec<Box<Resource>>> = LazyLock::new(|| load_resources());
+
+#[derive(Embed)]
+#[folder = "./artifacts/r4"]
+#[include = "haste_health/search_parameter/*.json"]
+#[include = "hl7/minified/search-parameters.min.json"]
+
+struct EmbededSearchParameterAssets;
+
+/// System level Search Parameters. These are used for all tenants and projects and are loaded from embedded assets at startup.
+pub static R4_SEARCH_PARAMETERS: LazyLock<Vec<Box<SearchParameter>>> = LazyLock::new(|| {
+    let mut search_parameters = vec![];
+
+    for path in EmbededSearchParameterAssets::iter() {
+        let data = EmbededSearchParameterAssets::get(path.as_ref()).unwrap();
+        let bundle = haste_fhir_serialization_json::from_str::<Resource>(
+            std::str::from_utf8(&data.data).unwrap(),
+        )
+        .expect("Failed to parse search parameters JSON");
+
+        search_parameters.extend(flatten_if_bundle(bundle).into_iter().filter_map(|r| {
+            if let Resource::SearchParameter(param) = *r {
+                Some(Box::new(param))
+            } else {
+                None
+            }
+        }));
+    }
+
+    search_parameters
+});

--- a/backend/crates/artifacts/src/search_parameters.rs
+++ b/backend/crates/artifacts/src/search_parameters.rs
@@ -12,7 +12,7 @@ pub enum ArtifactError {
     InvalidResource(String),
 }
 
-struct SearchParametersIndex {
+pub struct SearchParametersIndex {
     by_url: HashMap<String, Arc<SearchParameter>>,
     by_resource_type: HashMap<String, HashMap<String, Arc<SearchParameter>>>,
 }
@@ -111,6 +111,16 @@ static R4_SEARCH_PARAMETERS: LazyLock<SearchParametersIndex> = LazyLock::new(|| 
 
     index
 });
+
+pub fn create_index_map(search_parameters: Vec<SearchParameter>) -> SearchParametersIndex {
+    let mut index = SearchParametersIndex::default();
+    for param in search_parameters {
+        build_search_parameter_index_map(&mut index, Resource::SearchParameter(param))
+            .expect("Failed to build search parameter index");
+    }
+
+    index
+}
 
 #[derive(Clone)]
 pub struct MemoryResolver {}

--- a/backend/crates/fhir-search/Cargo.toml
+++ b/backend/crates/fhir-search/Cargo.toml
@@ -19,6 +19,7 @@ haste-fhirpath = { path = "../fhirpath", version = "0.*" }
 haste-jwt = { path = "../jwt", version = "0.*" }
 haste-reflect = { path = "../reflect", version = "0.*" }
 haste-repository = { path = "../repository", version = "0.*" }
+haste-artifacts = { path = "../artifacts", version = "0.*" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/backend/crates/fhir-search/Cargo.toml
+++ b/backend/crates/fhir-search/Cargo.toml
@@ -23,3 +23,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+moka = { workspace = true, features = ["future"] }

--- a/backend/crates/fhir-search/src/elastic_search/mod.rs
+++ b/backend/crates/fhir-search/src/elastic_search/mod.rs
@@ -26,6 +26,7 @@ use std::{collections::HashMap, sync::Arc};
 
 mod migration;
 mod search;
+mod search_parameter_resolver;
 
 #[derive(Deserialize, Debug)]
 struct SearchEntryPrivate {

--- a/backend/crates/fhir-search/src/elastic_search/search_parameter_resolver.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search_parameter_resolver.rs
@@ -1,0 +1,43 @@
+use elasticsearch::Elasticsearch;
+use std::sync::Arc;
+
+use crate::SearchParameterResolve;
+
+pub struct ElasticSearchParameterResolver {
+    client: Arc<Elasticsearch>,
+}
+
+impl ElasticSearchParameterResolver {
+    pub fn new(client: Arc<Elasticsearch>) -> Self {
+        ElasticSearchParameterResolver { client }
+    }
+}
+
+impl SearchParameterResolve for ElasticSearchParameterResolver {
+    async fn by_resource_type(
+        &self,
+        tenant_id: &haste_jwt::TenantId,
+        project_id: &haste_jwt::ProjectId,
+        resource_type: &haste_fhir_model::r4::generated::resources::ResourceType,
+    ) -> Vec<Arc<haste_fhir_model::r4::generated::resources::SearchParameter>> {
+        todo!()
+    }
+
+    async fn by_name(
+        &self,
+        tenant_id: &haste_jwt::TenantId,
+        project_id: &haste_jwt::ProjectId,
+        resource_type: Option<&haste_fhir_model::r4::generated::resources::ResourceType>,
+        code: &str,
+    ) -> Option<Arc<haste_fhir_model::r4::generated::resources::SearchParameter>> {
+        todo!()
+    }
+
+    async fn all(
+        &self,
+        tenant_id: &haste_jwt::TenantId,
+        project_id: &haste_jwt::ProjectId,
+    ) -> Vec<Arc<haste_fhir_model::r4::generated::resources::SearchParameter>> {
+        todo!()
+    }
+}

--- a/backend/crates/fhir-search/src/elastic_search/search_parameter_resolver.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search_parameter_resolver.rs
@@ -1,16 +1,17 @@
 use elasticsearch::Elasticsearch;
-use haste_fhir_model::r4::generated::resources::SearchParameter;
 use haste_jwt::{ProjectId, TenantId};
 use moka::future::{Cache, CacheBuilder};
 use std::sync::{Arc, LazyLock};
 
-use crate::SearchParameterResolve;
+use crate::{SearchParameterResolve, memory::SearchParametersIndex};
 
+#[allow(dead_code)]
 pub struct ElasticSearchParameterResolver {
     client: Arc<Elasticsearch>,
 }
 
-static SEARCHPARAMETER_CACHE: LazyLock<Cache<(TenantId, ProjectId), Vec<Arc<SearchParameter>>>> =
+#[allow(dead_code)]
+static SEARCHPARAMETER_CACHE: LazyLock<Cache<(TenantId, ProjectId), SearchParametersIndex>> =
     LazyLock::new(|| {
         CacheBuilder::new(50_000)
             // Duration for 1 hour for search parameters.
@@ -19,6 +20,7 @@ static SEARCHPARAMETER_CACHE: LazyLock<Cache<(TenantId, ProjectId), Vec<Arc<Sear
     });
 
 impl ElasticSearchParameterResolver {
+    #[allow(dead_code)]
     pub fn new(client: Arc<Elasticsearch>) -> Self {
         ElasticSearchParameterResolver { client }
     }
@@ -27,27 +29,27 @@ impl ElasticSearchParameterResolver {
 impl SearchParameterResolve for ElasticSearchParameterResolver {
     async fn by_resource_type(
         &self,
-        tenant: &haste_jwt::TenantId,
-        project: &haste_jwt::ProjectId,
-        resource_type: &haste_fhir_model::r4::generated::resources::ResourceType,
+        _tenant: &haste_jwt::TenantId,
+        _project: &haste_jwt::ProjectId,
+        _resource_type: &haste_fhir_model::r4::generated::resources::ResourceType,
     ) -> Vec<Arc<haste_fhir_model::r4::generated::resources::SearchParameter>> {
         todo!()
     }
 
     async fn by_name(
         &self,
-        tenant: &haste_jwt::TenantId,
-        project: &haste_jwt::ProjectId,
-        resource_type: Option<&haste_fhir_model::r4::generated::resources::ResourceType>,
-        code: &str,
+        _tenant: &haste_jwt::TenantId,
+        _project: &haste_jwt::ProjectId,
+        _resource_type: Option<&haste_fhir_model::r4::generated::resources::ResourceType>,
+        _code: &str,
     ) -> Option<Arc<haste_fhir_model::r4::generated::resources::SearchParameter>> {
         todo!()
     }
 
     async fn all(
         &self,
-        tenant: &haste_jwt::TenantId,
-        project: &haste_jwt::ProjectId,
+        _tenant: &haste_jwt::TenantId,
+        _project: &haste_jwt::ProjectId,
     ) -> Vec<Arc<haste_fhir_model::r4::generated::resources::SearchParameter>> {
         todo!()
     }

--- a/backend/crates/fhir-search/src/elastic_search/search_parameter_resolver.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search_parameter_resolver.rs
@@ -1,11 +1,22 @@
 use elasticsearch::Elasticsearch;
-use std::sync::Arc;
+use haste_fhir_model::r4::generated::resources::SearchParameter;
+use haste_jwt::{ProjectId, TenantId};
+use moka::future::{Cache, CacheBuilder};
+use std::sync::{Arc, LazyLock};
 
 use crate::SearchParameterResolve;
 
 pub struct ElasticSearchParameterResolver {
     client: Arc<Elasticsearch>,
 }
+
+static SEARCHPARAMETER_CACHE: LazyLock<Cache<(TenantId, ProjectId), Vec<Arc<SearchParameter>>>> =
+    LazyLock::new(|| {
+        CacheBuilder::new(50_000)
+            // Duration for 1 hour for search parameters.
+            .time_to_idle(std::time::Duration::from_secs(60 * 60))
+            .build()
+    });
 
 impl ElasticSearchParameterResolver {
     pub fn new(client: Arc<Elasticsearch>) -> Self {
@@ -16,8 +27,8 @@ impl ElasticSearchParameterResolver {
 impl SearchParameterResolve for ElasticSearchParameterResolver {
     async fn by_resource_type(
         &self,
-        tenant_id: &haste_jwt::TenantId,
-        project_id: &haste_jwt::ProjectId,
+        tenant: &haste_jwt::TenantId,
+        project: &haste_jwt::ProjectId,
         resource_type: &haste_fhir_model::r4::generated::resources::ResourceType,
     ) -> Vec<Arc<haste_fhir_model::r4::generated::resources::SearchParameter>> {
         todo!()
@@ -25,8 +36,8 @@ impl SearchParameterResolve for ElasticSearchParameterResolver {
 
     async fn by_name(
         &self,
-        tenant_id: &haste_jwt::TenantId,
-        project_id: &haste_jwt::ProjectId,
+        tenant: &haste_jwt::TenantId,
+        project: &haste_jwt::ProjectId,
         resource_type: Option<&haste_fhir_model::r4::generated::resources::ResourceType>,
         code: &str,
     ) -> Option<Arc<haste_fhir_model::r4::generated::resources::SearchParameter>> {
@@ -35,8 +46,8 @@ impl SearchParameterResolve for ElasticSearchParameterResolver {
 
     async fn all(
         &self,
-        tenant_id: &haste_jwt::TenantId,
-        project_id: &haste_jwt::ProjectId,
+        tenant: &haste_jwt::TenantId,
+        project: &haste_jwt::ProjectId,
     ) -> Vec<Arc<haste_fhir_model::r4::generated::resources::SearchParameter>> {
         todo!()
     }

--- a/backend/crates/fhir-search/src/lib.rs
+++ b/backend/crates/fhir-search/src/lib.rs
@@ -44,23 +44,23 @@ pub trait SearchParameterResolve: Send + Sync {
     // Returns all search parameters for the given resource type, if any exist.
     fn by_resource_type(
         &self,
-        tenant_id: &TenantId,
-        project_id: &ProjectId,
+        tenant: &TenantId,
+        project: &ProjectId,
         resource_type: &ResourceType,
     ) -> impl Future<Output = Vec<Arc<SearchParameter>>> + Send + Sync;
     // Returns the search parameter for the given resource type and code, if it exists.
     fn by_name(
         &self,
-        tenant_id: &TenantId,
-        project_id: &ProjectId,
+        tenant: &TenantId,
+        project: &ProjectId,
         resource_type: Option<&ResourceType>,
         code: &str,
     ) -> impl Future<Output = Option<Arc<SearchParameter>>> + Send + Sync;
     // Returns all search parameters, regardless of resource type.
     fn all(
         &self,
-        tenant_id: &TenantId,
-        project_id: &ProjectId,
+        tenant: &TenantId,
+        project: &ProjectId,
     ) -> impl Future<Output = Vec<Arc<SearchParameter>>> + Send + Sync;
 }
 

--- a/backend/crates/fhir-search/src/lib.rs
+++ b/backend/crates/fhir-search/src/lib.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 
 pub mod elastic_search;
 pub mod indexing_conversion;
+pub mod memory;
 
 #[derive(Clone)]
 pub struct IndexResource {

--- a/backend/crates/fhir-search/src/memory/mod.rs
+++ b/backend/crates/fhir-search/src/memory/mod.rs
@@ -1,7 +1,7 @@
+use crate::SearchParameterResolve;
+use haste_artifacts::R4_SEARCH_PARAMETERS;
 use haste_fhir_model::r4::generated::resources::{Resource, ResourceType, SearchParameter};
-use haste_fhir_search::SearchParameterResolve;
 use haste_jwt::{ProjectId, TenantId};
-use rust_embed::Embed;
 use std::{
     collections::HashMap,
     sync::{Arc, LazyLock},
@@ -12,6 +12,7 @@ pub enum ArtifactError {
     InvalidResource(String),
 }
 
+#[derive(Clone)]
 pub struct SearchParametersIndex {
     by_url: HashMap<String, Arc<SearchParameter>>,
     by_resource_type: HashMap<String, HashMap<String, Arc<SearchParameter>>>,
@@ -89,32 +90,18 @@ fn build_search_parameter_index_map(
     }
 }
 
-#[derive(Embed)]
-#[folder = "./artifacts/r4"]
-#[include = "haste_health/search_parameter/*.json"]
-#[include = "hl7/minified/search-parameters.min.json"]
-
-struct EmbededSearchParameterAssets;
-
-static R4_SEARCH_PARAMETERS: LazyLock<SearchParametersIndex> = LazyLock::new(|| {
-    let mut index = SearchParametersIndex::default();
-
-    for path in EmbededSearchParameterAssets::iter() {
-        let data = EmbededSearchParameterAssets::get(path.as_ref()).unwrap();
-        let bundle = haste_fhir_serialization_json::from_str::<Resource>(
-            std::str::from_utf8(&data.data).unwrap(),
-        )
-        .expect("Failed to parse search parameters JSON");
-        build_search_parameter_index_map(&mut index, bundle)
-            .expect("Failed to extract search parameters");
-    }
-
-    index
+static R4_SEARCH_PARAMETERS_INDEX: LazyLock<SearchParametersIndex> = LazyLock::new(|| {
+    create_index_map(
+        R4_SEARCH_PARAMETERS
+            .iter()
+            .map(|param| param.as_ref().clone())
+            .collect(),
+    )
 });
 
 pub fn create_index_map(search_parameters: Vec<SearchParameter>) -> SearchParametersIndex {
     let mut index = SearchParametersIndex::default();
-    for param in search_parameters {
+    for param in search_parameters.into_iter() {
         build_search_parameter_index_map(&mut index, Resource::SearchParameter(param))
             .expect("Failed to build search parameter index");
     }
@@ -123,24 +110,24 @@ pub fn create_index_map(search_parameters: Vec<SearchParameter>) -> SearchParame
 }
 
 #[derive(Clone)]
-pub struct MemoryResolver {}
-impl MemoryResolver {
+pub struct SearchParameterMemoryResolve {}
+impl SearchParameterMemoryResolve {
     pub fn new() -> Self {
         Self {}
     }
 }
-impl SearchParameterResolve for MemoryResolver {
+impl SearchParameterResolve for SearchParameterMemoryResolve {
     async fn by_resource_type(
         &self,
         _tenant: &TenantId,
         _project: &ProjectId,
         resource_type: &ResourceType,
     ) -> Vec<Arc<SearchParameter>> {
-        let resource_params = R4_SEARCH_PARAMETERS
+        let resource_params = R4_SEARCH_PARAMETERS_INDEX
             .by_resource_type
             .get("Resource")
             .unwrap();
-        let domain_params = R4_SEARCH_PARAMETERS
+        let domain_params = R4_SEARCH_PARAMETERS_INDEX
             .by_resource_type
             .get("DomainResource")
             .unwrap();
@@ -148,7 +135,7 @@ impl SearchParameterResolve for MemoryResolver {
         return_vec.extend(resource_params.values().cloned());
         return_vec.extend(domain_params.values().cloned());
 
-        if let Some(params) = R4_SEARCH_PARAMETERS
+        if let Some(params) = R4_SEARCH_PARAMETERS_INDEX
             .by_resource_type
             .get(resource_type.as_ref())
         {
@@ -167,19 +154,19 @@ impl SearchParameterResolve for MemoryResolver {
     ) -> Option<Arc<SearchParameter>> {
         resource_type
             .and_then(|resource_type| {
-                R4_SEARCH_PARAMETERS
+                R4_SEARCH_PARAMETERS_INDEX
                     .by_resource_type
                     .get(resource_type.as_ref())
             })
             .and_then(|params| params.get(name))
             .or_else(|| {
-                R4_SEARCH_PARAMETERS
+                R4_SEARCH_PARAMETERS_INDEX
                     .by_resource_type
                     .get("Resource")
                     .and_then(|params| params.get(name))
             })
             .or_else(|| {
-                R4_SEARCH_PARAMETERS
+                R4_SEARCH_PARAMETERS_INDEX
                     .by_resource_type
                     .get("DomainResource")
                     .and_then(|params| params.get(name))
@@ -188,7 +175,7 @@ impl SearchParameterResolve for MemoryResolver {
     }
 
     async fn all(&self, _tenant: &TenantId, _project: &ProjectId) -> Vec<Arc<SearchParameter>> {
-        R4_SEARCH_PARAMETERS
+        R4_SEARCH_PARAMETERS_INDEX
             .by_url
             .values()
             .cloned()

--- a/backend/crates/fhir-subscription-processor/src/lib.rs
+++ b/backend/crates/fhir-subscription-processor/src/lib.rs
@@ -266,11 +266,11 @@ impl traits::SubscriptionFilter for MemorySubscriptionFilter {
 
 #[cfg(test)]
 mod tests {
-    use haste_artifacts::search_parameters::MemoryResolver;
     use haste_fhir_model::r4::generated::{
         resources::Patient,
         types::{FHIRString, HumanName},
     };
+    use haste_fhir_search::memory::SearchParameterMemoryResolve;
 
     use crate::traits::SubscriptionFilter;
 
@@ -286,7 +286,7 @@ mod tests {
             ..Default::default()
         };
 
-        let resolver = Arc::new(MemoryResolver::new());
+        let resolver = Arc::new(SearchParameterMemoryResolve::new());
 
         let sub_filter = MemorySubscriptionFilter::new(
             &TenantId::System,
@@ -322,7 +322,7 @@ mod tests {
             ..Default::default()
         };
 
-        let resolver = Arc::new(MemoryResolver::new());
+        let resolver = Arc::new(SearchParameterMemoryResolve::new());
         let sub_filter = MemorySubscriptionFilter::new(
             &TenantId::System,
             &ProjectId::System,
@@ -350,7 +350,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_fhirpath() {
-        let resolver = Arc::new(MemoryResolver::new());
+        let resolver = Arc::new(SearchParameterMemoryResolve::new());
         let sub_filter = MemorySubscriptionFilter::new(
             &TenantId::System,
             &ProjectId::System,

--- a/backend/crates/jwt/src/lib.rs
+++ b/backend/crates/jwt/src/lib.rs
@@ -112,7 +112,7 @@ impl Display for AuthorKind {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TenantId {
     System,
     Custom(String),
@@ -171,7 +171,7 @@ impl Display for TenantId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ProjectId {
     System,
     Custom(String),

--- a/backend/crates/repository/Cargo.toml
+++ b/backend/crates/repository/Cargo.toml
@@ -20,7 +20,7 @@ haste-fhir-operation-error = { path = "../fhir-operation-error", version = "0.*"
 haste-rate-limit = { path = "../rate-limit", version = "0.*" }
 haste-jwt = { path = "../jwt", version = "0.*", features = ["sqlx"] }
 haste-reflect = { path = "../reflect", version = "0.*", features = ["derive"] }
-moka = { version = "0.12.11", features = ["future"] }
+moka = { workspace=true, features = ["future"] }
 nanoid = "0.4.0"
 regex = { workspace = true }
 serde = { workspace = true }

--- a/backend/crates/server/Cargo.toml
+++ b/backend/crates/server/Cargo.toml
@@ -88,4 +88,4 @@ tower-sessions-sqlx-store = { version = "0.15.0", features = ["postgres"] }
 typify = "0.5.0"
 url = "2.5.4"
 zxcvbn = "3.1.0"
-moka = {version = "0.12.15", features = ["future"] }
+moka = { workspace=true, features = ["future"] }

--- a/backend/crates/server/src/services.rs
+++ b/backend/crates/server/src/services.rs
@@ -2,10 +2,10 @@ use crate::{
     ServerEnvironmentVariables,
     fhir_client::{FHIRServerClient, ServerClientConfig},
 };
-use haste_artifacts::search_parameters::MemoryResolver;
 use haste_config::Config;
 use haste_fhir_model::r4::generated::terminology::IssueType;
 use haste_fhir_operation_error::{OperationOutcomeError, derive::OperationOutcomeError};
+use haste_fhir_search::memory::SearchParameterMemoryResolve;
 use haste_fhir_search::{
     SearchEngine,
     elastic_search::{ElasticSearchEngine, create_es_client},
@@ -122,7 +122,13 @@ impl<
 pub async fn create_services(
     config: Arc<dyn Config<ServerEnvironmentVariables>>,
 ) -> Result<
-    Arc<AppState<PGConnection, ElasticSearchEngine<MemoryResolver>, FHIRCanonicalTerminology>>,
+    Arc<
+        AppState<
+            PGConnection,
+            ElasticSearchEngine<SearchParameterMemoryResolve>,
+            FHIRCanonicalTerminology,
+        >,
+    >,
     OperationOutcomeError,
 > {
     let pool = Arc::new(PGConnection::pool(get_pool(config.as_ref()).await.clone()));
@@ -149,7 +155,7 @@ pub async fn create_services(
     .expect("Failed to create Elasticsearch client");
 
     let search_engine = Arc::new(haste_fhir_search::elastic_search::ElasticSearchEngine::new(
-        Arc::new(MemoryResolver::new()),
+        Arc::new(SearchParameterMemoryResolve::new()),
         Arc::new(FPEngine::new()),
         es_client,
     ));

--- a/backend/crates/wal_worker/src/main.rs
+++ b/backend/crates/wal_worker/src/main.rs
@@ -5,9 +5,11 @@ use etl::{
     pipeline::Pipeline,
     store::both::memory::MemoryStore,
 };
-use haste_artifacts::search_parameters::MemoryResolver;
 use haste_config::get_config;
-use haste_fhir_search::elastic_search::{ElasticSearchEngine, create_es_client};
+use haste_fhir_search::{
+    elastic_search::{ElasticSearchEngine, create_es_client},
+    memory::SearchParameterMemoryResolve,
+};
 
 use crate::es_search_destination::ESSearchDestination;
 mod es_search_destination;
@@ -60,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .expect("Failed to create Elasticsearch client");
 
     let search_engine = ElasticSearchEngine::new(
-        Arc::new(MemoryResolver::new()),
+        Arc::new(SearchParameterMemoryResolve::new()),
         Arc::new(haste_fhirpath::FPEngine::new()),
         es_client,
     );

--- a/backend/crates/worker/src/lib.rs
+++ b/backend/crates/worker/src/lib.rs
@@ -1,11 +1,11 @@
 use crate::indexing_lock::IndexLockProvider;
-use haste_artifacts::search_parameters::MemoryResolver;
 use haste_config::get_config;
 use haste_fhir_model::r4::generated::resources::ResourceTypeError;
 use haste_fhir_operation_error::{OperationOutcomeError, derive::OperationOutcomeError};
 use haste_fhir_search::{
     IndexResource, SearchEngine,
     elastic_search::{ElasticSearchEngine, create_es_client},
+    memory::SearchParameterMemoryResolve,
 };
 use haste_fhirpath::FHIRPathError;
 use haste_jwt::{TenantId, VersionId};
@@ -239,7 +239,7 @@ pub async fn run_worker() -> Result<(), OperationOutcomeError> {
     .expect("Failed to create Elasticsearch client");
 
     let search_engine = Arc::new(ElasticSearchEngine::new(
-        Arc::new(MemoryResolver::new()),
+        Arc::new(SearchParameterMemoryResolve::new()),
         fp_engine.clone(),
         es_client,
     ));


### PR DESCRIPTION
Will use this in resolver that also resolves a users project SearchParameters on next PR. Will embed this in a memory cache with ttl for 2hrs.