### PR TITLE
Misconfigured license metadata

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2024"
 description = "Haste Health binary."
 publish = false
-license = "GPL-3.0"
+license = "Apache-2.0"
 
 # [profile.release]
 # strip = true    # Automatically strip symbols from the binary.
@@ -55,7 +55,7 @@ members = [
 [workspace.package]
 version = "0.18.0"
 authors = ["Haste Health"]
-license = "BSD-3-Clause"
+license = "Apache-2.0"
 homepage = "https://haste.health"
 edition = "2024"
 

--- a/backend/crates/server/Cargo.toml
+++ b/backend/crates/server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "haste-server"
 publish = false
 description = "Haste Health server application."
-license = "GPL-3.0"
+license = "Apache-2.0"
 version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }

--- a/frontend/packages/artifacts/package.json
+++ b/frontend/packages/artifacts/package.json
@@ -20,7 +20,7 @@
   ],
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@haste-health/fhir-types": "workspace:^",
     "@types/node": "^22.20.0",

--- a/frontend/packages/codegen/package.json
+++ b/frontend/packages/codegen/package.json
@@ -14,7 +14,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "^22.20.0",
     "typescript": "6.0.3"

--- a/frontend/packages/fhir-pointer/package.json
+++ b/frontend/packages/fhir-pointer/package.json
@@ -17,7 +17,7 @@
   },
   "keywords": [],
   "author": "HasteHealth",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "exports": {
     ".": "./lib/index.js"
   },

--- a/frontend/packages/fhir-types/package.json
+++ b/frontend/packages/fhir-types/package.json
@@ -18,7 +18,7 @@
   "types": "lib/r4/types.d.ts",
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "exports": {
     "./versions": "./lib/versions.js",
     "./lib/generated/r4/types": "./lib/generated/r4/types.js",

--- a/frontend/packages/meta-value/package.json
+++ b/frontend/packages/meta-value/package.json
@@ -20,7 +20,7 @@
   },
   "keywords": [],
   "author": "haste-health",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@babel/plugin-syntax-import-attributes": "^7.29.7",
     "@babel/preset-env": "^7.29.7",


### PR DESCRIPTION
All code was licensed under apache 2.0 here https://github.com/HasteHealth/HasteHealth/commit/1efdf0f7ac9916ff7bf7058cfb6bc64f28ef9b76 . Metadata on cargo.toml and package.json files needs to be updated to reflect this change.