### PR TITLE
CSRF Synchronizer Token Pattern on Interactions

### DIFF
--- a/backend/crates/server/src/auth_n/global/routes/login.rs
+++ b/backend/crates/server/src/auth_n/global/routes/login.rs
@@ -1,5 +1,6 @@
 use crate::{
     auth_n::email::send_email,
+    extract::csrf_token::CSRFToken,
     services::ServerState,
     ui::{
         components::{banner, page_html},
@@ -32,7 +33,10 @@ use std::sync::Arc;
 #[typed_path("/login")]
 pub struct EmailSelect;
 
-pub async fn global_login_get(_: EmailSelect) -> Result<Response, OperationOutcomeError> {
+pub async fn global_login_get(
+    _: EmailSelect,
+    CSRFToken(csrf_token): CSRFToken,
+) -> Result<Response, OperationOutcomeError> {
     let global_login_post_uri = "/auth/login";
     let signup_url = "/auth/signup";
 
@@ -46,6 +50,7 @@ pub async fn global_login_get(_: EmailSelect) -> Result<Response, OperationOutco
                                 "Enter your email"
                             }
                             input type="email" id="email" class="bg-gray-50 border border-gray-300 text-slate-900 sm:text-sm rounded-lg focus:ring-blue-600 focus:border-blue-600 block w-full p-2.5" placeholder="name@company.com" required="" name="email" {}
+                            input type="hidden" name="csrf_token" value=(csrf_token) {}
                         }
                         button type="submit" class="cursor-pointer w-full text-white bg-brand-600 hover:bg-brand-500 focus:ring-4 focus:outline-none focus:ring-brand-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center" {
                             "Continue"
@@ -61,6 +66,7 @@ pub async fn global_login_get(_: EmailSelect) -> Result<Response, OperationOutco
 
 #[derive(Deserialize)]
 pub struct GlobalLoginForm {
+    pub csrf_token: String,
     pub email: EmailAddress,
 }
 
@@ -70,9 +76,17 @@ pub async fn global_login_post<
     Terminology: FHIRTerminology + Send + Sync,
 >(
     _: EmailSelect,
+    CSRFToken(csrf_token): CSRFToken,
     State(state): State<Arc<ServerState<Repo, Search, Terminology>>>,
     Form(login_data): Form<GlobalLoginForm>,
 ) -> Result<Response, OperationOutcomeError> {
+    if login_data.csrf_token != csrf_token {
+        return Err(OperationOutcomeError::error(
+            IssueType::Invalid(None),
+            "Invalid CSRF Token".to_string(),
+        ));
+    }
+
     let found_users = SystemAdmin::<User, UserSearchClauses>::search(
         state.repo.as_ref(),
         &UserSearchClauses {

--- a/backend/crates/server/src/auth_n/global/routes/signup.rs
+++ b/backend/crates/server/src/auth_n/global/routes/signup.rs
@@ -1,5 +1,6 @@
 use crate::{
     auth_n::email,
+    extract::csrf_token::CSRFToken,
     services::ServerState,
     tenants::create_tenant,
     ui::{
@@ -12,7 +13,7 @@ use axum::{extract::State, response::Response};
 use axum_extra::routing::TypedPath;
 use email_address::EmailAddress;
 use haste_fhir_model::r4::generated::{
-    terminology,
+    terminology::{self, IssueType},
     types::{FHIRString, HumanName},
 };
 use haste_fhir_operation_error::OperationOutcomeError;
@@ -37,12 +38,14 @@ pub async fn global_signup_get<
     Terminology: FHIRTerminology + Send + Sync,
 >(
     _: GlobalSignupGet,
+    CSRFToken(csrf_token): CSRFToken,
     State(_app_state): State<Arc<ServerState<Repo, Search, Terminology>>>,
 ) -> Result<Response, OperationOutcomeError> {
     Ok(page_html(html! {
         (banner("Sign up", None))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow  md:mt-0  xl:p-0 " {
             form class="space-y-4 p-6 sm:p-8" action=("/auth/signup") method="POST" {
+                input type="hidden" name="csrf_token" value=(csrf_token) {}
                 div class="grid grid-cols-4 gap-1 space-y-1" {                
                     div class="col-span-4" {
                         label for="email" class="block text-sm font-medium text-slate-600 dark:text-white" {
@@ -73,6 +76,7 @@ pub async fn global_signup_get<
 
 #[derive(serde::Deserialize)]
 pub struct GlobalSignupForm {
+    pub csrf_token: String,
     pub email: EmailAddress,
     #[serde(rename = "first-name")]
     pub first_name: String,
@@ -143,9 +147,17 @@ pub async fn global_signup_post<
     Terminology: FHIRTerminology + Send + Sync,
 >(
     _: GlobalSignupPost,
+    CSRFToken(csrf_token): CSRFToken,
     State(app_state): State<Arc<ServerState<Repo, Search, Terminology>>>,
     Form(form): Form<GlobalSignupForm>,
 ) -> Result<Response, OperationOutcomeError> {
+    if form.csrf_token != csrf_token {
+        return Err(OperationOutcomeError::error(
+            IssueType::Invalid(None),
+            "Invalid CSRF Token".to_string(),
+        ));
+    }
+
     let user = create_or_retrieve_user_tenant(app_state.as_ref(), &form).await?;
 
     email::send_password_reset_email(

--- a/backend/crates/server/src/auth_n/global/routes/tenant_select.rs
+++ b/backend/crates/server/src/auth_n/global/routes/tenant_select.rs
@@ -1,4 +1,5 @@
 use crate::auth_n::oidc::routes::route_string::tenant_route_string;
+use crate::extract::csrf_token::CSRFToken;
 use crate::services::ServerState;
 use crate::ui::components::{banner, page_html};
 use axum::response::{IntoResponse, Redirect, Response};
@@ -22,6 +23,7 @@ pub async fn tenant_select_get<
     Terminology: FHIRTerminology + Send + Sync,
 >(
     _: TenantSelectGet,
+    CSRFToken(csrf_token): CSRFToken,
     //ClientIp(ip_address): ClientIp,
     State(_app_state): State<Arc<ServerState<Repo, Search, Terminology>>>,
 ) -> Result<Response, OperationOutcomeError> {
@@ -33,6 +35,7 @@ pub async fn tenant_select_get<
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow md:mt-0 xl:p-0 text-slate-700" {
             div class="p-6 space-y-4 md:space-y-6 sm:p-8" {
                 form class="space-y-2" action=(action_url) method="POST" {
+                    input type="hidden" name="csrf_token" value=(csrf_token) {}
                     div class="grid grid-cols-4 gap-1" {
                         div class="col-span-4" {
                             label for="tenant" class="block text-sm font-medium text-slate-600" { "Tenant" }
@@ -54,6 +57,7 @@ pub async fn tenant_select_get<
 
 #[derive(serde::Deserialize)]
 pub struct TenantSelectForm {
+    pub csrf_token: String,
     pub tenant: String,
 }
 
@@ -63,8 +67,16 @@ pub struct TenantSelectPost {}
 
 pub async fn tenant_select_post(
     _: TenantSelectPost,
+    CSRFToken(csrf_token): CSRFToken,
     Form(form): Form<TenantSelectForm>,
 ) -> Result<Response, OperationOutcomeError> {
+    if form.csrf_token != csrf_token {
+        return Err(OperationOutcomeError::error(
+            haste_fhir_model::r4::generated::terminology::IssueType::Invalid(None),
+            "Invalid CSRF Token".to_string(),
+        ));
+    }
+
     let tenant_id = TenantId::new(form.tenant);
     let project_select_route =
         tenant_route_string(&tenant_id).join("./auth/interactions/project-select");

--- a/backend/crates/server/src/extract/csrf_token.rs
+++ b/backend/crates/server/src/extract/csrf_token.rs
@@ -1,0 +1,60 @@
+use axum::{extract::FromRequestParts, http::request::Parts};
+use axum_extra::extract::Cached;
+
+use haste_fhir_model::r4::generated::terminology::IssueType;
+use haste_fhir_operation_error::OperationOutcomeError;
+use haste_repository::utilities::generate_id;
+use tower_sessions::Session;
+
+/// CSRF Token that's stored per user session
+/// This token is used to protect against (CSRF) attacks.
+pub struct CSRFToken(pub String);
+
+static CSRF_TOKEN_SESSION_KEY: &str = "csrf_token";
+
+impl<B> FromRequestParts<B> for CSRFToken
+where
+    B: Send + Sync,
+{
+    type Rejection = OperationOutcomeError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &B,
+    ) -> Result<Self, OperationOutcomeError> {
+        let Cached(session) = Cached::<Session>::from_request_parts(parts, state)
+            .await
+            .map_err(|_err| {
+                OperationOutcomeError::error(
+                    IssueType::Invalid(None),
+                    format!("Failed to extract session"),
+                )
+            })?;
+
+        if let Some(csrf_token) = session
+            .get::<String>(CSRF_TOKEN_SESSION_KEY)
+            .await
+            .map_err(|_e| {
+                OperationOutcomeError::error(
+                    IssueType::Invalid(None),
+                    "Failed to retrieve CSRF Token from session".to_string(),
+                )
+            })?
+        {
+            Ok(CSRFToken(csrf_token))
+        } else {
+            let value = generate_id(Some(32));
+            session
+                .insert(CSRF_TOKEN_SESSION_KEY, value.clone())
+                .await
+                .map_err(|_e| {
+                    OperationOutcomeError::error(
+                        IssueType::Invalid(None),
+                        "Failed to insert CSRF Token into session".to_string(),
+                    )
+                })?;
+
+            Ok(CSRFToken(value))
+        }
+    }
+}

--- a/backend/crates/server/src/extract/mod.rs
+++ b/backend/crates/server/src/extract/mod.rs
@@ -1,3 +1,4 @@
 pub mod basic_credentials;
 pub mod bearer_token;
+pub mod csrf_token;
 pub mod path_tenant;


### PR DESCRIPTION
API protected via JWT. But using Token Synchronizer pattern for all html forms and routes on server. This addresses global routes on a seperate PR will alter for Project routes on OIDC.

Method I use is an extractor. If token present in session use it else lazily create it on the fly.