### PR TITLE
Make docker compose more flexible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
         condition: service_completed_successfully
       postgres:
         condition: service_healthy
-      elasticsearch: 
+      elasticsearch:
         condition: service_healthy
     command:
       - server
@@ -96,8 +96,7 @@ services:
       - HASTE_SEARCH.url=http://elasticsearch:9200
       - HASTE_SEARCH.username=elastic
       - HASTE_SEARCH.password=elastic
-      
-    
+
   hastehealth-worker:
     image: ghcr.io/hastehealth/hastehealth/hastehealth:latest
     platform: linux/amd64
@@ -108,7 +107,7 @@ services:
         condition: service_completed_successfully
       postgres:
         condition: service_healthy
-      elasticsearch: 
+      elasticsearch:
         condition: service_healthy
     environment:
       - RUST_LOG=error

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.1.2-arm64
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.1.2
     volumes:
       - ./data/elasticsearch:/usr/share/elasticsearch/data
     ports:


### PR DESCRIPTION
This PR improves the `docker-compose.yml` file

- Remove the `arm64` suffix to allow using the `elasticsearch` image on any architecture
- Format the file