### PR TITLE
Fix project building

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1548,12 +1548,13 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.400.0"
+version = "0.407.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed1303a8cb70e9e4044f01df0d0410542f6b7c76e85c93e93a26bcd14e1e428"
+checksum = "8b70c7f700cadd75d58a5177eba7f3085277d7dff436b3911b3a4bb4bee3b4cb"
 dependencies = [
  "anyhow",
  "az",
+ "base64",
  "bincode",
  "bit-set",
  "bit-vec",
@@ -1561,7 +1562,6 @@ dependencies = [
  "bytes",
  "capacity_builder",
  "cooked-waker",
- "deno_core_icudata",
  "deno_error",
  "deno_ops",
  "deno_path_util",
@@ -1570,6 +1570,7 @@ dependencies = [
  "indexmap 2.14.0",
  "inventory",
  "libc",
+ "num-bigint",
  "parking_lot",
  "percent-encoding",
  "pin-project",
@@ -1587,12 +1588,6 @@ dependencies = [
  "wasm_dep_analyzer",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "deno_core_icudata"
-version = "0.77.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9efff8990a82c1ae664292507e1a5c6749ddd2312898cdf9cd7cb1fd4bc64c6"
 
 [[package]]
 name = "deno_error"
@@ -1632,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.276.0"
+version = "0.283.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b76896d2bbdde3a38689fdd3bcfd0d83fa748dd6d3575e4f471071ad954d067"
+checksum = "52f8f376774b72e0159beca6087a03ab633182559eadf7dfe6515994f51f4d3d"
 dependencies = [
  "indexmap 2.14.0",
  "proc-macro2",
@@ -6540,9 +6535,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.309.0"
+version = "0.316.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0384d8fb13b9d7e215e281c7e26423e9efe772e475cf26eddf57fb58ff27203"
+checksum = "0f85ce22bc90f626c24e4d86b082d0757a2d20e2be87b774f7211a7c099846a9"
 dependencies = [
  "deno_error",
  "num-bigint",
@@ -7511,9 +7506,9 @@ dependencies = [
 
 [[package]]
 name = "sys_traits"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a79feaa49de4a6c8191bdbd5fb3eada50671e9367d874d1c12e3d36db131414"
+checksum = "88826d6169418c98e8bc52a43f79d50907dfa3e87ba5161930d42c6f980b35ee"
 dependencies = [
  "sys_traits_macros",
 ]
@@ -8452,9 +8447,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "147.4.0"
+version = "149.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df8fffd507fb18ed000673a83d937f58e60fb07f3306b2274284125b15137cd"
+checksum = "ebfd8d6919bfb4b627ca778a67f85ca45e5fb442d352947ba093798bdf9b07e0"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/backend/crates/operation_executor/Cargo.toml
+++ b/backend/crates/operation_executor/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 
 [dependencies]
 deno_ast = { version = "0.53.2", features = ["transpiling"] }
-deno_core = "0.400.0"
+deno_core = "0.407.0"
 deno_error = "0.7.1"
 haste-fhir-client = { path = "../fhir-client", version = "0.*", features = [
     "http"
@@ -21,4 +21,4 @@ haste-reflect = { path = "../reflect", version = "0.*" }
 tokio = { workspace = true, features = ["full"] }
 
 [build-dependencies]
-deno_core = "0.400.0"
+deno_core = "0.407.0"

--- a/docker-services-compose.yml
+++ b/docker-services-compose.yml
@@ -62,6 +62,7 @@ services:
     environment:
       - HASTE_REPO.backend=postgres
       - HASTE_REPO.database_url=postgresql://postgres:postgres@postgres:5432/haste_health
+      - HASTE_REPO.max_connections=20
       - HASTE_SEARCH.backend=elasticsearch
       - HASTE_SEARCH.url=http://elasticsearch:9200
       - HASTE_SEARCH.username=elastic

--- a/docker-services-compose.yml
+++ b/docker-services-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.1.2-arm64
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.1.2
     volumes:
       - ./data/elasticsearch:/usr/share/elasticsearch/data
     ports:


### PR DESCRIPTION
This PR fixes the project building

- Remove the `arm64` suffix to allow using the `elasticsearch` image on any architecture
- Define the maximum number of connections, otherwise there is an issue with the `hastehealth-hastehealth-migrate` 
- Update to `deno_core = 0.407.0` to avoid having linking problems with `lld`