### PR TITLE
Migrate hash to argon2

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -296,6 +296,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +640,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -2884,6 +2905,7 @@ dependencies = [
 name = "haste-repository"
 version = "0.18.0"
 dependencies = [
+ "argon2",
  "chrono",
  "haste-fhir-client",
  "haste-fhir-model",
@@ -4746,6 +4768,17 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -59,6 +59,7 @@ homepage = "https://haste.health"
 edition = "2024"
 
 [workspace.dependencies]
+argon2 = "0.5.3"
 axum = "0.8.9"
 chrono = "0.4.44"
 derivative = "2.2.0"

--- a/backend/crates/repository/.sqlx/query-cd34528148240f5772f83bdfe9a18948ebcc43f06873751347b4a73679d99489.json
+++ b/backend/crates/repository/.sqlx/query-cd34528148240f5772f83bdfe9a18948ebcc43f06873751347b4a73679d99489.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                  SELECT id, tenant as \"tenant: TenantId\", email, role as \"role: UserRole\", method as \"method: AuthMethod\", provider_id FROM users WHERE tenant = $1 AND method = $2 AND email = $3 AND password = crypt($4, password)\n                ",
+  "query": "\n                  SELECT id, tenant as \"tenant: TenantId\", email, role as \"role: UserRole\", method as \"method: AuthMethod\", provider_id, password FROM users WHERE tenant = $1 AND method = $2 AND email = $3\n                ",
   "describe": {
     "columns": [
       {
@@ -53,6 +53,11 @@
         "ordinal": 5,
         "name": "provider_id",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "password",
+        "type_info": "Text"
       }
     ],
     "parameters": {
@@ -69,7 +74,6 @@
             }
           }
         },
-        "Text",
         "Text"
       ]
     },
@@ -79,8 +83,9 @@
       true,
       false,
       false,
+      true,
       true
     ]
   },
-  "hash": "c7481699d26ab9d402628e265a53fbc4d35c09a5444ac04cf78aa2ba03c2c637"
+  "hash": "cd34528148240f5772f83bdfe9a18948ebcc43f06873751347b4a73679d99489"
 }

--- a/backend/crates/repository/Cargo.toml
+++ b/backend/crates/repository/Cargo.toml
@@ -10,6 +10,7 @@ homepage = { workspace = true }
 rate-limit = []
 
 [dependencies]
+argon2 = { workspace = true }
 chrono = { workspace = true }
 haste-fhir-client = { path = "../fhir-client", version = "0.*" }
 haste-fhir-model = { path = "../fhir-model", version = "0.*", features = [

--- a/backend/crates/repository/src/pg/mod.rs
+++ b/backend/crates/repository/src/pg/mod.rs
@@ -36,7 +36,7 @@ pub enum StoreError {
     #[error(code = "invalid", diagnostic = "Failed to commit the transaction.")]
     FailedCommitTransaction,
     #[error(code = "exception", diagnostic = "Failed to hash password.")]
-    PasswordHashError(#[from] argon2::password_hash::Error),
+    PasswordHashError(argon2::password_hash::Error),
 }
 
 /// Connection types supported by the repository traits.

--- a/backend/crates/repository/src/pg/mod.rs
+++ b/backend/crates/repository/src/pg/mod.rs
@@ -35,6 +35,8 @@ pub enum StoreError {
     NotTransaction,
     #[error(code = "invalid", diagnostic = "Failed to commit the transaction.")]
     FailedCommitTransaction,
+    #[error(code = "exception", diagnostic = "Failed to hash password.")]
+    PasswordHashError(#[from] argon2::password_hash::Error),
 }
 
 /// Connection types supported by the repository traits.

--- a/backend/crates/repository/src/pg/user.rs
+++ b/backend/crates/repository/src/pg/user.rs
@@ -18,7 +18,7 @@ fn hash_password(password: &str) -> Result<String, StoreError> {
     let salt = SaltString::generate(&mut OsRng);
     let hash = Argon2::default()
         .hash_password(password.as_bytes(), &salt)
-        .map_err(StoreError::PasswordHashError)?
+        .map_err(|e| StoreError::PasswordHashError(e))?
         .to_string();
 
     Ok(hash)

--- a/backend/crates/repository/src/pg/user.rs
+++ b/backend/crates/repository/src/pg/user.rs
@@ -6,9 +6,23 @@ use crate::{
         UserSearchClauses,
     },
 };
+use argon2::{
+    Argon2, PasswordHasher, PasswordVerifier,
+    password_hash::{PasswordHash, SaltString, rand_core::OsRng},
+};
 use haste_fhir_operation_error::OperationOutcomeError;
 use haste_jwt::TenantId;
 use sqlx::{Acquire, Postgres, QueryBuilder};
+
+fn hash_password(password: &str) -> Result<String, StoreError> {
+    let salt = SaltString::generate(&mut OsRng);
+    let hash = Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .map_err(StoreError::PasswordHashError)?
+        .to_string();
+
+    Ok(hash)
+}
 
 fn login<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
     connection: Connection,
@@ -19,22 +33,43 @@ fn login<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
         let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
         match method {
             LoginMethod::EmailPassword { email, password } => {
-                let user = sqlx::query_as!(
-                    User,
+                let row = sqlx::query!(
                     r#"
-                  SELECT id, tenant as "tenant: TenantId", email, role as "role: UserRole", method as "method: AuthMethod", provider_id FROM users WHERE tenant = $1 AND method = $2 AND email = $3 AND password = crypt($4, password)
+                  SELECT id, tenant as "tenant: TenantId", email, role as "role: UserRole", method as "method: AuthMethod", provider_id, password FROM users WHERE tenant = $1 AND method = $2 AND email = $3
                 "#,
                     tenant.as_ref(),
                     AuthMethod::EmailPassword as AuthMethod,
-                    email,
-                    password
+                    email
                 ).fetch_optional(&mut *conn).await.map_err(StoreError::from)?;
 
-                if let Some(user) = user {
-                    Ok(LoginResult::Success { user })
-                } else {
-                    Ok(LoginResult::Failure)
+                let Some(row) = row else {
+                    return Ok(LoginResult::Failure);
+                };
+
+                let verified = row
+                    .password
+                    .as_deref()
+                    .and_then(|hash| PasswordHash::new(hash).ok())
+                    .is_some_and(|parsed_hash| {
+                        Argon2::default()
+                            .verify_password(password.as_bytes(), &parsed_hash)
+                            .is_ok()
+                    });
+
+                if !verified {
+                    return Ok(LoginResult::Failure);
                 }
+
+                Ok(LoginResult::Success {
+                    user: User {
+                        id: row.id,
+                        tenant: row.tenant,
+                        email: row.email,
+                        role: row.role,
+                        method: row.method,
+                        provider_id: row.provider_id,
+                    },
+                })
             }
             LoginMethod::OIDC {
                 email: _,
@@ -97,10 +132,8 @@ fn create_user<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>
         }
 
         if let Some(password) = new_user.password {
-            seperator
-                .push("crypt(")
-                .push_bind_unseparated(password)
-                .push_unseparated(", gen_salt('bf'))");
+            let hashed_password = hash_password(&password)?;
+            seperator.push_bind(hashed_password);
         } else {
             seperator.push_bind(None::<String>);
         }
@@ -178,10 +211,10 @@ fn update_user<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>
         }
 
         if let Some(password) = model.password {
+            let hashed_password = hash_password(&password)?;
             update_clauses
-                .push(" password = crypt(")
-                .push_bind_unseparated(password)
-                .push_unseparated(", gen_salt('bf'))");
+                .push(" password = ")
+                .push_bind_unseparated(hashed_password);
         }
 
         update_clauses


### PR DESCRIPTION
Better security to use argon2 for password hashing than default pg crypt. Also move from database layer to perform hashing into application to avoid possible logs holding any password.