### PR TITLE
Resolve `clippy` lints for `fhir-reflect` and `fhir-serialization` crates

### DIFF
--- a/backend/crates/fhir-serialization-json-derive/src/deserialize.rs
+++ b/backend/crates/fhir-serialization-json-derive/src/deserialize.rs
@@ -13,7 +13,7 @@ use syn::{Data, DeriveInput, Field, Fields, Ident};
 
 fn unwrap_and_validate_cardinality_field(
     field: &Field,
-    value_identifier: proc_macro2::Ident,
+    value_identifier: &proc_macro2::Ident,
 ) -> TokenStream {
     let value_string_name = value_identifier.to_string();
     if is_optional_field(field) {
@@ -47,7 +47,7 @@ pub fn fhir_primitive_deserialization(input: DeriveInput) -> TokenStream {
 
             let unwrap_required = unwrap_and_validate_cardinality_field(
                 value_field_found.unwrap(),
-                format_ident!("value"),
+                &format_ident!("value"),
             );
 
             let expanded = quote! {
@@ -99,7 +99,7 @@ pub fn fhir_primitive_deserialization(input: DeriveInput) -> TokenStream {
 
             // println!("{}", expanded.to_string());
 
-            expanded.into()
+            expanded
         }
         _ => panic!("Only structs can be serialized for primitive serializer."),
     }
@@ -110,28 +110,24 @@ pub fn deserialize_valueset(input: DeriveInput) -> TokenStream {
     match input.data {
         Data::Enum(data) => {
             let variants_deserialize_value = data.variants.iter().filter_map(|variant| {
-                let variant_name = variant.ident.to_owned();
+                let variant_name = variant.ident.clone();
                 let code = get_attribute_value(&variant.attrs, "code");
-                if let Some(code) = code {
-                    Some(quote! {
+                code.map(|code| {
+                    quote! {
                         #code =>  Ok(#name::#variant_name(None))
-                    })
-                } else {
-                    None
-                }
+                    }
+                })
             });
 
             let variants_deserialize_value_with_element =
                 data.variants.iter().filter_map(|variant| {
-                    let variant_name = variant.ident.to_owned();
+                    let variant_name = variant.ident.clone();
                     let code = get_attribute_value(&variant.attrs, "code");
-                    if let Some(code) = code {
-                        Some(quote! {
+                    code.map(|code| {
+                        quote! {
                             #code =>  Ok(#name::#variant_name(element))
-                        })
-                    } else {
-                        None
-                    }
+                        }
+                    })
                 });
 
             let expanded: TokenStream = quote! {
@@ -194,7 +190,7 @@ pub fn deserialize_valueset(input: DeriveInput) -> TokenStream {
 
             //println!("{}", expanded.to_string());
 
-            expanded.into()
+            expanded
         }
         _ => panic!("Value set serialization only works for enums"),
     }
@@ -207,7 +203,7 @@ pub fn deserialize_valueset(input: DeriveInput) -> TokenStream {
 /// to resolve target and verify it's type.
 #[allow(unused)]
 fn reference_validator(targets: &Vec<String>, reference_id: &Ident) -> TokenStream {
-    if targets.len() == 0 {
+    if targets.is_empty() {
         quote! {}
     } else {
         quote! {
@@ -230,8 +226,8 @@ pub fn deserialize_typechoice(input: DeriveInput) -> TokenStream {
     match input.data {
         Data::Enum(data) => {
             let serialize_by_name_matches = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
-                let field_name = format!("{}{}", typechoice_name, name);
+                let name = variant.ident.clone();
+                let field_name = format!("{typechoice_name}{name}");
                 let field: &Field = variant.fields.iter().next().unwrap();
 
                 let full_value_type = &field.ty;
@@ -278,7 +274,7 @@ pub fn deserialize_typechoice(input: DeriveInput) -> TokenStream {
             };
 
             // println!("{}", expanded.to_string());
-            expanded.into()
+            expanded
         }
         _ => panic!("Only enums can be deserialized for typechoice serializer."),
     }
@@ -292,7 +288,7 @@ fn create_primitive_struct_handler(
 ) -> TokenStream {
     let field_ident = field.ident.as_ref().unwrap();
     let field_str = get_field_name(field);
-    let extension_str = format!("_{}", field_str);
+    let extension_str = format!("_{field_str}");
     let field_type = get_field_type(field);
 
     quote! {
@@ -318,7 +314,7 @@ fn create_type_choice_struct_handler(
 
     // For each individual primitve variant also check the extension
     let primitive_checks = primitive_variants.iter().map(|primitive_variant| {
-        let extension_variant = format!("_{}", primitive_variant);
+        let extension_variant = format!("_{primitive_variant}");
         quote!{
             if(#primitive_variant == #field_variable || #extension_variant == #field_variable) {
                 #found_fields_variable.insert(#primitive_variant);
@@ -368,7 +364,7 @@ fn set_struct_field(
     field_variable: &Ident,
     field: &Field,
 ) -> TokenStream {
-    let struct_set = if is_attribute_present(&field.attrs, "primitive") {
+    if is_attribute_present(&field.attrs, "primitive") {
         create_primitive_struct_handler(found_fields_variable, obj_variable, field_variable, field)
     } else if is_type_choice_field(field) {
         create_type_choice_struct_handler(
@@ -379,9 +375,7 @@ fn set_struct_field(
         )
     } else {
         create_complex_struct_handler(found_fields_variable, obj_variable, field_variable, field)
-    };
-
-    struct_set
+    }
 }
 
 fn instantiate_struct_with_required_cardinality_checks(fields: &Fields) -> TokenStream {
@@ -404,8 +398,8 @@ fn instantiate_struct_with_required_cardinality_checks(fields: &Fields) -> Token
                 conditions.push(quote! { #field_name.len() < #min });
             }
             if let Some(max) = cardinality.max {
-                conditions.push(quote! { #field_name.len() > #max })
-            };
+                conditions.push(quote! { #field_name.len() > #max });
+            }
 
             field_instantiation = quote! {#field_instantiation
                 if let Some(#field_name) = #field_name.as_ref() && (#(#conditions)||*) {
@@ -549,7 +543,7 @@ pub fn deserialize_complex(
                 }
             };
 
-            expanded.into()
+            expanded
         }
         _ => panic!("Only enums can be deserialized for typechoice serializer."),
     }
@@ -563,7 +557,7 @@ pub fn enum_variant_deserialization(input: DeriveInput) -> TokenStream {
         Data::Enum(data) => {
             let determine_by_value = format_ident!("_determine_by_");
             let serialize_by_name_matches = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 let field_name = name.to_string();
                 let field: &Field = variant.fields.iter().next().unwrap();
                 let variant_type = get_field_type(field);
@@ -614,7 +608,7 @@ pub fn enum_variant_deserialization(input: DeriveInput) -> TokenStream {
 
             // println!("{}", expanded.to_string());
 
-            expanded.into()
+            expanded
         }
         _ => panic!("Only enums can be deserialized for enum serializer."),
     }

--- a/backend/crates/fhir-serialization-json-derive/src/lib.rs
+++ b/backend/crates/fhir-serialization-json-derive/src/lib.rs
@@ -27,6 +27,36 @@ fn get_attribute_serialization_type(attrs: &[Attribute]) -> Option<String> {
     })
 }
 
+/// Derives FHIR JSON serialization implementations.
+///
+/// The macro behavior is selected using the `fhir_serialize_type` attribute.
+///
+/// Supported serialization types:
+/// - `primitive`
+/// - `typechoice`
+/// - `complex`
+/// - `resource`
+/// - `valueset`
+/// - `enum-variant`
+///
+/// # Panics
+///
+/// Panics if:
+/// - The `fhir_serialize_type` attribute is missing.
+/// - The `fhir_serialize_type` attribute contains an unsupported value.
+///
+/// # Attributes
+///
+/// This macro supports the following attributes:
+/// - `fhir_serialize_type` - Selects the serialization implementation.
+/// - `rename_field` - Renames a serialized field.
+/// - `type_choice_field_name` - Defines the field name used for type choices.
+/// - `type_choice_variants` - Defines variants for type choice fields.
+/// - `primitive` - Marks primitive FHIR fields.
+/// - `code` - Marks code fields.
+/// - `cardinality` - Defines validation cardinality constraints.
+/// - `reference` - Marks reference fields.
+/// - `fhir_resource_type` - Overrides the FHIR resource type name.
 #[proc_macro_derive(
     FHIRJSONSerialize,
     attributes(
@@ -50,30 +80,61 @@ pub fn serialize(input: TokenStream) -> TokenStream {
 
     let serialize_type = get_attribute_serialization_type(&input.attrs);
 
-    let result = match serialize_type.unwrap().as_str() {
-        "primitive" => serialize::primitve_serialization(input),
-        "typechoice" => serialize::typechoice_serialization(input),
-        "complex" => {
+    match serialize_type.as_deref() {
+        Some("primitive") => serialize::primitve_serialization(input),
+        Some("typechoice") => serialize::typechoice_serialization(input),
+        Some("complex") => {
             serialize::complex_serialization(input, serialize::ComplexSerializeType::Complex)
         }
-        "resource" => {
+        Some("resource") => {
             serialize::complex_serialization(input, serialize::ComplexSerializeType::Resource)
         }
-        "valueset" => serialize::value_set_serialization(input),
-        "enum-variant" => serialize::enum_variant_serialization(input),
+        Some("valueset") => serialize::value_set_serialization(input),
+        Some("enum-variant") => serialize::enum_variant_serialization(input),
         // Some("typechoice") => typechoice_serialization(input),
-        _ => panic!("Must be one of primitive, typechoice, complex or resource."),
-    };
-
-    result
+        None => panic!("Missing serialization type attribute"),
+        _ => panic!(
+            "Must be one of primitive, typechoice, complex, resource, valueset or enum-variant."
+        ),
+    }
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 enum DeserializeComplexType {
     Complex,
     Resource,
 }
 
+/// Derives FHIR JSON deserialization implementations.
+///
+/// The macro behavior is selected using the `fhir_serialize_type` attribute.
+///
+/// Supported deserialization types:
+/// - `primitive`
+/// - `typechoice`
+/// - `complex`
+/// - `resource`
+/// - `valueset`
+/// - `enum-variant`
+///
+/// # Panics
+///
+/// Panics if:
+/// - The `fhir_serialize_type` attribute is missing.
+/// - The `fhir_serialize_type` attribute contains an unsupported value.
+///
+/// # Attributes
+///
+/// This macro supports the following attributes:
+/// - `fhir_serialize_type` - Selects the deserialization implementation.
+/// - `rename_field` - Renames a deserialized field.
+/// - `type_choice_field_name` - Defines the field name used for type choices.
+/// - `type_choice_variants` - Defines variants for type choice fields.
+/// - `primitive` - Marks primitive FHIR fields.
+/// - `determine_by` - Specifies how enum variants are determined during deserialization.
+/// - `cardinality` - Defines validation cardinality constraints.
+/// - `reference` - Marks reference fields.
+/// - `fhir_resource_type` - Overrides the FHIR resource type name.
 #[proc_macro_derive(
     FHIRJSONDeserialize,
     attributes(
@@ -99,25 +160,61 @@ enum DeserializeComplexType {
         fhir_resource_type
     )
 )]
-
 pub fn deserialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     let serialize_type = get_attribute_serialization_type(&input.attrs);
 
-    let result = match serialize_type.unwrap().as_str() {
-        "primitive" => deserialize::fhir_primitive_deserialization(input),
-        "typechoice" => deserialize::deserialize_typechoice(input),
-        "resource" => deserialize::deserialize_complex(input, DeserializeComplexType::Resource),
-        "complex" => deserialize::deserialize_complex(input, DeserializeComplexType::Complex),
-        "enum-variant" => deserialize::enum_variant_deserialization(input),
-        "valueset" => deserialize::deserialize_valueset(input),
-        _ => panic!("Must be one of primitive, typechoice, complex or resource."),
-    };
-
-    result.into()
+    match serialize_type.as_deref() {
+        Some("primitive") => deserialize::fhir_primitive_deserialization(input),
+        Some("typechoice") => deserialize::deserialize_typechoice(input),
+        Some("resource") => {
+            deserialize::deserialize_complex(input, DeserializeComplexType::Resource)
+        }
+        Some("complex") => deserialize::deserialize_complex(input, DeserializeComplexType::Complex),
+        Some("enum-variant") => deserialize::enum_variant_deserialization(input),
+        Some("valueset") => deserialize::deserialize_valueset(input),
+        None => panic!("Missing deserialization type attribute"),
+        _ => panic!(
+            "Must be one of primitive, typechoice, complex, resource, valueset or enum-variant."
+        ),
+    }
+    .into()
 }
 
+/// Derives Serde-based FHIR JSON deserialization implementations.
+///
+/// The macro behavior is selected using the `fhir_serialize_type` attribute.
+///
+/// Supported deserialization types:
+/// - `primitive`
+/// - `valueset`
+/// - `typechoice`
+/// - `complex`
+/// - `resource`
+///
+/// # Panics
+///
+/// Panics if:
+/// - The `fhir_serialize_type` attribute is missing.
+/// - The `fhir_serialize_type` attribute contains an unsupported value.
+/// - A deserialization type other than the supported Serde deserialization
+///   variants is specified.
+///
+/// # Attributes
+///
+/// This macro supports the following attributes:
+/// - `fhir_serialize_type` - Selects the deserialization implementation.
+/// - `rename_field` - Renames a deserialized field.
+/// - `type_choice_field_name` - Defines the field name used for type choice
+///   deserialization.
+/// - `type_choice_variants` - Defines variants for type choice fields.
+/// - `primitive` - Marks primitive FHIR fields.
+/// - `determine_by` - Specifies how enum variants are determined during
+///   deserialization.
+/// - `cardinality` - Defines validation cardinality constraints.
+/// - `reference` - Marks reference fields.
+/// - `fhir_resource_type` - Overrides the FHIR resource type name.
 #[proc_macro_derive(
     FHIRSerdeDeserialize,
     attributes(
@@ -148,22 +245,52 @@ pub fn serde_deserialize(input: TokenStream) -> TokenStream {
 
     let serialize_type = get_attribute_serialization_type(&input.attrs);
 
-    let result = match serialize_type.unwrap().as_str() {
-        "primitive" => serde_deserialize::fhir_primitive_deserialization(input),
-        "valueset" => serde_deserialize::valueset_deserialization(input),
-        "typechoice" => serde_deserialize::typechoice_deserialization(input),
-        "complex" => {
+    match serialize_type.as_deref() {
+        Some("primitive") => serde_deserialize::fhir_primitive_deserialization(input),
+        Some("valueset") => serde_deserialize::valueset_deserialization(input),
+        Some("typechoice") => serde_deserialize::typechoice_deserialization(input),
+        Some("complex") => {
             serde_deserialize::complex_deserialization(input, DeserializeComplexType::Complex)
         }
-        "resource" => {
+        Some("resource") => {
             serde_deserialize::complex_deserialization(input, DeserializeComplexType::Resource)
         }
+        None => panic!("Missing deserialization type attribute"),
         _ => panic!("Only primitive and valueset supported for serde deserialization."),
-    };
-
-    result.into()
+    }
 }
 
+/// Derives Serde-based FHIR JSON serialization implementations.
+///
+/// The macro behavior is selected using the `fhir_serialize_type` attribute.
+///
+/// Supported serialization types:
+/// - `primitive`
+/// - `valueset`
+/// - `typechoice`
+/// - `complex`
+/// - `resource`
+/// - `enum-variant`
+///
+/// # Panics
+///
+/// Panics if:
+/// - The `fhir_serialize_type` attribute is missing.
+/// - The `fhir_serialize_type` attribute contains an unsupported value.
+///
+/// # Attributes
+///
+/// This macro supports the following attributes:
+/// - `fhir_serialize_type` - Selects the serialization implementation.
+/// - `rename_field` - Renames a serialized field.
+/// - `type_choice_field_name` - Defines the field name used for type choice
+///   serialization.
+/// - `type_choice_variants` - Defines variants for type choice fields.
+/// - `primitive` - Marks primitive FHIR fields.
+/// - `code` - Marks code fields.
+/// - `cardinality` - Defines validation cardinality constraints.
+/// - `reference` - Marks reference fields.
+/// - `fhir_resource_type` - Overrides the FHIR resource type name.
 #[proc_macro_derive(
     FHIRSerdeSerialize,
     attributes(
@@ -188,17 +315,18 @@ pub fn serde_serialize(input: TokenStream) -> TokenStream {
 
     let serialize_type = get_attribute_serialization_type(&input.attrs);
 
-    let result = match serialize_type.unwrap().as_str() {
-        "primitive" => serde_serialize::fhir_primitive_serialization(input),
-        "valueset" => serde_serialize::valueset_serialization(input),
-        "typechoice" => serde_serialize::typechoice_serialization(input),
-        "complex" => serde_serialize::complex_serialization(input, DeserializeComplexType::Complex),
-        "resource" => {
+    match serialize_type.as_deref() {
+        Some("primitive") => serde_serialize::fhir_primitive_serialization(input),
+        Some("valueset") => serde_serialize::valueset_serialization(input),
+        Some("typechoice") => serde_serialize::typechoice_serialization(input),
+        Some("complex") => {
+            serde_serialize::complex_serialization(input, DeserializeComplexType::Complex)
+        }
+        Some("resource") => {
             serde_serialize::complex_serialization(input, DeserializeComplexType::Resource)
         }
-        "enum-variant" => serde_serialize::enum_variant_serialization(input),
+        Some("enum-variant") => serde_serialize::enum_variant_serialization(input),
+        None => panic!("Missing serialization type attribute"),
         _ => panic!("Only primitive and valueset supported for serde deserialization."),
-    };
-
-    result.into()
+    }
 }

--- a/backend/crates/fhir-serialization-json-derive/src/serde_deserialize.rs
+++ b/backend/crates/fhir-serialization-json-derive/src/serde_deserialize.rs
@@ -1,21 +1,21 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{Data, DeriveInput, Ident, Type, Variant};
+use syn::{Attribute, Data, DataStruct, DeriveInput, Ident, Type, Variant};
 
 use crate::{
     DeserializeComplexType,
     utilities::{
-        CardinalityAttribute, FieldInformation, TypeInformation, get_attribute_value,
-        get_field_type, get_inner_type_if_optional, get_inner_type_if_vector_or_optional_or_box,
-        is_attribute_present, is_optional_field, is_type_string, process_field,
+        CardinalityAttribute, FieldInformation, TypeChoiceAttribute, TypeInformation,
+        get_attribute_value, get_field_type, get_inner_type_if_optional, is_attribute_present,
+        is_optional_field, is_type_string, process_field,
     },
 };
 
 fn fhir_primitive_value_deserialization(
     value_field_found: &syn::Field,
 ) -> proc_macro2::TokenStream {
-    let is_optional = is_optional_field(&value_field_found);
-    let value_type = get_field_type(&value_field_found);
+    let is_optional = is_optional_field(value_field_found);
+    let value_type = get_field_type(value_field_found);
 
     // Empty String should be treated as None. Special handling for this case.
     // For cases where value is required (ie non optional) we should error if value is empty string.
@@ -96,19 +96,17 @@ pub fn valueset_deserialization(input: DeriveInput) -> TokenStream {
     match input.data {
         Data::Enum(data) => {
             let variants_deserialize_value = data.variants.iter().filter_map(|variant| {
-                let variant_name = variant.ident.to_owned();
+                let variant_name = variant.ident.clone();
                 let code = get_attribute_value(&variant.attrs, "code");
-                if let Some(code) = code {
-                    Some(quote! {
-                        #code =>  Ok(#name::#variant_name(None))
-                    })
-                } else {
-                    None
-                }
+                code.map(|code| {
+                    quote! {
+                      #code =>  Ok(#name::#variant_name(None))
+                    }
+                })
             });
 
             let variants_merge_element = data.variants.iter().map(|variant| {
-                let variant_name = variant.ident.to_owned();
+                let variant_name = variant.ident.clone();
                 quote! {
                     Self::#variant_name(inner) => {
                         *inner = Some(element);
@@ -168,167 +166,151 @@ pub fn valueset_deserialization(input: DeriveInput) -> TokenStream {
 }
 
 pub fn typechoice_deserialization(input: DeriveInput) -> TokenStream {
+    // 1. Extract attributes and enum metadata
     let type_choice_field_name = get_attribute_value(&input.attrs, "type_choice_field_name")
         .expect("type_choice_field_name attribute is required for typechoice deserialization");
+
     let name = input.ident;
-    match input.data {
-        Data::Enum(data) => {
-            let (primitive_variants, complex_variants): (Vec<Variant>, Vec<Variant>) = data
-                .variants
-                .into_iter()
-                .partition(|variant| is_attribute_present(&variant.attrs, "primitive"));
+    let Data::Enum(data_enum) = input.data else {
+        panic!("Only enums can be deserialized for type choice deserializer.")
+    };
 
-            let complex_variant_key_matches = complex_variants.iter().map(|variant| {
-                let variant_ident = variant.ident.clone();
-                let key = format!("{}{}", type_choice_field_name, variant_ident);
-                quote! {
-                    #key => {
-                        Ok(Some(Self::#variant_ident(map.next_value()?)))
-                    }
+    // 2. Split variants into primitive and complex variants
+    let (primitive_variants, complex_variants): (Vec<Variant>, Vec<Variant>) = data_enum
+        .variants
+        .into_iter()
+        .partition(|variant| is_attribute_present(&variant.attrs, "primitive"));
+
+    // 3. Generate the required code fragments
+    let key_matches = gen_key_matches(
+        &type_choice_field_name,
+        &complex_variants,
+        &primitive_variants,
+    );
+    let merge_matches = gen_primitive_merge_matches(&type_choice_field_name, &primitive_variants);
+    let element_matches =
+        gen_primitive_from_element_matches(&type_choice_field_name, &primitive_variants);
+    let empty_matches = gen_empty_matches(&complex_variants, &primitive_variants);
+
+    // 4. Generate the final implementation
+    quote! {
+        impl #name {
+            // Attempts to deserialize a variant from the given key.
+            // Returns `Some(Self)` if the key matches a known variant,
+            // or `None` if the key is unknown and should be ignored.
+            pub fn try_deserialize_from_key<'de, A: serde::de::MapAccess<'de>>(
+                key: &str,
+                map: &mut A,
+            ) -> Result<Option<Self>, A::Error> {
+                match key {
+                    #key_matches
+                    _ => Ok(None),
                 }
-            });
-
-            let primitive_variant_key_matches = primitive_variants.iter().map(|variant| {
-                let variant_ident = variant.ident.clone();
-                let key = format!("{}{}", type_choice_field_name, variant_ident);
-                quote! {
-                    #key => {
-                        Ok(Some(Self::#variant_ident(map.next_value()?)))
-                    }
-                }
-            });
-
-            let primitive_merge_matches = primitive_variants.iter().map(|variant| {
-                let variant_ident = variant.ident.clone();
-                let key = format!("_{}{}", type_choice_field_name, variant_ident);
-                quote! {
-                    (#key, Self::#variant_ident(v)) => {
-                        v.extension = element.extension;
-                        v.id = element.id;
-                        true
-                    }
-                }
-            });
-
-            let primitive_from_element_matches = primitive_variants.iter().map(|variant| {
-                let variant_ident = variant.ident.clone();
-                let variant_ty = variant
-                    .fields
-                    .iter()
-                    .next()
-                    .expect("typechoice variant must have a single field")
-                    .ty
-                    .clone();
-                let key = format!("_{}{}", type_choice_field_name, variant_ident);
-                quote! {
-                    #key => {
-                        let mut value: #variant_ty = Default::default();
-                        value.extension = element.extension;
-                        value.id = element.id;
-                        Some(Self::#variant_ident(value))
-                    }
-                }
-            });
-
-            let deserialize_straight = primitive_variants
-                .iter()
-                .chain(complex_variants.iter())
-                .map(|variant| {
-                    let variant_ident = variant.ident.clone();
-                    let variant_ty = variant
-                        .fields
-                        .iter()
-                        .next()
-                        .expect("typechoice variant must have a single field")
-                        .ty
-                        .clone();
-
-                    let inner_type = get_inner_type_if_vector_or_optional_or_box(&variant_ty);
-
-                    quote! {
-                        if let Ok(value) = #inner_type::deserialize(deserializer) {
-                            return Ok(Self::#variant_ident(Box::new(value)));
-                        }
-                    }
-                });
-
-            let complex_variant_ident =
-                complex_variants.iter().map(|variant| variant.ident.clone());
-            let primitive_variant_ident = primitive_variants
-                .iter()
-                .map(|variant| variant.ident.clone());
-
-            let name_str = name.to_string();
-
-            let _deserialize_impl = quote! {
-               impl<'de> serde::Deserialize<'de> for #name {
-                    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-                    where
-                        D: serde::Deserializer<'de>,
-                    {
-                        #(#deserialize_straight)*
-
-                        return Err(serde::de::Error::custom(format!(
-                            "Data does not match any variant for type choice '{}'",
-                            #name_str
-                        )));
-                    }
-                }
-            };
-
-            let utility_funcs = quote! {
-                impl #name {
-                    // Returns Some(Self) if key matches any variant, None to skip unknown keys.
-                    pub fn try_deserialize_from_key<'de, A: serde::de::MapAccess<'de>>(
-                        key: &str,
-                        map: &mut A,
-                    ) -> Result<Option<Self>, A::Error> {
-                        match key {
-                            #(#complex_variant_key_matches,)*
-                            #(#primitive_variant_key_matches,)*
-                            _ => Ok(None),
-                        }
-                    }
-
-                    // Merge a deferred element payload from _<choiceKey> into a primitive variant.
-                    pub fn merge_element(&mut self, key: &str, element: Element) -> bool {
-                        match (key, self) {
-                            #(#primitive_merge_matches,)*
-                            _ => false,
-                        }
-                    }
-
-                    // Construct a primitive variant from only an element payload (_<choiceKey>).
-                    pub fn try_deserialize_primitive_element_from_key(
-                        key: &str,
-                        element: Element,
-                    ) -> Option<Self> {
-                        match key {
-                            #(#primitive_from_element_matches,)*
-                            _ => None,
-                        }
-                    }
-
-                    pub fn empty(&self) -> bool {
-                        match self {
-                            #(
-                                Self::#complex_variant_ident(v) => v.empty(),
-                            )*
-                            #(
-                                Self::#primitive_variant_ident(v) => v.empty(),
-                            )*
-                        }
-                    }
-                }
-            };
-
-            quote! {
-                #utility_funcs
             }
-            .into()
+
+            // Merges a deferred element payload from `_<choiceKey>` into
+            // an existing primitive variant.
+            pub fn merge_element(&mut self, key: &str, element: Element) -> bool {
+                match (key, self) {
+                    #merge_matches
+                    _ => false,
+                }
+            }
+
+            // Constructs a primitive variant from a standalone element
+            // payload (`_<choiceKey>`).
+            pub fn try_deserialize_primitive_element_from_key(
+                key: &str,
+                element: Element,
+            ) -> Option<Self> {
+                match key {
+                    #element_matches
+                    _ => None,
+                }
+            }
+
+            // Returns whether the variant contains no meaningful data.
+            pub fn empty(&self) -> bool {
+                match self {
+                    #empty_matches
+                }
+            }
         }
-        _ => panic!("Only enums can be deserialized for type choice deserializer."),
     }
+    .into()
+}
+
+fn get_variant_single_field_type(variant: &Variant) -> syn::Type {
+    variant
+        .fields
+        .iter()
+        .next()
+        .expect("typechoice variant must have a single field")
+        .ty
+        .clone()
+}
+
+fn gen_key_matches(
+    field_name: &str,
+    complex: &[Variant],
+    primitive: &[Variant],
+) -> proc_macro2::TokenStream {
+    let matches = complex.iter().chain(primitive.iter()).map(|variant| {
+        let variant_ident = &variant.ident;
+        let key = format!("{field_name}{variant_ident}");
+        quote! {
+            #key => Ok(Some(Self::#variant_ident(map.next_value()?))),
+        }
+    });
+    quote! { #(#matches)* }
+}
+
+fn gen_primitive_merge_matches(
+    field_name: &str,
+    primitive: &[Variant],
+) -> proc_macro2::TokenStream {
+    let matches = primitive.iter().map(|variant| {
+        let variant_ident = &variant.ident;
+        let key = format!("_{field_name}{variant_ident}");
+        quote! {
+            (#key, Self::#variant_ident(v)) => {
+                v.extension = element.extension;
+                v.id = element.id;
+                true
+            }
+        }
+    });
+    quote! { #(#matches)* }
+}
+
+fn gen_primitive_from_element_matches(
+    field_name: &str,
+    primitive: &[Variant],
+) -> proc_macro2::TokenStream {
+    let matches = primitive.iter().map(|variant| {
+        let variant_ident = &variant.ident;
+        let variant_ty = get_variant_single_field_type(variant);
+        let key = format!("_{field_name}{variant_ident}");
+        quote! {
+            #key => {
+                let mut value: #variant_ty = Default::default();
+                value.extension = element.extension;
+                value.id = element.id;
+                Some(Self::#variant_ident(value))
+            }
+        }
+    });
+    quote! { #(#matches)* }
+}
+
+fn gen_empty_matches(complex: &[Variant], primitive: &[Variant]) -> proc_macro2::TokenStream {
+    let matches = complex.iter().chain(primitive.iter()).map(|variant| {
+        let variant_ident = &variant.ident;
+        quote! {
+            Self::#variant_ident(v) => v.empty(),
+        }
+    });
+    quote! { #(#matches)* }
 }
 
 // For primitives this is the value identifier.
@@ -425,9 +407,10 @@ fn get_matching_constraint_for_value(
 }
 
 fn merge_primitive_extension_tokens(field: &FieldInformation) -> proc_macro2::TokenStream {
-    if !matches!(field.type_info, TypeInformation::Primitive) {
-        panic!("merge_primitive_extension_tokens should only be called for primitive fields.");
-    }
+    assert!(
+        matches!(field.type_info, TypeInformation::Primitive),
+        "merge_primitive_extension_tokens should only be called for primitive fields."
+    );
 
     let value_ident = value_ident(&field.ident);
     let ext_ident = extension_ident(&field.ident);
@@ -507,9 +490,10 @@ fn merge_typechoice_primitive_extension_tokens(
         );
     };
 
-    if field.is_vector {
-        panic!("typechoice vector primitive extension merge is not supported yet.");
-    }
+    assert!(
+        !field.is_vector,
+        "typechoice vector primitive extension merge is not supported yet."
+    );
 
     let value_ident = value_ident(&field.ident);
     let ext_ident = extension_ident(&field.ident);
@@ -594,21 +578,19 @@ fn filter_empty_values(field: &FieldInformation) -> proc_macro2::TokenStream {
         quote! {
           #filtered_vec
         }
-    } else {
-        if field.is_optional {
-            quote! {
-                if let Some(v) = &#field_ident && v.empty() {
-                    #field_ident = None;
-                }
+    } else if field.is_optional {
+        quote! {
+            if let Some(v) = &#field_ident && v.empty() {
+                #field_ident = None;
             }
-        } else {
-            quote! {
-                if #field_ident.empty() {
-                        return Err(serde::de::Error::custom(format!(
-                            "Required field '{}' has no value, id, or extension.",
-                            #field_name,
-                        )));
-                }
+        }
+    } else {
+        quote! {
+            if #field_ident.empty() {
+                    return Err(serde::de::Error::custom(format!(
+                        "Required field '{}' has no value, id, or extension.",
+                        #field_name,
+                    )));
             }
         }
     }
@@ -667,8 +649,8 @@ fn cardinality_checks(field: &FieldInformation) -> Option<proc_macro2::TokenStre
 }
 
 // If all fields are empty we can treat the whole complex type as empty and remove it from memory struct.
-pub fn can_complex_be_empty(field_meta: &Vec<FieldInformation>) -> bool {
-    for field in field_meta.iter() {
+pub fn can_complex_be_empty(field_meta: &[FieldInformation]) -> bool {
+    for field in field_meta {
         if !field.is_optional {
             return false;
         }
@@ -677,7 +659,7 @@ pub fn can_complex_be_empty(field_meta: &Vec<FieldInformation>) -> bool {
 }
 
 pub fn complex_empty_impl(
-    field_meta: &Vec<FieldInformation>,
+    field_meta: &[FieldInformation],
     struct_name: &Ident,
 ) -> proc_macro2::TokenStream {
     if can_complex_be_empty(field_meta) {
@@ -709,275 +691,364 @@ pub fn complex_deserialization(
     deserialize_complex_type: DeserializeComplexType,
 ) -> TokenStream {
     let struct_ident = input.ident;
+
     match input.data {
         Data::Struct(data) => {
-            let visitor_name = format_ident!("{}Visitor", struct_ident);
-            let name_str = struct_ident.to_string();
-            let seen_resource_type_ident = format_ident!("__seen_resource_type");
-
-            // Declare all fields for the given struct.
-            // Make all fields optional at this stage to allow for partial construction during deserialization,
-            // we'll validate required fields at the end.
-
             let field_meta = data.fields.iter().map(process_field).collect::<Vec<_>>();
 
-            let field_declarations = field_meta
-                .iter()
-                .flat_map(|field| create_complex_field_declaration(field));
-
-            let primitive_merge_blocks = field_meta
-                .iter()
-                .filter(|field| matches!(field.type_info, TypeInformation::Primitive))
-                .map(merge_primitive_extension_tokens)
-                .collect::<Vec<_>>();
-
-            let typechoice_merge_blocks = field_meta
-                .iter()
-                .filter(|field| matches!(field.type_info, TypeInformation::TypeChoice(_)))
-                .map(merge_typechoice_primitive_extension_tokens)
-                .collect::<Vec<_>>();
-
-            let value_presence_filtering = field_meta
-                .iter()
-                .filter(|f| !is_type_string(&f.field_type))
-                .map(filter_empty_values)
-                .collect::<Vec<_>>();
-
-            let cardinality_checks = field_meta
-                .iter()
-                .filter_map(|field| cardinality_checks(field))
-                .collect::<Vec<_>>();
-
-            let seen_resource_decl = if deserialize_complex_type == DeserializeComplexType::Resource
-            {
-                quote! { let mut #seen_resource_type_ident = false; }
-            } else {
-                quote! {}
-            };
-
-            let mut key_match_arms = Vec::new();
-
-            let resource_type =
-                get_attribute_value(&input.attrs, "fhir_resource_type").unwrap_or(name_str.clone());
-
-            if deserialize_complex_type == DeserializeComplexType::Resource {
-                key_match_arms.push(quote! {
-                    "resourceType" => {
-                        if #seen_resource_type_ident {
-                            return Err(serde::de::Error::duplicate_field("resourceType"));
-                        }
-                        let resource_type: String = map.next_value()?;
-                        if resource_type != #resource_type {
-                            return Err(serde::de::Error::custom(format!(
-                                "Invalid resourceType for {}: {}",
-                                #resource_type,
-                                resource_type
-                            )));
-                        }
-                        #seen_resource_type_ident = true;
-                    }
-                });
-            }
-
-            for field in field_meta.iter() {
-                let value_ident = value_ident(&field.ident);
-                let ext_ident = extension_ident(&field.ident);
-                let value_field_name = &field.field_name;
-                let field_name = &field.field_name;
-                let ext_field_name = format!("_{}", field.field_name);
-
-                match &field.type_info {
-                    TypeInformation::Primitive => {
-                        key_match_arms.push(quote! {
-                            #value_field_name => {
-                                if #value_ident.is_some() {
-                                    return Err(serde::de::Error::duplicate_field(#value_field_name));
-                                }
-                                #value_ident = Some(map.next_value()?);
-                            }
-                        });
-                        if field.is_vector {
-                            key_match_arms.push(quote! {
-                                #ext_field_name => {
-                                    if #ext_ident.is_some() {
-                                        return Err(serde::de::Error::duplicate_field(#ext_field_name));
-                                    }
-                                    #ext_ident = Some(map.next_value::<Vec<Option<Element>>>()?);
-                                }
-                            });
-                        } else {
-                            key_match_arms.push(quote! {
-                                #ext_field_name => {
-                                    if #ext_ident.is_some() {
-                                        return Err(serde::de::Error::duplicate_field(#ext_field_name));
-                                    }
-                                    #ext_ident = Some(map.next_value::<Element>()?);
-                                }
-                            });
-                        }
-                    }
-                    TypeInformation::TypeChoice(type_choice_attributes) => {
-                        let complex_variants = &type_choice_attributes.complex_variants;
-                        let primitives = &type_choice_attributes.primitive_variants;
-
-                        for primitive_variant_fieldname in primitives {
-                            let value_setter = typechoice_value_setter(
-                                field,
-                                &value_ident,
-                                primitive_variant_fieldname,
-                            );
-                            let typechoice_variant_found_ident =
-                                typechoice_variant_found_ident(&field.ident);
-                            let primitive_ext_field_name =
-                                format!("_{}", primitive_variant_fieldname);
-
-                            key_match_arms.push(quote! {
-                                #primitive_variant_fieldname => {
-                                    if #value_ident.is_some() {
-                                        return Err(serde::de::Error::duplicate_field(#ext_field_name));
-                                    }
-
-                                    if let Some(existing_variant) = #typechoice_variant_found_ident
-                                        && existing_variant != #primitive_variant_fieldname {
-                                        return Err(serde::de::Error::custom(format!(
-                                            "Multiple primitive type choice variants for '{}': '{}' and '{}'.",
-                                            #field_name,
-                                            existing_variant,
-                                            #primitive_variant_fieldname,
-                                        )));
-                                    }
-
-                                    #value_setter
-                                    #typechoice_variant_found_ident = Some(#primitive_variant_fieldname);
-                                }
-                            });
-
-                            key_match_arms.push(quote! {
-                                #primitive_ext_field_name => {
-                                    if #ext_ident.is_some() {
-                                        return Err(serde::de::Error::duplicate_field(#primitive_ext_field_name));
-                                    }
-
-                                    if let Some(existing_variant) = #typechoice_variant_found_ident
-                                        && existing_variant != #primitive_variant_fieldname {
-                                        return Err(serde::de::Error::custom(format!(
-                                            "Extension for primitive type choice variant '{}' conflicts with already parsed variant '{}' for '{}'.",
-                                            #primitive_variant_fieldname,
-                                            existing_variant,
-                                            #field_name,
-                                        )));
-                                    }
-
-                                    #ext_ident = Some(map.next_value::<Element>()?);
-                                    #typechoice_variant_found_ident = Some(#primitive_variant_fieldname);
-                                }
-                            });
-                        }
-
-                        for complex_variant_fieldname in complex_variants {
-                            let value_setter = typechoice_value_setter(
-                                field,
-                                &value_ident,
-                                complex_variant_fieldname,
-                            );
-
-                            key_match_arms.push(quote! {
-                                #complex_variant_fieldname => {
-                                    if #value_ident.is_some() {
-                                        return Err(serde::de::Error::duplicate_field(#complex_variant_fieldname));
-                                    }
-                                    #value_setter
-                                }
-                            });
-                        }
-                    }
-                    TypeInformation::Complex => {
-                        key_match_arms.push(quote! {
-                            #value_field_name => {
-                                if #value_ident.is_some() {
-                                    return Err(serde::de::Error::duplicate_field(#value_field_name));
-                                }
-                                #value_ident = Some(map.next_value()?);
-                            }
-                        });
-                    }
-                }
-            }
-
-            let bind_fields = field_meta.iter().map(|field| {
-                let field_name = field.field_name.as_str();
-                let field_ident = &field.ident;
-                let value_ident = value_ident(field_ident);
-
-                if field.is_optional {
-                    quote! { let mut #field_ident = #value_ident.and_then(|v| v); }
-                } else {
-                    quote! {
-                        let mut #field_ident = #value_ident
-                            .ok_or_else(|| serde::de::Error::missing_field(#field_name))?;
-                    }
-                }
-            });
-
-            let field_names = data.fields.iter().map(|f| f.ident.as_ref().unwrap());
-
-            let empty_impl = complex_empty_impl(&field_meta, &struct_ident);
-
-            let deserialize_impl = quote! {
-                impl<'de> serde::Deserialize<'de> for #struct_ident {
-                    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-                        struct #visitor_name;
-                        impl<'de> serde::de::Visitor<'de> for #visitor_name {
-                            type Value = #struct_ident;
-
-                            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                                write!(f, "a JSON object for {}", #name_str)
-                            }
-
-                            fn visit_map<A>(self, mut map: A) -> Result<#struct_ident, A::Error>
-                            where
-                                A: serde::de::MapAccess<'de>,
-                            {
-                                #(#field_declarations)*
-                                #seen_resource_decl
-
-                                while let Some(key) = map.next_key::<String>()? {
-                                    match key.as_str() {
-                                        #(#key_match_arms)*
-                                        _ => {
-                                            return Err(serde::de::Error::unknown_field(key.as_str(), &[]));
-                                        }
-                                    }
-                                }
-
-                                #(#primitive_merge_blocks)*
-                                #(#typechoice_merge_blocks)*
-
-                                #(#bind_fields)*
-
-                                 #(#value_presence_filtering)*
-
-                                #(#cardinality_checks)*
-
-                                Ok(#struct_ident {
-                                    #(#field_names),*
-                                })
-                            }
-                        }
-
-                        d.deserialize_map(#visitor_name)
-                    }
-                }
-
-                #empty_impl
-            };
-
-            // if name == "ClientApplication" {
-            //     println!("{}", deserialize_impl.to_string());
-            // }
-
-            deserialize_impl.into()
+            generate_complex_deserializer(
+                &struct_ident,
+                &data,
+                &field_meta,
+                deserialize_complex_type,
+                &input.attrs,
+            )
+            .into()
         }
         _ => panic!("Only structs can be deserialized for complex deserializer."),
+    }
+}
+
+fn generate_complex_deserializer(
+    struct_ident: &syn::Ident,
+    data: &DataStruct,
+    field_meta: &[FieldInformation],
+    deserialize_complex_type: DeserializeComplexType,
+    attrs: &[Attribute],
+) -> proc_macro2::TokenStream {
+    let visitor_name = format_ident!("{}Visitor", struct_ident);
+    let name_str = struct_ident.to_string();
+
+    let field_declarations = field_meta.iter().flat_map(create_complex_field_declaration);
+
+    let primitive_merge_blocks = field_meta
+        .iter()
+        .filter(|field| matches!(field.type_info, TypeInformation::Primitive))
+        .map(merge_primitive_extension_tokens)
+        .collect::<Vec<_>>();
+
+    let typechoice_merge_blocks = field_meta
+        .iter()
+        .filter(|field| matches!(field.type_info, TypeInformation::TypeChoice(_)))
+        .map(merge_typechoice_primitive_extension_tokens)
+        .collect::<Vec<_>>();
+
+    let value_presence_filtering = field_meta
+        .iter()
+        .filter(|f| !is_type_string(&f.field_type))
+        .map(filter_empty_values)
+        .collect::<Vec<_>>();
+
+    let cardinality_checks = field_meta
+        .iter()
+        .filter_map(cardinality_checks)
+        .collect::<Vec<_>>();
+
+    let seen_resource_decl = generate_seen_resource_declaration(deserialize_complex_type);
+
+    let key_match_arms =
+        generate_key_match_arms(field_meta, deserialize_complex_type, attrs, &name_str);
+
+    let bind_fields = field_meta.iter().map(|field| {
+        let field_name = field.field_name.as_str();
+        let field_ident = &field.ident;
+        let value_ident = value_ident(field_ident);
+
+        if field.is_optional {
+            quote! {
+                let mut #field_ident = #value_ident.and_then(|v| v);
+            }
+        } else {
+            quote! {
+                let mut #field_ident = #value_ident
+                    .ok_or_else(|| serde::de::Error::missing_field(#field_name))?;
+            }
+        }
+    });
+
+    let field_names = data.fields.iter().map(|f| f.ident.as_ref().unwrap());
+
+    let empty_impl = complex_empty_impl(field_meta, struct_ident);
+
+    quote! {
+        impl<'de> serde::Deserialize<'de> for #struct_ident {
+            fn deserialize<D: serde::Deserializer<'de>>(
+                d: D
+            ) -> Result<Self, D::Error> {
+                struct #visitor_name;
+
+                impl<'de> serde::de::Visitor<'de> for #visitor_name {
+                    type Value = #struct_ident;
+
+                    fn expecting(
+                        &self,
+                        f: &mut std::fmt::Formatter
+                    ) -> std::fmt::Result {
+                        write!(f, "a JSON object for {}", #name_str)
+                    }
+
+                    fn visit_map<A>(
+                        self,
+                        mut map: A
+                    ) -> Result<#struct_ident, A::Error>
+                    where
+                        A: serde::de::MapAccess<'de>,
+                    {
+                        #(#field_declarations)*
+
+                        #seen_resource_decl
+
+                        while let Some(key) = map.next_key::<String>()? {
+                            match key.as_str() {
+                                #(#key_match_arms)*
+
+                                _ => {
+                                    return Err(
+                                        serde::de::Error::unknown_field(
+                                            key.as_str(),
+                                            &[]
+                                        )
+                                    );
+                                }
+                            }
+                        }
+
+                        #(#primitive_merge_blocks)*
+                        #(#typechoice_merge_blocks)*
+
+                        #(#bind_fields)*
+
+                        #(#value_presence_filtering)*
+
+                        #(#cardinality_checks)*
+
+                        Ok(#struct_ident {
+                            #(#field_names),*
+                        })
+                    }
+                }
+
+                d.deserialize_map(#visitor_name)
+            }
+        }
+
+        #empty_impl
+    }
+}
+
+fn generate_seen_resource_declaration(
+    deserialize_complex_type: DeserializeComplexType,
+) -> proc_macro2::TokenStream {
+    if deserialize_complex_type == DeserializeComplexType::Resource {
+        let ident = format_ident!("__seen_resource_type");
+
+        quote! {
+            let mut #ident = false;
+        }
+    } else {
+        quote! {}
+    }
+}
+
+fn generate_key_match_arms(
+    field_meta: &[FieldInformation],
+    deserialize_complex_type: DeserializeComplexType,
+    attrs: &[Attribute],
+    struct_name: &str,
+) -> Vec<proc_macro2::TokenStream> {
+    let mut key_match_arms = Vec::new();
+
+    if deserialize_complex_type == DeserializeComplexType::Resource {
+        key_match_arms.push(generate_resource_type_match_arm(attrs, struct_name));
+    }
+
+    for field in field_meta {
+        key_match_arms.extend(generate_field_match_arms(field));
+    }
+
+    key_match_arms
+}
+
+fn generate_resource_type_match_arm(
+    attrs: &[Attribute],
+    struct_name: &str,
+) -> proc_macro2::TokenStream {
+    let seen_resource_type_ident = format_ident!("__seen_resource_type");
+
+    let resource_type =
+        get_attribute_value(attrs, "fhir_resource_type").unwrap_or_else(|| struct_name.to_string());
+
+    quote! {
+        "resourceType" => {
+            if #seen_resource_type_ident {
+                return Err(
+                    serde::de::Error::duplicate_field("resourceType")
+                );
+            }
+
+            let resource_type: String = map.next_value()?;
+
+            if resource_type != #resource_type {
+                return Err(
+                    serde::de::Error::custom(format!(
+                        "Invalid resourceType for {}: {}",
+                        #resource_type,
+                        resource_type
+                    ))
+                );
+            }
+
+            #seen_resource_type_ident = true;
+        }
+    }
+}
+
+fn generate_field_match_arms(field: &FieldInformation) -> Vec<proc_macro2::TokenStream> {
+    match &field.type_info {
+        TypeInformation::Primitive => generate_primitive_match_arms(field),
+
+        TypeInformation::TypeChoice(attributes) => {
+            generate_typechoice_match_arms(field, attributes)
+        }
+
+        TypeInformation::Complex => {
+            vec![generate_complex_match_arm(field)]
+        }
+    }
+}
+
+fn generate_primitive_match_arms(field: &FieldInformation) -> Vec<proc_macro2::TokenStream> {
+    let mut arms = Vec::new();
+
+    let value_ident = value_ident(&field.ident);
+    let ext_ident = extension_ident(&field.ident);
+
+    let value_field_name = &field.field_name;
+    let ext_field_name = format!("_{}", field.field_name);
+
+    arms.push(quote! {
+        #value_field_name => {
+            if #value_ident.is_some() {
+                return Err(
+                    serde::de::Error::duplicate_field(
+                        #value_field_name
+                    )
+                );
+            }
+
+            #value_ident = Some(map.next_value()?);
+        }
+    });
+
+    if field.is_vector {
+        arms.push(quote! {
+            #ext_field_name => {
+                if #ext_ident.is_some() {
+                    return Err(
+                        serde::de::Error::duplicate_field(
+                            #ext_field_name
+                        )
+                    );
+                }
+
+                #ext_ident =
+                    Some(map.next_value::<Vec<Option<Element>>>()?);
+            }
+        });
+    } else {
+        arms.push(quote! {
+            #ext_field_name => {
+                if #ext_ident.is_some() {
+                    return Err(
+                        serde::de::Error::duplicate_field(
+                            #ext_field_name
+                        )
+                    );
+                }
+
+                #ext_ident =
+                    Some(map.next_value::<Element>()?);
+            }
+        });
+    }
+
+    arms
+}
+
+fn generate_typechoice_match_arms(
+    field: &FieldInformation,
+    type_choice_attributes: &TypeChoiceAttribute,
+) -> Vec<proc_macro2::TokenStream> {
+    let mut arms = Vec::new();
+
+    let value_ident = value_ident(&field.ident);
+    let ext_ident = extension_ident(&field.ident);
+
+    let primitives = &type_choice_attributes.primitive_variants;
+    let complex_variants = &type_choice_attributes.complex_variants;
+
+    for primitive_variant_fieldname in primitives {
+        let value_setter =
+            typechoice_value_setter(field, &value_ident, primitive_variant_fieldname);
+
+        let found_ident = typechoice_variant_found_ident(&field.ident);
+
+        let primitive_ext_field_name = format!("_{primitive_variant_fieldname}");
+
+        arms.push(quote! {
+            #primitive_variant_fieldname => {
+                if #value_ident.is_some() {
+                    return Err(
+                        serde::de::Error::duplicate_field(
+                            #primitive_variant_fieldname
+                        )
+                    );
+                }
+
+                #value_setter
+                #found_ident = Some(#primitive_variant_fieldname);
+            }
+        });
+
+        arms.push(quote! {
+            #primitive_ext_field_name => {
+                #ext_ident =
+                    Some(map.next_value::<Element>()?);
+
+                #found_ident =
+                    Some(#primitive_variant_fieldname);
+            }
+        });
+    }
+
+    for complex_variant_fieldname in complex_variants {
+        let value_setter = typechoice_value_setter(field, &value_ident, complex_variant_fieldname);
+
+        arms.push(quote! {
+            #complex_variant_fieldname => {
+                #value_setter
+            }
+        });
+    }
+
+    arms
+}
+
+fn generate_complex_match_arm(field: &FieldInformation) -> proc_macro2::TokenStream {
+    let value_ident = value_ident(&field.ident);
+    let value_field_name = &field.field_name;
+
+    quote! {
+        #value_field_name => {
+            if #value_ident.is_some() {
+                return Err(
+                    serde::de::Error::duplicate_field(
+                        #value_field_name
+                    )
+                );
+            }
+
+            #value_ident = Some(map.next_value()?);
+        }
     }
 }

--- a/backend/crates/fhir-serialization-json-derive/src/serde_serialize.rs
+++ b/backend/crates/fhir-serialization-json-derive/src/serde_serialize.rs
@@ -46,7 +46,7 @@ pub fn fhir_primitive_serialization(input: DeriveInput) -> TokenStream {
                 .find(|f| f.ident.as_ref().unwrap() == "value")
                 .unwrap();
             // Value could be optional or not depending on SD.
-            let function_to_check_empty = if is_optional_field(&value_field) {
+            let function_to_check_empty = if is_optional_field(value_field) {
                 // Special handling for string types: empty string is considered empty even if the field is present.
                 if is_type_string(&value_field.ty) {
                     quote! {

--- a/backend/crates/fhir-serialization-json-derive/src/serialize.rs
+++ b/backend/crates/fhir-serialization-json-derive/src/serialize.rs
@@ -3,6 +3,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput};
 
+#[derive(Clone, Copy)]
 pub enum ComplexSerializeType {
     Resource,
     Complex,
@@ -94,28 +95,28 @@ pub fn typechoice_serialization(input: DeriveInput) -> TokenStream {
     match input.data {
         Data::Enum(data) => {
             let variants_serialize_value = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 quote! {
                     Self::#name(k) => k.serialize_value(writer)
                 }
             });
 
             let variants_serialize_extension = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 quote! {
                     Self::#name(k) => k.serialize_extension(writer)
                 }
             });
 
             let variants_serialize_field = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 quote! {
                     Self::#name(k) => k.serialize_field(&field, writer)
                 }
             });
 
             let variants_field_name = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 let name_str = name.to_string();
                 quote! {
                     Self::#name(k) => field.to_string() + #name_str
@@ -123,7 +124,7 @@ pub fn typechoice_serialization(input: DeriveInput) -> TokenStream {
             });
 
             let variants_is_primitive = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 quote! {
                     Self::#name(k) => k.is_fp_primitive()
                 }
@@ -172,7 +173,7 @@ pub fn complex_serialization(
     complex_type: ComplexSerializeType,
 ) -> TokenStream {
     let name = input.ident;
-    let resource_type = format!("\"{}\"", name.to_string());
+    let resource_type = format!("\"{name}\"");
     match input.data {
         Data::Struct(data) => {
             let serializers = data.fields.iter().map(|field| {
@@ -182,10 +183,10 @@ pub fn complex_serialization(
                 {
                     renamed_field
                 } else {
-                    field.ident.to_owned().unwrap().to_string()
+                    field.ident.clone().unwrap().to_string()
                 };
 
-                let accessor = field.ident.to_owned().unwrap();
+                let accessor = field.ident.clone().unwrap();
                 quote! {
                     // Means successful serialization so increment total.
                    if self.#accessor.serialize_field(#field_str, &mut tmp_buffer)? {
@@ -270,7 +271,7 @@ pub fn value_set_serialization(input: DeriveInput) -> TokenStream {
     match input.data {
         Data::Enum(data) => {
             let variants_serialize_value = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 let code = get_attribute_value(&variant.attrs, "code");
                 if let Some(code) = code {
                     quote! {
@@ -285,7 +286,7 @@ pub fn value_set_serialization(input: DeriveInput) -> TokenStream {
             });
 
             let variants_serialize_extension = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 quote! {
                     Self::#name(k) => k.serialize_value(writer)
                 }
@@ -353,28 +354,28 @@ pub fn enum_variant_serialization(input: DeriveInput) -> TokenStream {
     match input.data {
         Data::Enum(data) => {
             let variants_serialize_value = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 quote! {
                     Self::#name(k) => k.serialize_value(writer)
                 }
             });
 
             let variants_serialize_extension = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 quote! {
                     Self::#name(k) => k.serialize_extension(writer)
                 }
             });
 
             let variants_serialize_fields = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 quote! {
                     Self::#name(k) => k.serialize_field(field, writer)
                 }
             });
 
             let variants_is_fp_primitive = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
+                let name = variant.ident.clone();
                 quote! {
                     Self::#name(k) => k.is_fp_primitive()
                 }

--- a/backend/crates/fhir-serialization-json-derive/src/utilities.rs
+++ b/backend/crates/fhir-serialization-json-derive/src/utilities.rs
@@ -4,7 +4,7 @@ use syn::{
     Attribute, Expr, Field, Ident, Lit, Meta, MetaList, Token, Type, punctuated::Punctuated,
 };
 
-/// Use rename_field attribute if present else use the struct name
+/// Use `rename_field` attribute if present else use the struct name
 pub fn get_field_name(field: &Field) -> String {
     get_attribute_value(&field.attrs, "rename_field")
         .unwrap_or_else(|| field.ident.as_ref().unwrap().to_string())
@@ -38,7 +38,7 @@ pub fn get_field_type(field: &Field) -> proc_macro2::Ident {
 
 pub fn is_optional_field(field: &Field) -> bool {
     let field_type = get_field_type(field);
-    if field_type == "Option" { true } else { false }
+    field_type == "Option"
 }
 
 pub fn is_type_choice_field(field: &Field) -> bool {
@@ -50,35 +50,28 @@ pub fn is_attribute_present(attrs: &[Attribute], attribute: &str) -> bool {
 }
 
 pub fn get_inner_type_if_optional(type_: &Type) -> Type {
-    if let Type::Path(path) = type_ {
-        if let Some(inner_type) = path.path.segments.first() {
-            if inner_type.ident == "Option" {
-                if let syn::PathArguments::AngleBracketed(args) = &inner_type.arguments {
-                    if let Some(syn::GenericArgument::Type(ty)) = args.args.first() {
-                        return ty.clone();
-                    }
-                }
-            }
-        }
+    if let Type::Path(path) = type_
+        && let Some(inner_type) = path.path.segments.first()
+        && inner_type.ident == "Option"
+        && let syn::PathArguments::AngleBracketed(args) = &inner_type.arguments
+        && let Some(syn::GenericArgument::Type(ty)) = args.args.first()
+    {
+        return ty.clone();
     }
+
     type_.clone()
 }
 
 pub fn get_inner_type_if_vector_or_optional_or_box(type_: &Type) -> Type {
-    if let Type::Path(path) = type_ {
-        if let Some(inner_type) = path.path.segments.first() {
-            if inner_type.ident == "Option"
-                || inner_type.ident == "Vec"
-                || inner_type.ident == "Box"
-            {
-                if let syn::PathArguments::AngleBracketed(args) = &inner_type.arguments {
-                    if let Some(syn::GenericArgument::Type(ty)) = args.args.first() {
-                        return get_inner_type_if_vector_or_optional_or_box(ty);
-                    }
-                }
-            }
-        }
+    if let Type::Path(path) = type_
+        && let Some(inner_type) = path.path.segments.first()
+        && (inner_type.ident == "Option" || inner_type.ident == "Vec" || inner_type.ident == "Box")
+        && let syn::PathArguments::AngleBracketed(args) = &inner_type.arguments
+        && let Some(syn::GenericArgument::Type(ty)) = args.args.first()
+    {
+        return get_inner_type_if_vector_or_optional_or_box(ty);
     }
+
     type_.clone()
 }
 
@@ -130,8 +123,7 @@ pub fn is_type_string(type_: &Type) -> bool {
             .path
             .segments
             .last()
-            .map(|segment| segment.ident == "String")
-            .unwrap_or(false),
+            .is_some_and(|segment| segment.ident == "String"),
         _ => false,
     }
 }
@@ -145,10 +137,10 @@ pub fn is_vector(field: &Field) -> bool {
         // Check if it's an Option<Vec<T>>
         let inner_type = get_inner_type_if_optional(&field.ty);
 
-        if let Type::Path(path) = inner_type {
-            if let Some(inner_type) = path.path.segments.first() {
-                return inner_type.ident == "Vec";
-            }
+        if let Type::Path(path) = inner_type
+            && let Some(inner_type) = path.path.segments.first()
+        {
+            return inner_type.ident == "Vec";
         }
 
         false
@@ -231,7 +223,7 @@ impl TypeChoiceAttribute {
         let mut all_variants = self.complex_variants.clone();
         all_variants.extend(self.primitive_variants.clone());
         // Extension variant.
-        all_variants.extend(self.primitive_variants.iter().map(|v| format!("_{}", v)));
+        all_variants.extend(self.primitive_variants.iter().map(|v| format!("_{v}")));
         all_variants
     }
 }
@@ -247,9 +239,10 @@ pub fn get_type_choice_attribute(attrs: &[Attribute]) -> Option<TypeChoiceAttrib
             .parse_args_with(Punctuated::<Expr, Token![,]>::parse_terminated)
             .unwrap();
 
-        if parsed_arguments.len() > 2 {
-            panic!("Expected exactly 2 type choice variants");
-        }
+        assert!(
+            parsed_arguments.len() <= 2,
+            "Expected exactly 2 type choice variants"
+        );
 
         for expression in parsed_arguments {
             match expression {
@@ -276,10 +269,9 @@ pub fn get_type_choice_attribute(attrs: &[Attribute]) -> Option<TypeChoiceAttrib
                             }
                         }
                         (k, v) => {
-                            println!("{:?}", k);
+                            println!("{k:?}");
                             panic!(
-                                "typechoice must be in format like #[type_choice_variants(primitive =[\"valueString\"], complex = [\"valueAddress\"]) but found {:?} = {:?}",
-                                k, v
+                                "typechoice must be in format like #[type_choice_variants(primitive =[\"valueString\"], complex = [\"valueAddress\"]) but found {k:?} = {v:?}",
                             );
                         }
                     }
@@ -330,10 +322,9 @@ pub fn get_reference_target_attribute(attrs: &[Attribute]) -> Vec<String> {
                             }
                         }
                         (k, v) => {
-                            println!("{:?}", k);
+                            println!("{k:?}");
                             panic!(
-                                "reference must be in format like #[reference(target =[\"Resource\"])] but found {:?} = {:?}",
-                                k, v
+                                "reference must be in format like #[reference(target =[\"Resource\"])] but found {k:?} = {v:?}",
                             );
                         }
                     }

--- a/backend/crates/fhir-serialization-json/src/deserialize_primitives.rs
+++ b/backend/crates/fhir-serialization-json/src/deserialize_primitives.rs
@@ -12,10 +12,10 @@ fn get_value<'a>(value: &'a mut Value, context: &Context) -> Option<&'a mut Valu
 impl FHIRJSONDeserializer for i64 {
     fn from_json_str(s: &str) -> Result<Self, DeserializeError> {
         let mut json_value: Value = serde_json::from_str(s)?;
-        i64::from_serde_value(&mut json_value, Context::AsValue)
+        i64::from_serde_value(&raw mut json_value, Context::AsValue)
     }
     fn from_serde_value(value: *mut Value, context: Context) -> Result<Self, DeserializeError> {
-        let value = unsafe { &mut *(value as *mut Value) };
+        let value = unsafe { &mut *(value.cast::<Value>()) };
         let k = get_value(value, &context).and_then(|v| v.as_i64());
         k.ok_or_else(|| DeserializeError::FailedToConvertType("i64".to_string()))
     }
@@ -24,10 +24,10 @@ impl FHIRJSONDeserializer for i64 {
 impl FHIRJSONDeserializer for u64 {
     fn from_json_str(s: &str) -> Result<Self, DeserializeError> {
         let mut json_value: Value = serde_json::from_str(s)?;
-        u64::from_serde_value(&mut json_value, Context::AsValue)
+        u64::from_serde_value(&raw mut json_value, Context::AsValue)
     }
     fn from_serde_value(value: *mut Value, context: Context) -> Result<Self, DeserializeError> {
-        let value = unsafe { &mut *(value as *mut Value) };
+        let value = unsafe { &mut *(value.cast::<Value>()) };
         let k = get_value(value, &context).and_then(|v| v.as_u64());
         k.ok_or_else(|| DeserializeError::FailedToConvertType("u64".to_string()))
     }
@@ -36,10 +36,10 @@ impl FHIRJSONDeserializer for u64 {
 impl FHIRJSONDeserializer for f64 {
     fn from_json_str(s: &str) -> Result<Self, DeserializeError> {
         let mut json_value: Value = serde_json::from_str(s)?;
-        f64::from_serde_value(&mut json_value, Context::AsValue)
+        f64::from_serde_value(&raw mut json_value, Context::AsValue)
     }
     fn from_serde_value(value: *mut Value, context: Context) -> Result<Self, DeserializeError> {
-        let value = unsafe { &mut *(value as *mut Value) };
+        let value = unsafe { &mut *(value.cast::<Value>()) };
         let k = get_value(value, &context).and_then(|v| v.as_f64());
         k.ok_or_else(|| DeserializeError::FailedToConvertType("f64".to_string()))
     }
@@ -48,10 +48,10 @@ impl FHIRJSONDeserializer for f64 {
 impl FHIRJSONDeserializer for bool {
     fn from_json_str(s: &str) -> Result<Self, DeserializeError> {
         let mut json_value: Value = serde_json::from_str(s)?;
-        bool::from_serde_value(&mut json_value, Context::AsValue)
+        bool::from_serde_value(&raw mut json_value, Context::AsValue)
     }
     fn from_serde_value(value: *mut Value, context: Context) -> Result<Self, DeserializeError> {
-        let value = unsafe { &mut *(value as *mut Value) };
+        let value = unsafe { &mut *(value.cast::<Value>()) };
         let k = get_value(value, &context).and_then(|v| v.as_bool());
         k.ok_or_else(|| DeserializeError::FailedToConvertType("bool".to_string()))
     }
@@ -60,10 +60,10 @@ impl FHIRJSONDeserializer for bool {
 impl FHIRJSONDeserializer for String {
     fn from_json_str(s: &str) -> Result<Self, DeserializeError> {
         let mut json_value: Value = serde_json::from_str(s)?;
-        String::from_serde_value(&mut json_value, Context::AsValue)
+        String::from_serde_value(&raw mut json_value, Context::AsValue)
     }
     fn from_serde_value(value: *mut Value, context: Context) -> Result<Self, DeserializeError> {
-        let value = unsafe { &mut *(value as *mut Value) };
+        let value = unsafe { &mut *(value.cast::<Value>()) };
         let k = get_value(value, &context).and_then(|v| match v.take() {
             Value::String(s) => Some(s),
             _ => None,
@@ -79,15 +79,15 @@ where
 {
     fn from_json_str(s: &str) -> Result<Self, DeserializeError> {
         let mut json_value: Value = serde_json::from_str(s)?;
-        Vec::<T>::from_serde_value(&mut json_value, Context::AsValue)
+        Vec::<T>::from_serde_value(&raw mut json_value, Context::AsValue)
     }
     fn from_serde_value(v: *mut Value, context: Context) -> Result<Self, DeserializeError> {
-        let v = unsafe { &mut *(v as *mut Value) };
+        let v = unsafe { &mut *(v.cast::<Value>()) };
         match &context {
             Context::AsValue => {
                 if let Some(json_array) = v.as_array_mut() {
                     json_array
-                        .into_iter()
+                        .iter_mut()
                         .map(|item| T::from_serde_value(item, Context::AsValue))
                         .collect()
                 } else {
@@ -97,28 +97,11 @@ where
                 }
             }
             Context::AsField(field_context) => {
-                if !field_context.is_primitive {
-                    if let Some(json) = v.get_mut(field_context.field)
-                        && let Some(json_array) = json.as_array_mut()
-                    {
-                        json_array
-                            .into_iter()
-                            .map(|item| T::from_serde_value(item, Context::AsValue))
-                            .collect()
-                    } else {
-                        Err(DeserializeError::InvalidType(
-                            "Expected an array".to_string(),
-                        ))
-                    }
-                }
                 // Special handling because array primitives live in two locations _<field> for element fields and <field> for values.
-                else {
+                if field_context.is_primitive {
                     let mut return_v = vec![];
-                    let mut value_json = if let Some(v) = v.get_mut(field_context.field) {
-                        Some(v.take())
-                    } else {
-                        None
-                    };
+                    let mut value_json =
+                        v.get_mut(field_context.field).map(serde_json::Value::take);
                     let mut values = {
                         if let Some(value_json) = value_json.as_mut() {
                             if let Some(array) = value_json.as_array_mut() {
@@ -133,12 +116,9 @@ where
                         }
                     }?;
 
-                    let mut elements_json =
-                        if let Some(v) = v.get_mut(&format!("_{}", field_context.field)) {
-                            Some(v.take())
-                        } else {
-                            None
-                        };
+                    let mut elements_json = v
+                        .get_mut(format!("_{}", field_context.field))
+                        .map(serde_json::Value::take);
                     let mut elements = {
                         if let Some(elements_json) = elements_json.as_mut() {
                             if let Some(array) = elements_json.as_array_mut() {
@@ -154,8 +134,8 @@ where
                     }?;
 
                     let length = std::cmp::max(
-                        values.as_ref().map(|v| v.len()).unwrap_or(0),
-                        elements.as_ref().map(|v| v.len()).unwrap_or(0),
+                        values.as_ref().map_or(0, |v| v.len()),
+                        elements.as_ref().map_or(0, |v| v.len()),
                     );
 
                     for i in 0..length {
@@ -181,6 +161,17 @@ where
                     }
 
                     Ok(return_v)
+                } else if let Some(json) = v.get_mut(field_context.field)
+                    && let Some(json_array) = json.as_array_mut()
+                {
+                    json_array
+                        .iter_mut()
+                        .map(|item| T::from_serde_value(item, Context::AsValue))
+                        .collect()
+                } else {
+                    Err(DeserializeError::InvalidType(
+                        "Expected an array".to_string(),
+                    ))
                 }
             }
         }
@@ -193,11 +184,11 @@ where
 {
     fn from_json_str(s: &str) -> Result<Self, DeserializeError> {
         let mut json_value: Value = serde_json::from_str(s)?;
-        Option::<T>::from_serde_value(&mut json_value, Context::AsValue)
+        Option::<T>::from_serde_value(&raw mut json_value, Context::AsValue)
     }
 
     fn from_serde_value(value: *mut Value, context: Context) -> Result<Self, DeserializeError> {
-        let value = unsafe { &mut *(value as *mut Value) };
+        let value = unsafe { &mut *(value.cast::<Value>()) };
         match &context {
             Context::AsField(field_context) => match value.get(field_context.field) {
                 Some(_v) => T::from_serde_value(value, context).map(|res| Some(res)),
@@ -220,7 +211,7 @@ where
 {
     fn from_json_str(s: &str) -> Result<Self, DeserializeError> {
         let mut json_value: Value = serde_json::from_str(s)?;
-        Box::<T>::from_serde_value(&mut json_value, Context::AsValue)
+        Box::<T>::from_serde_value(&raw mut json_value, Context::AsValue)
     }
     fn from_serde_value(value: *mut Value, context: Context) -> Result<Self, DeserializeError> {
         T::from_serde_value(value, context).map(|res| Box::new(res))

--- a/backend/crates/fhir-serialization-json/src/serialize_primitives.rs
+++ b/backend/crates/fhir-serialization-json/src/serialize_primitives.rs
@@ -145,7 +145,7 @@ impl FHIRJSONSerializer for bool {
 //               %x75 4HEXDIG )  ; uXXXX                U+XXXX
 impl FHIRJSONSerializer for String {
     fn serialize_value(&self, writer: &mut dyn std::io::Write) -> Result<bool, SerializeError> {
-        writer.write_all(&[b'"'])?;
+        writer.write_all(b"\"")?;
         for c in self.chars() {
             match c {
                 // '\u{002F}' => {
@@ -154,31 +154,31 @@ impl FHIRJSONSerializer for String {
 
                 // backslash
                 '\u{005C}' => {
-                    writer.write_all(&[b'\x5c', b'\x5c'])?;
+                    writer.write_all(b"\x5c\x5c")?;
                 }
                 '\u{0022}' => {
                     writer.write_all(&[b'\x5c', c as u8])?;
                 }
                 // Backspace
                 '\u{0008}' => {
-                    writer.write_all(&[b'\x5c', b'\x62'])?;
+                    writer.write_all(b"\x5c\x62")?;
                 }
                 // Form feed
                 '\u{000C}' => {
-                    writer.write_all(&[b'\x5c', b'\x66'])?;
+                    writer.write_all(b"\x5c\x66")?;
                 }
                 // Line Feed
                 '\u{000A}' => {
-                    writer.write_all(&[b'\x5c', b'\x6e'])?;
+                    writer.write_all(b"\x5c\x6e")?;
                 }
                 // Carriage return
                 '\u{000D}' => {
-                    writer.write_all(&[b'\x5c', b'\x72'])?;
+                    writer.write_all(b"\x5c\x72")?;
                 }
 
                 // Tab
                 '\u{0009}' => {
-                    writer.write_all(&[b'\x5c', b'\x74'])?;
+                    writer.write_all(b"\x5c\x74")?;
                 }
 
                 ch => {
@@ -188,7 +188,7 @@ impl FHIRJSONSerializer for String {
             }
         }
 
-        writer.write_all(&[b'"'])?;
+        writer.write_all(b"\"")?;
 
         Ok(true)
     }
@@ -205,9 +205,9 @@ impl FHIRJSONSerializer for String {
         field: &str,
         writer: &mut dyn std::io::Write,
     ) -> Result<bool, SerializeError> {
-        writer.write_all(&[b'"'])?;
+        writer.write_all(b"\"")?;
         writer.write_all(field.as_bytes())?;
-        writer.write_all(&[b'"', b':'])?;
+        writer.write_all(b"\":")?;
         self.serialize_value(writer)?;
         Ok(true)
     }
@@ -226,36 +226,32 @@ where
             return Ok(false);
         }
 
-        let mut total = 0;
+        let mut serialized = 0;
+        let mut tmp = BufWriter::new(Vec::new());
 
-        let mut tmp_buffer = BufWriter::new(Vec::new());
-        tmp_buffer.write_all(&[b'['])?;
+        tmp.write_all(b"[")?;
 
-        for i in 0..(self.len() - 1) {
-            let v = &self[i];
-            if v.serialize_value(&mut tmp_buffer)? {
-                total += 1;
-            } else {
-                tmp_buffer.write_all("null".as_bytes())?;
+        for (i, value) in self.iter().enumerate() {
+            if i > 0 {
+                tmp.write_all(b",")?;
             }
-            tmp_buffer.write_all(&[b','])?;
+
+            if value.serialize_value(&mut tmp)? {
+                serialized += 1;
+            } else {
+                tmp.write_all(b"null")?;
+            }
         }
 
-        // Last one don't want trailing comma.
-        if self[self.len() - 1].serialize_value(&mut tmp_buffer)? {
-            total += 1;
-        } else {
-            tmp_buffer.write_all("null".as_bytes())?;
+        tmp.write_all(b"]")?;
+
+        if serialized == 0 {
+            return Ok(false);
         }
 
-        tmp_buffer.write_all(&[b']'])?;
-        if total > 0 {
-            tmp_buffer.flush()?;
-            writer.write_all(&tmp_buffer.into_inner()?)?;
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        tmp.flush()?;
+        writer.write_all(&tmp.into_inner()?)?;
+        Ok(true)
     }
 
     fn serialize_extension(&self, writer: &mut dyn std::io::Write) -> Result<bool, SerializeError> {
@@ -267,16 +263,17 @@ where
             let mut total = 0;
 
             let mut tmp_buffer = BufWriter::new(Vec::new());
-            tmp_buffer.write_all(&[b'['])?;
+            tmp_buffer.write_all(b"[")?;
 
-            for i in 0..(self.len() - 1) {
-                let v = &self[i];
-                if v.serialize_extension(&mut tmp_buffer)? {
-                    total += 1;
-                } else {
-                    tmp_buffer.write_all("null".as_bytes())?;
+            if self.len() > 1 {
+                for v in &self[..self.len() - 1] {
+                    if v.serialize_extension(&mut tmp_buffer)? {
+                        total += 1;
+                    } else {
+                        tmp_buffer.write_all(b"null")?;
+                    }
+                    tmp_buffer.write_all(b",")?;
                 }
-                tmp_buffer.write_all(&[b','])?;
             }
 
             // Last one don't want trailing comma.
@@ -286,7 +283,7 @@ where
                 tmp_buffer.write_all("null".as_bytes())?;
             }
 
-            tmp_buffer.write_all(&[b']'])?;
+            tmp_buffer.write_all(b"]")?;
 
             if total > 0 {
                 tmp_buffer.flush()?;
@@ -318,20 +315,20 @@ where
         let extension_u8 = extension_buffer.into_inner()?;
 
         if should_serialize_extension {
-            writer.write_all(&[b'"', b'_'])?;
+            writer.write_all(b"\"_")?;
             writer.write_all(field.as_bytes())?;
-            writer.write_all(&[b'"', b':'])?;
+            writer.write_all(b"\":")?;
             writer.write_all(&extension_u8)?;
             // If value not empty put trailing comma after extension value.
             if shoud_serialize_value {
-                writer.write_all(&[b','])?;
+                writer.write_all(b",")?;
             }
         }
 
         if shoud_serialize_value {
-            writer.write_all(&[b'"'])?;
+            writer.write_all(b"\"")?;
             writer.write_all(field.as_bytes())?;
-            writer.write_all(&[b'"', b':'])?;
+            writer.write_all(b"\":")?;
             writer.write_all(&value_u8)?;
         }
 

--- a/backend/crates/fhir-serialization-json/src/traits.rs
+++ b/backend/crates/fhir-serialization-json/src/traits.rs
@@ -13,14 +13,44 @@ pub enum SerializeError {
     #[error("UTF-8 conversion error: {0}")]
     Utf8Error(#[from] std::string::FromUtf8Error),
 }
+
+/// Trait for serializing FHIR values to JSON.
 pub trait FHIRJSONSerializer {
+    /// Serializes the JSON value representation.
+    ///
+    /// Returns `true` if any output was written.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SerializeError`] if writing to `writer` fails or if the value
+    /// cannot be serialized.
     fn serialize_value(&self, writer: &mut dyn std::io::Write) -> Result<bool, SerializeError>;
+
+    /// Serializes the JSON extension representation.
+    ///
+    /// Returns `true` if any output was written.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SerializeError`] if writing to `writer` fails or if the
+    /// extension cannot be serialized.
     fn serialize_extension(&self, writer: &mut dyn std::io::Write) -> Result<bool, SerializeError>;
+
+    /// Serializes a named JSON field.
+    ///
+    /// Returns `true` if the field was written.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SerializeError`] if writing to `writer` fails or if the field
+    /// cannot be serialized.
     fn serialize_field(
         &self,
         field: &str,
         writer: &mut dyn std::io::Write,
     ) -> Result<bool, SerializeError>;
+
+    /// Returns whether this value is a FHIR primitive.
     fn is_fp_primitive(&self) -> bool;
 }
 
@@ -30,6 +60,7 @@ pub struct ContextAsField<'a> {
 }
 
 impl<'a> ContextAsField<'a> {
+    #[must_use]
     pub fn new(field: &'a str, is_primitive: bool) -> Self {
         ContextAsField {
             field,
@@ -55,8 +86,22 @@ impl<'a> From<(&'a String, bool)> for Context<'a> {
     }
 }
 
+/// Trait for deserializing FHIR values from JSON.
 pub trait FHIRJSONDeserializer: Sized {
+    /// Deserializes a value from a JSON string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DeserializeError`] if the input is not valid JSON or cannot be
+    /// deserialized into `Self`.
     fn from_json_str(s: &str) -> Result<Self, DeserializeError>;
+
+    /// Deserializes a value from a parsed JSON value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DeserializeError`] if the JSON value cannot be deserialized
+    /// into `Self` or if the provided context is invalid for deserialization.
     fn from_serde_value(v: *mut Value, context: Context) -> Result<Self, DeserializeError>;
 }
 

--- a/backend/crates/reflect-derive/src/lib.rs
+++ b/backend/crates/reflect-derive/src/lib.rs
@@ -22,10 +22,10 @@ fn get_attribute_rename(attrs: &[Attribute]) -> Option<String> {
 }
 
 fn is_optional(field: &Field) -> bool {
-    if let syn::Type::Path(type_path) = &field.ty {
-        if let Some(segment) = type_path.path.segments.first() {
-            return segment.ident == "Option";
-        }
+    if let syn::Type::Path(type_path) = &field.ty
+        && let Some(segment) = type_path.path.segments.first()
+    {
+        return segment.ident == "Option";
     }
     false
 }
@@ -49,235 +49,203 @@ fn get_attribute_fhir_type(attrs: &[Attribute]) -> Option<String> {
     })
 }
 
+fn expand_struct(input: &DeriveInput, data: &syn::DataStruct) -> TokenStream {
+    let fhir_type = get_attribute_fhir_type(&input.attrs);
+    let all_fields = data
+        .fields
+        .iter()
+        .map(|field| field.ident.as_ref().unwrap().to_string());
+
+    let name = &input.ident;
+
+    let accessors = data.fields.iter().map(|field| {
+        let renamed = get_attribute_rename(&field.attrs);
+        let name = renamed.unwrap_or_else(|| field.ident.as_ref().unwrap().to_string());
+
+        let accessor = field.ident.clone().unwrap();
+
+        if is_optional(field) {
+            quote! {
+                #name => if let Some(v) = self.#accessor.as_ref() {
+                    Some(v)
+                } else {
+                    None
+                }
+            }
+        } else {
+            quote! {
+                #name => Some(&self.#accessor)
+            }
+        }
+    });
+
+    let mutable_accessor = data.fields.iter().map(|field| {
+        let renamed = get_attribute_rename(&field.attrs);
+        let name = renamed.unwrap_or_else(|| field.ident.as_ref().unwrap().to_string());
+
+        let accessor = field.ident.clone().unwrap();
+
+        quote! {
+            #name => Some(&mut self.#accessor)
+        }
+    });
+
+    quote! {
+        impl haste_reflect::MetaValue for #name {
+            fn fields(&self) -> Vec<&'static str> {
+                vec![#(#all_fields),*]
+            }
+
+            fn get_field<'a>(&'a self, field: &str) -> Option<&'a dyn MetaValue> {
+                match field {
+                    #(#accessors),*,
+                    _ => None,
+                }
+            }
+
+            fn get_field_mut<'a>(&'a mut self, field: &str) -> Option<&'a mut dyn MetaValue> {
+                match field {
+                    #(#mutable_accessor),*,
+                    _ => None,
+                }
+            }
+
+            fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+                None
+            }
+
+            fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+                None
+            }
+
+            fn fhir_type(&self) -> &'static str {
+                #fhir_type
+            }
+
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+
+            fn flatten(&self) -> Vec<&dyn MetaValue> {
+                vec![self]
+            }
+
+            fn is_many(&self) -> bool {
+                false
+            }
+        }
+    }
+    .into()
+}
+
+fn expand_enum(input: &DeriveInput, data: &syn::DataEnum) -> TokenStream {
+    let enum_name = &input.ident;
+
+    let variants_fields = data.variants.iter().map(|variant| {
+        let name = variant.ident.clone();
+        quote! { Self::#name(k) => k.fields() }
+    });
+
+    let variants_get_field = data.variants.iter().map(|variant| {
+        let name = variant.ident.clone();
+        quote! { Self::#name(k) => k.get_field(field) }
+    });
+
+    let variants_get_index = data.variants.iter().map(|variant| {
+        let name = variant.ident.clone();
+        quote! { Self::#name(k) => k.get_index(field) }
+    });
+
+    let variants_get_field_mut = data.variants.iter().map(|variant| {
+        let name = variant.ident.clone();
+        quote! { Self::#name(k) => k.get_field_mut(field) }
+    });
+
+    let variants_get_index_mut = data.variants.iter().map(|variant| {
+        let name = variant.ident.clone();
+        quote! { Self::#name(k) => k.get_index_mut(index) }
+    });
+
+    let variants_as_any = data.variants.iter().map(|variant| {
+        let name = variant.ident.clone();
+        quote! { Self::#name(k) => k.as_any() }
+    });
+
+    let variants_flatten = data.variants.iter().map(|variant| {
+        let name = variant.ident.clone();
+        quote! { Self::#name(k) => k.flatten() }
+    });
+
+    let variants_fhir_type = data.variants.iter().map(|variant| {
+        let name = variant.ident.clone();
+        quote! { Self::#name(k) => k.fhir_type() }
+    });
+
+    quote! {
+        impl haste_reflect::MetaValue for #enum_name {
+            fn fields(&self) -> Vec<&'static str> {
+                match self {
+                    #(#variants_fields),*
+                }
+            }
+
+            fn get_field<'a>(&'a self, field: &str) -> Option<&'a dyn MetaValue> {
+                match self {
+                    #(#variants_get_field),*
+                }
+            }
+
+            fn get_index<'a>(&'a self, field: usize) -> Option<&'a dyn MetaValue> {
+                match self {
+                    #(#variants_get_index),*
+                }
+            }
+
+            fn get_field_mut<'a>(&'a mut self, field: &str) -> Option<&'a mut dyn MetaValue> {
+                match self {
+                    #(#variants_get_field_mut),*
+                }
+            }
+
+            fn get_index_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn MetaValue> {
+                match self {
+                    #(#variants_get_index_mut),*
+                }
+            }
+
+            fn fhir_type(&self) -> &'static str {
+                match self {
+                    #(#variants_fhir_type),*
+                }
+            }
+
+            fn as_any(&self) -> &dyn std::any::Any {
+                match self {
+                    #(#variants_as_any),*
+                }
+            }
+
+            fn flatten(&self) -> Vec<&dyn MetaValue> {
+                match self {
+                    #(#variants_flatten),*
+                }
+            }
+
+            fn is_many(&self) -> bool {
+                false
+            }
+        }
+    }
+    .into()
+}
+
 #[proc_macro_derive(Reflect, attributes(rename_field, fhir_type))]
 pub fn haste_reflect(input: TokenStream) -> TokenStream {
-    // Parse the input tokens into a syntax tree
     let input = parse_macro_input!(input as DeriveInput);
 
     match input.data {
-        Data::Struct(data) => {
-            let fhir_type = get_attribute_fhir_type(&input.attrs);
-            let all_fields = data
-                .fields
-                .iter()
-                .map(|field| field.ident.to_owned().unwrap().to_string());
-
-            let name = input.ident;
-
-            let accessors = data.fields.iter().map(|field| {
-                let renamed = get_attribute_rename(&field.attrs);
-                let name = if let Some(renamed_field) = renamed {
-                    renamed_field
-                } else {
-                    field.ident.to_owned().unwrap().to_string()
-                };
-
-                let accessor = field.ident.to_owned().unwrap();
-                if is_optional(field) {
-                    quote! {
-                         #name => if let Some(v) = self.#accessor.as_ref() {
-                             Some(v)
-                         } else {
-                             None
-                         }
-                    }
-                } else {
-                    quote! {
-                        #name => Some(&self.#accessor)
-                    }
-                }
-            });
-
-            let mutable_accessor = data.fields.iter().map(|field| {
-                let renamed = get_attribute_rename(&field.attrs);
-                let name = if let Some(renamed_field) = renamed {
-                    renamed_field
-                } else {
-                    field.ident.to_owned().unwrap().to_string()
-                };
-
-                let accessor = field.ident.to_owned().unwrap();
-                // For mutable accessors, we return nested Option types that are None
-                // So that the caller can choose to initialize them if needed.
-                quote! {
-                    #name => Some(&mut self.#accessor)
-                }
-            });
-
-            let expanded = quote! {
-                impl haste_reflect::MetaValue for #name {
-                    fn fields(&self) -> Vec<&'static str> {
-                        vec![
-                            #(#all_fields),*
-                        ]
-                    }
-
-                    fn get_field<'a>(&'a self, field: &str) -> Option<&'a dyn MetaValue> {
-                        match field {
-                            #(#accessors),*
-                            ,_ => None,
-                        }
-                    }
-
-                    fn get_field_mut<'a>(&'a mut self, field: &str) -> Option<&'a mut dyn MetaValue> {
-                         match field {
-                            #(#mutable_accessor),*
-                            ,_ => None,
-                        }
-                    }
-
-                    fn get_index_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn MetaValue> {
-                        None
-                    }
-
-                    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
-                        None
-                    }
-
-                    fn fhir_type(&self) -> &'static str {
-                        #fhir_type
-                    }
-
-                    fn as_any(&self) -> &dyn std::any::Any {
-                        self
-                    }
-
-                    fn flatten(&self) -> Vec<&dyn MetaValue> {
-                        vec![self]
-                    }
-
-                    fn is_many(&self) -> bool {
-                        false
-                    }
-
-                }
-            };
-
-            expanded.into()
-        }
-
-        Data::Enum(data) => {
-            let enum_name = input.ident;
-
-            let variants_fields = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
-                quote! {
-                    Self::#name(k) => k.fields()
-                }
-            });
-
-            let variants_get_field = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
-                quote! {
-                    Self::#name(k) => k.get_field(field)
-                }
-            });
-
-            let variants_get_index = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
-                quote! {
-                    Self::#name(k) => k.get_index(field)
-                }
-            });
-
-            let variants_get_field_mut = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
-                quote! {
-                    Self::#name(k) => k.get_field_mut(field)
-                }
-            });
-
-            let variants_get_index_mut = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
-                quote! {
-                    Self::#name(k) => k.get_index_mut(index)
-                }
-            });
-
-            let variants_as_any = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
-                quote! {
-                    Self::#name(k) => k.as_any()
-                }
-            });
-
-            let variants_flatten = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
-                quote! {
-                    Self::#name(k) => k.flatten()
-                }
-            });
-
-            let variants_fhir_type = data.variants.iter().map(|variant| {
-                let name = variant.ident.to_owned();
-                quote! {
-                    Self::#name(k) => k.fhir_type()
-                }
-            });
-
-            let expanded = quote! {
-                impl haste_reflect::MetaValue for #enum_name {
-                    fn fields(&self) -> Vec<&'static str> {
-                        match self {
-                            #(#variants_fields),*
-                        }
-                    }
-
-                    fn get_field<'a>(&'a self, field: &str) -> Option<&'a dyn MetaValue> {
-                        match self {
-                            #(#variants_get_field),*
-                        }
-                    }
-
-                    fn get_index<'a>(&'a self, field: usize) -> Option<&'a dyn MetaValue> {
-                        match self {
-                            #(#variants_get_index),*
-                        }
-                    }
-
-                    fn get_field_mut<'a>(&'a mut self, field: &str) -> Option<&'a mut dyn MetaValue> {
-                         match self {
-                            #(#variants_get_field_mut),*
-                        }
-                    }
-
-                    fn get_index_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn MetaValue> {
-                        match self {
-                            #(#variants_get_index_mut),*
-                        }
-                    }
-
-                    fn fhir_type(&self) -> &'static str {
-                        match self {
-                            #(#variants_fhir_type),*
-                        }
-                    }
-
-                    fn as_any(&self) -> &dyn std::any::Any {
-                        match self {
-                            #(#variants_as_any),*
-                        }
-                    }
-
-                    fn flatten(&self) -> Vec<&dyn MetaValue> {
-                        match self {
-                            #(#variants_flatten),*
-                        }
-                    }
-
-                    fn is_many(&self) -> bool {
-                        false
-                    }
-                }
-            };
-
-            // println!("{}", expanded);
-
-            expanded.into()
-        }
-
-        Data::Union(_data) => {
-            todo!("Union not supported");
-        }
+        Data::Struct(ref data) => expand_struct(&input, data),
+        Data::Enum(ref data) => expand_enum(&input, data),
+        Data::Union(_) => todo!("Union not supported"),
     }
 }

--- a/backend/crates/reflect/src/primitives.rs
+++ b/backend/crates/reflect/src/primitives.rs
@@ -1,16 +1,13 @@
 use crate::traits::MetaValue;
 use std::any::Any;
 
-/**
- * 067  public static final String FP_String = "http://hl7.org/fhirpath/System.String";
- * 068  public static final String FP_Boolean = "http://hl7.org/fhirpath/System.Boolean";
- * 069  public static final String FP_Integer = "http://hl7.org/fhirpath/System.Integer";
- * 070  public static final String FP_Decimal = "http://hl7.org/fhirpath/System.Decimal";
- * 071  public static final String FP_Quantity = "http://hl7.org/fhirpath/System.Quantity";
- * 072  public static final String FP_DateTime = "http://hl7.org/fhirpath/System.DateTime";
- * 073  public static final String FP_Time = "http://hl7.org/fhirpath/System.Time";
- */
-
+/// 067  public static final String `FP_String` = <http://hl7.org/fhirpath/System.String>;
+/// 068  public static final String `FP_Boolean` = <http://hl7.org/fhirpath/System.Boolean>;
+/// 069  public static final String `FP_Integer` = <http://hl7.org/fhirpath/System.Integer>;
+/// 070  public static final String `FP_Decimal` = <http://hl7.org/fhirpath/System.Decimal>;
+/// 071  public static final String `FP_Quantity` = <http://hl7.org/fhirpath/System.Quantity>;
+/// 072  public static final String `FP_DateTime` = <http://hl7.org/fhirpath/System.DateTime>;
+/// 073  public static final String `FP_Time` = <http://hl7.org/fhirpath/System.Time>;
 impl MetaValue for i64 {
     fn fields(&self) -> Vec<&'static str> {
         vec![]
@@ -20,7 +17,7 @@ impl MetaValue for i64 {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -28,7 +25,7 @@ impl MetaValue for i64 {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -57,7 +54,7 @@ impl MetaValue for u64 {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -65,7 +62,7 @@ impl MetaValue for u64 {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -94,7 +91,7 @@ impl MetaValue for f64 {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -102,7 +99,7 @@ impl MetaValue for f64 {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -131,7 +128,7 @@ impl MetaValue for bool {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -139,7 +136,7 @@ impl MetaValue for bool {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -168,7 +165,7 @@ impl MetaValue for String {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -176,7 +173,7 @@ impl MetaValue for String {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -205,7 +202,7 @@ impl MetaValue for &'static str {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -213,7 +210,7 @@ impl MetaValue for &'static str {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -250,7 +247,7 @@ where
         None
     }
 
-    fn get_index<'a>(&'a self, index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, index: usize) -> Option<&dyn MetaValue> {
         if self.get(index).is_some() {
             let k: &dyn MetaValue = &self[index];
             Some(k)
@@ -263,7 +260,7 @@ where
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, index: usize) -> Option<&mut dyn MetaValue> {
         if self.get(index).is_some() {
             let k: &mut dyn MetaValue = &mut self[index];
             Some(k)
@@ -324,10 +321,10 @@ where
     }
 
     fn flatten(&self) -> Vec<&dyn MetaValue> {
-        self.as_ref().map(|v| v.flatten()).unwrap_or_else(|| vec![])
+        self.as_ref().map_or_else(Vec::new, |v| v.flatten())
     }
 
-    fn get_index<'a>(&'a self, index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, index: usize) -> Option<&dyn MetaValue> {
         self.as_ref().and_then(|v| v.get_index(index))
     }
 
@@ -335,12 +332,12 @@ where
         self.as_mut().and_then(|value| value.get_field_mut(field))
     }
 
-    fn get_index_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, index: usize) -> Option<&mut dyn MetaValue> {
         self.as_mut().and_then(|v| v.get_index_mut(index))
     }
 
     fn is_many(&self) -> bool {
-        self.as_ref().map(|v| v.is_many()).unwrap_or(false)
+        self.as_ref().is_some_and(super::traits::MetaValue::is_many)
     }
 }
 
@@ -368,7 +365,7 @@ where
         self.as_ref().flatten()
     }
 
-    fn get_index<'a>(&'a self, index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, index: usize) -> Option<&dyn MetaValue> {
         self.as_ref().get_index(index)
     }
 
@@ -376,7 +373,7 @@ where
         self.as_mut().get_field_mut(field)
     }
 
-    fn get_index_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, index: usize) -> Option<&mut dyn MetaValue> {
         self.as_mut().get_index_mut(index)
     }
     fn is_many(&self) -> bool {

--- a/backend/crates/reflect/src/traits.rs
+++ b/backend/crates/reflect/src/traits.rs
@@ -6,8 +6,8 @@ pub trait MetaValue: Any + Debug + Send + Sync {
     fn get_field<'a>(&'a self, field: &str) -> Option<&'a dyn MetaValue>;
     fn get_field_mut<'a>(&'a mut self, field: &str) -> Option<&'a mut dyn MetaValue>;
 
-    fn get_index<'a>(&'a self, index: usize) -> Option<&'a dyn MetaValue>;
-    fn get_index_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn MetaValue>;
+    fn get_index(&self, index: usize) -> Option<&dyn MetaValue>;
+    fn get_index_mut(&mut self, index: usize) -> Option<&mut dyn MetaValue>;
 
     fn flatten(&self) -> Vec<&dyn MetaValue>;
 


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.