### PR TITLE
Remove WAL Worker Dep from backend

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2941,7 +2941,6 @@ dependencies = [
  "haste-server",
  "haste-testscript-runner",
  "haste-worker",
- "haste_wal_worker",
  "json-patch",
  "jsonwebtoken",
  "opentelemetry",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -99,7 +99,6 @@ haste-repository = { path = "./crates/repository" }
 haste-server = { path = "./crates/server" }
 haste-testscript-runner = { path = "./crates/testscript-runner" }
 haste-worker = { path = "./crates/worker" }
-haste_wal_worker = { path = "./crates/wal_worker" }
 json-patch = "4.2.0"
 jsonwebtoken = { workspace = true, features = ["rust_crypto"] }
 opentelemetry = "0.32.0"


### PR DESCRIPTION
Currently getting warning on compilation because WAL worker is a binary not a lib. This library is currently very experimental and should not be bundled with backend binary (for now).