### PR TITLE
Catch Panics

### DIFF
--- a/backend/crates/server/Cargo.toml
+++ b/backend/crates/server/Cargo.toml
@@ -85,6 +85,7 @@ tower-http = { version = "0.6.11", features = [
     "compression-gzip",
     "trace",
     "set-header",
+    "catch-panic",
 ] }
 tower-sessions = "0.14.0"
 tower-sessions-sqlx-store = { version = "0.15.0", features = ["postgres"] }

--- a/backend/crates/server/src/server.rs
+++ b/backend/crates/server/src/server.rs
@@ -34,7 +34,7 @@ use serde::Deserialize;
 use std::net::SocketAddr;
 use std::{collections::HashMap, sync::Arc};
 use tower::{Layer, ServiceBuilder};
-use tower_http::normalize_path::NormalizePath;
+use tower_http::{catch_panic::CatchPanicLayer, normalize_path::NormalizePath};
 use tower_http::{
     compression::CompressionLayer,
     cors::{Any, CorsLayer},
@@ -234,6 +234,7 @@ pub async fn server(
         .nest("/w/{tenant}", tenant_router)
         .layer(
             ServiceBuilder::new()
+                .layer(CatchPanicLayer::new())
                 .layer(ip_source.into_extension())
                 .layer(NewSentryLayer::<Request<Body>>::new_from_top())
                 .layer(TraceLayer::new_for_http())


### PR DESCRIPTION
Catch panics on server. Note that sentry will still capture errors occuring in middleware.