### PR TITLE
Resolve `clippy` lints for `fhir-query`, `pointer` and `jwt` crates

### DIFF
--- a/backend/crates/jwt/src/claims.rs
+++ b/backend/crates/jwt/src/claims.rs
@@ -19,11 +19,12 @@ pub enum SubscriptionTier {
 impl From<SubscriptionTier> for String {
     fn from(tier: SubscriptionTier) -> Self {
         match tier {
-            SubscriptionTier::Free => "free".to_string(),
-            SubscriptionTier::Professional => "professional".to_string(),
-            SubscriptionTier::Team => "team".to_string(),
-            SubscriptionTier::Unlimited => "unlimited".to_string(),
+            SubscriptionTier::Free => "free",
+            SubscriptionTier::Professional => "professional",
+            SubscriptionTier::Team => "team",
+            SubscriptionTier::Unlimited => "unlimited",
         }
+        .to_string()
     }
 }
 
@@ -37,7 +38,7 @@ impl TryFrom<String> for SubscriptionTier {
             "unlimited" => Ok(SubscriptionTier::Unlimited),
             _ => Err(OperationOutcomeError::error(
                 IssueType::INVALID,
-                format!("Invalid subscription tier: '{}'", value),
+                format!("Invalid subscription tier: '{value}'"),
             )),
         }
     }

--- a/backend/crates/jwt/src/lib.rs
+++ b/backend/crates/jwt/src/lib.rs
@@ -44,6 +44,7 @@ pub enum AuthorId {
 }
 
 impl AuthorId {
+    #[must_use]
     pub fn new(id: String) -> Self {
         // Should never be able to create a system author from user.
         if id == SYSTEM {
@@ -84,7 +85,7 @@ impl Serialize for AuthorId {
 impl Display for AuthorId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AuthorId::System => write!(f, "{}", SYSTEM),
+            AuthorId::System => write!(f, "{SYSTEM}"),
             AuthorId::User(id) => write!(f, "{}", id.as_ref()),
         }
     }
@@ -124,6 +125,7 @@ pub enum TenantId {
 }
 
 impl TenantId {
+    #[must_use]
     pub fn new(id: String) -> Self {
         // Should never be able to create a system tenant from user.
         if id == SYSTEM {
@@ -170,8 +172,8 @@ impl Serialize for TenantId {
 impl Display for TenantId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TenantId::System => write!(f, "{}", SYSTEM),
-            TenantId::Custom(id) => write!(f, "{}", id),
+            TenantId::System => write!(f, "{SYSTEM}"),
+            TenantId::Custom(id) => write!(f, "{id}"),
         }
     }
 }
@@ -184,6 +186,7 @@ pub enum ProjectId {
     Custom(String),
 }
 impl ProjectId {
+    #[must_use]
     pub fn new(id: String) -> Self {
         // Should never be able to create a system project from user.
         if id == SYSTEM {
@@ -224,21 +227,22 @@ impl Serialize for ProjectId {
 impl Display for ProjectId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProjectId::System => write!(f, "{}", SYSTEM),
-            ProjectId::Custom(id) => write!(f, "{}", id),
+            ProjectId::System => write!(f, "{SYSTEM}"),
+            ProjectId::Custom(id) => write!(f, "{id}"),
         }
     }
 }
 
 pub struct VersionIdRef<'a>(&'a str);
 impl<'a> VersionIdRef<'a> {
+    #[must_use]
     pub fn new(id: &'a str) -> Self {
         VersionIdRef(id)
     }
 }
 impl<'a> AsRef<str> for VersionIdRef<'a> {
     fn as_ref(&self) -> &'a str {
-        &self.0
+        self.0
     }
 }
 impl<'a> From<&'a VersionId> for VersionIdRef<'a> {
@@ -251,6 +255,7 @@ impl<'a> From<&'a VersionId> for VersionIdRef<'a> {
 #[derivative(Debug = "transparent")]
 pub struct VersionId(String);
 impl VersionId {
+    #[must_use]
     pub fn new(id: String) -> Self {
         VersionId(id)
     }
@@ -270,6 +275,7 @@ impl AsRef<str> for VersionId {
 #[derivative(Debug = "transparent")]
 pub struct ResourceId(String);
 impl ResourceId {
+    #[must_use]
     pub fn new(id: String) -> Self {
         ResourceId(id)
     }

--- a/backend/crates/jwt/src/reflect.rs
+++ b/backend/crates/jwt/src/reflect.rs
@@ -11,7 +11,7 @@ impl MetaValue for TenantId {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -19,7 +19,7 @@ impl MetaValue for TenantId {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -49,7 +49,7 @@ impl MetaValue for ProjectId {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -57,7 +57,7 @@ impl MetaValue for ProjectId {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -87,7 +87,7 @@ impl MetaValue for ResourceId {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -95,7 +95,7 @@ impl MetaValue for ResourceId {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -124,15 +124,15 @@ impl MetaValue for VersionId {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
-    fn get_field_mut<'a>(&'a mut self, _field: &str) -> Option<&'a mut dyn MetaValue> {
+    fn get_field_mut(&mut self, _field: &str) -> Option<&mut dyn MetaValue> {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut<'a>(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 

--- a/backend/crates/jwt/src/scopes.rs
+++ b/backend/crates/jwt/src/scopes.rs
@@ -35,7 +35,7 @@ impl TryFrom<&str> for OIDCScope {
             "online_access" => Ok(Self::OnlineAccess),
             _ => Err(OperationOutcomeError::error(
                 IssueType::NOT_SUPPORTED,
-                format!("OIDC Scope '{}' not supported.", value),
+                format!("OIDC Scope '{value}' not supported."),
             )),
         }
     }
@@ -65,7 +65,7 @@ impl TryFrom<&str> for LaunchType {
             "patient" => Ok(LaunchType::Patient),
             _ => Err(OperationOutcomeError::error(
                 IssueType::NOT_SUPPORTED,
-                format!("Launch type '{}' not supported.", value),
+                format!("Launch type '{value}' not supported."),
             )),
         }
     }
@@ -79,9 +79,10 @@ pub struct LaunchTypeScope {
 impl From<LaunchTypeScope> for String {
     fn from(value: LaunchTypeScope) -> Self {
         match value.launch_type {
-            LaunchType::Encounter => "launch/encounter".to_string(),
-            LaunchType::Patient => "launch/patient".to_string(),
+            LaunchType::Encounter => "launch/encounter",
+            LaunchType::Patient => "launch/patient",
         }
+        .to_string()
     }
 }
 
@@ -102,7 +103,7 @@ impl TryFrom<&str> for SmartResourceScopeUser {
             "patient" => Ok(SmartResourceScopeUser::Patient),
             _ => Err(OperationOutcomeError::error(
                 IssueType::NOT_SUPPORTED,
-                format!("Smart resource scope level '{}' not supported.", value),
+                format!("Smart resource scope level '{value}' not supported."),
             )),
         }
     }
@@ -125,8 +126,7 @@ impl TryFrom<&str> for SmartResourceScopeLevel {
                     OperationOutcomeError::error(
                         IssueType::NOT_SUPPORTED,
                         format!(
-                            "Smart resource scope resource type '{}' not supported.",
-                            resource_type,
+                            "Smart resource scope resource type '{resource_type}' not supported.",
                         ),
                     )
                 })?;
@@ -149,10 +149,12 @@ pub enum SmartResourceScopePermission {
 pub struct SmartResourceScopePermissions(Vec<SmartResourceScopePermission>);
 
 impl SmartResourceScopePermissions {
+    #[must_use]
     pub fn new(permissions: Vec<SmartResourceScopePermission>) -> Self {
         Self(permissions)
     }
 
+    #[must_use]
     pub fn has_permission(&self, permission: &SmartResourceScopePermission) -> bool {
         self.0.contains(permission)
     }
@@ -197,14 +199,20 @@ impl TryFrom<&str> for SmartResourceScopePermissions {
                     let found_index = SMART_RESOURCE_SCOPE_PERMISSION_ORDER
                         .iter()
                         .position(|o| *o == method)
-                        .map(|p| p as i8);
+                        .map(i8::try_from)
+                        .transpose()
+                        .map_err(|e| {
+                            OperationOutcomeError::error(
+                                IssueType::NOT_SUPPORTED,
+                                format!("Permission order index overflow {e}"),
+                            )
+                        })?;
 
                     if found_index <= Some(current_index) || found_index.is_none() {
                         return Err(OperationOutcomeError::error(
                             IssueType::NOT_SUPPORTED,
                             format!(
-                                "Invalid scope access type methods: '{}' not supported or in wrong place must be in 'cruds' order.",
-                                method
+                                "Invalid scope access type methods: '{method}' not supported or in wrong place must be in 'cruds' order.",
                             ),
                         ));
                     }
@@ -312,7 +320,7 @@ impl From<SMARTResourceScope> for String {
             permissions_str.push('s');
         }
 
-        format!("{}/{}.{}", user_str, level_str, permissions_str)
+        format!("{user_str}/{level_str}.{permissions_str}")
     }
 }
 
@@ -346,7 +354,7 @@ impl TryFrom<&str> for SmartScope {
                 if chunks.len() != 2 {
                     return Err(OperationOutcomeError::error(
                         IssueType::NOT_SUPPORTED,
-                        format!("Invalid launch scope: '{}'.", value),
+                        format!("Invalid launch scope: '{value}'."),
                     ));
                 }
 
@@ -362,7 +370,7 @@ impl TryFrom<&str> for SmartScope {
                 if parts.len() != 2 {
                     return Err(OperationOutcomeError::error(
                         IssueType::NOT_SUPPORTED,
-                        format!("Invalid smart resource scope: '{}'.", value),
+                        format!("Invalid smart resource scope: '{value}'."),
                     ));
                 }
 
@@ -371,7 +379,7 @@ impl TryFrom<&str> for SmartScope {
                 if permissions_parts.len() != 2 {
                     return Err(OperationOutcomeError::error(
                         IssueType::NOT_SUPPORTED,
-                        format!("Invalid smart resource scope: '{}'.", value),
+                        format!("Invalid smart resource scope: '{value}'."),
                     ));
                 }
 
@@ -386,7 +394,7 @@ impl TryFrom<&str> for SmartScope {
             }
             _ => Err(OperationOutcomeError::error(
                 IssueType::NOT_SUPPORTED,
-                format!("Smart Scope '{}' not supported.", value),
+                format!("Smart Scope '{value}' not supported."),
             )),
         }
     }
@@ -419,18 +427,13 @@ impl From<Scope> for String {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct Scopes(pub Vec<Scope>);
 
 impl Scopes {
+    #[must_use]
     pub fn contains_scope(&self, scope: &Scope) -> bool {
         self.0.contains(scope)
-    }
-}
-
-impl Default for Scopes {
-    fn default() -> Self {
-        Scopes(vec![])
     }
 }
 
@@ -438,10 +441,8 @@ impl TryFrom<&str> for Scopes {
     type Error = OperationOutcomeError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let scopes: Result<Vec<Scope>, OperationOutcomeError> = value
-            .split_whitespace()
-            .map(|s| Scope::try_from(s))
-            .collect();
+        let scopes: Result<Vec<Scope>, OperationOutcomeError> =
+            value.split_whitespace().map(Scope::try_from).collect();
 
         Ok(Scopes(scopes?))
     }
@@ -450,9 +451,7 @@ impl TryFrom<&str> for Scopes {
 // Used by sqlx binding this is not safe.
 impl From<String> for Scopes {
     fn from(value: String) -> Self {
-        let scopes = Self::try_from(value.as_str()).expect("Invalid scopes string");
-
-        scopes
+        Self::try_from(value.as_str()).expect("Invalid scopes string")
     }
 }
 
@@ -471,7 +470,7 @@ impl From<Scopes> for String {
         value
             .0
             .into_iter()
-            .map(|s| String::from(s))
+            .map(String::from)
             .collect::<Vec<_>>()
             .join(" ")
     }

--- a/backend/crates/pointer/src/escape.rs
+++ b/backend/crates/pointer/src/escape.rs
@@ -1,5 +1,5 @@
 pub fn escape_field(field: &str) -> String {
-    field.replace("~", "~0").replace("/", "~1")
+    field.replace('~', "~0").replace('/', "~1")
 }
 
 pub fn unescape_field(field: &str) -> String {

--- a/backend/crates/pointer/src/lib.rs
+++ b/backend/crates/pointer/src/lib.rs
@@ -6,6 +6,12 @@ mod escape;
 #[derive(Debug, Clone)]
 pub struct Path(String);
 
+impl Default for Path {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Display for Path {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
@@ -13,24 +19,36 @@ impl Display for Path {
 }
 
 impl Path {
+    #[must_use]
     pub fn new() -> Self {
-        Self("".to_string())
+        Self(String::new())
     }
+    #[must_use]
     pub fn descend(&self, field: &str) -> Self {
         Self(format!("{}/{}", self.0, escape::escape_field(field)))
     }
+    #[must_use]
     pub fn ascend(&self) -> Option<(Self, Key)> {
         if self.0.is_empty() {
-            None
-        } else {
-            let mut parts = self.0.rsplitn(2, '/');
-            let field = parts.next().unwrap();
-            let parent_path = parts.next().unwrap_or("");
+            return None;
+        }
 
-            Some((
-                Path(parent_path.to_string()),
-                Key::from_str(&escape::unescape_field(field)),
-            ))
+        // Find the last '/' separator from the end of the string
+        match self.0.rfind('/') {
+            // Case 1: Separator found (e.g., "a/b/c" -> parent: "a/b", field: "c")
+            Some(idx) => {
+                let parent_path = &self.0[..idx];
+                let field = &self.0[idx + 1..];
+                Some((
+                    Path(parent_path.to_string()),
+                    Key::parse(&escape::unescape_field(field)),
+                ))
+            }
+            // Case 2: No separator found, the string is a single field (e.g., "a" -> parent: "", field: "a")
+            None => Some((
+                Path(String::new()),
+                Key::parse(&escape::unescape_field(&self.0)),
+            )),
         }
     }
 
@@ -38,7 +56,7 @@ impl Path {
         let mut current = value;
         // Skip the first empty part from the leading '/'
         for part in self.0.split('/').skip(1) {
-            let k = Key::from_str(&escape::unescape_field(part));
+            let k = Key::parse(&escape::unescape_field(part));
 
             match k {
                 Key::Field(field) => {
@@ -66,7 +84,8 @@ pub enum Key {
 }
 
 impl Key {
-    pub fn from_str(field: &str) -> Self {
+    #[must_use]
+    pub fn parse(field: &str) -> Self {
         if let Ok(index) = field.parse::<usize>() {
             Key::Index(index)
         } else {
@@ -91,29 +110,32 @@ pub struct TypedPointer<T: MetaValue, U: MetaValue> {
 impl<Root: MetaValue, U: MetaValue> TypedPointer<Root, U> {
     pub fn new(value: Arc<Root>) -> TypedPointer<Root, Root> {
         TypedPointer {
-            value: ChildPointer(&*value.as_ref() as *const Root),
+            value: ChildPointer(&raw const *value.as_ref()),
             root: value,
             path: Path::new(),
         }
     }
 
+    #[must_use]
     pub fn root(&self) -> TypedPointer<Root, Root> {
         TypedPointer {
-            value: ChildPointer(&*self.root.as_ref() as *const Root),
+            value: ChildPointer(&raw const *self.root.as_ref()),
             root: self.root.clone(),
             path: Path::new(),
         }
     }
 
+    #[must_use]
     pub fn path(&self) -> &str {
         self.path.0.as_str()
     }
 
+    #[must_use]
     pub fn value(&self) -> Option<&U> {
-        let p = unsafe { (*self.value.0).as_any().downcast_ref::<U>() };
-        p
+        unsafe { (*self.value.0).as_any().downcast_ref::<U>() }
     }
 
+    #[must_use]
     pub fn descend<Child: MetaValue>(&self, field: &Key) -> Option<TypedPointer<Root, Child>> {
         match field {
             Key::Field(field) => self.value().and_then(|v| {
@@ -121,7 +143,7 @@ impl<Root: MetaValue, U: MetaValue> TypedPointer<Root, U> {
                     .and_then(|v| v.as_any().downcast_ref::<Child>())
                     .map(|child| TypedPointer {
                         root: self.root.clone(),
-                        value: ChildPointer(&*child as *const Child),
+                        value: ChildPointer(&raw const *child),
                         path: self.path.descend(field),
                     })
             }),
@@ -130,13 +152,14 @@ impl<Root: MetaValue, U: MetaValue> TypedPointer<Root, U> {
                     .and_then(|v| v.as_any().downcast_ref::<Child>())
                     .map(|child| TypedPointer {
                         root: self.root.clone(),
-                        value: ChildPointer(&*child as *const Child),
+                        value: ChildPointer(&raw const *child),
                         path: self.path.descend(&index.to_string()),
                     })
             }),
         }
     }
 
+    #[must_use]
     pub fn ascend(&self) -> Option<(Path, Key)> {
         self.path.ascend()
     }

--- a/backend/crates/x-fhir-query/src/conversion.rs
+++ b/backend/crates/x-fhir-query/src/conversion.rs
@@ -1,218 +1,97 @@
 use haste_fhir_model::r4::generated::{
     terminology::IssueType,
     types::{
-        FHIRBase64Binary, FHIRBoolean, FHIRCanonical, FHIRDate, FHIRDateTime, FHIRId, FHIRInstant,
-        FHIRInteger, FHIRMarkdown, FHIROid, FHIRPositiveInt, FHIRString, FHIRTime, FHIRUnsignedInt,
-        FHIRUri, FHIRUrl, FHIRUuid,
+        FHIRBase64Binary, FHIRBoolean, FHIRCanonical, FHIRCode, FHIRDate, FHIRDateTime,
+        FHIRDecimal, FHIRId, FHIRInstant, FHIRInteger, FHIRMarkdown, FHIROid, FHIRPositiveInt,
+        FHIRString, FHIRTime, FHIRUnsignedInt, FHIRUri, FHIRUrl, FHIRUuid,
     },
 };
 use haste_fhir_operation_error::OperationOutcomeError;
 use haste_reflect::MetaValue;
 
-fn downcast_meta_value<'a, T: 'static>(value: &'a dyn MetaValue) -> Option<&'a T> {
+fn downcast_meta_value<T: 'static>(value: &dyn MetaValue) -> Option<&T> {
     value.as_any().downcast_ref::<T>()
 }
 
+/// Converts a [`MetaValue`] into its string representation.
+///
+/// # Errors
+///
+/// Returns an [`OperationOutcomeError`] if:
+/// - the value cannot be downcast to the expected FHIR type,
+/// - the FHIR primitive value is missing,
+/// - the value type is not supported for stringification.
 pub fn stringify_meta_value(value: &dyn MetaValue) -> Result<String, OperationOutcomeError> {
     match value.fhir_type() {
         "http://hl7.org/fhirpath/System.String" => downcast_meta_value::<String>(value)
-            .map(|s| s.to_string())
+            .cloned()
             .ok_or_else(|| {
                 OperationOutcomeError::fatal(
                     IssueType::INVALID,
                     "http://hl7.org/fhirpath/System.String value is missing.".to_string(),
                 )
             }),
-        "base64Binary" => downcast_meta_value::<FHIRBase64Binary>(value)
-            .and_then(|s| s.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "base64Binary value is missing.".to_string(),
-                )
-            }),
-        "decimal" => {
-            downcast_meta_value::<haste_fhir_model::r4::generated::types::FHIRDecimal>(value)
-                .and_then(|d| d.value.as_ref())
-                .map(|s| s.to_string())
-                .ok_or_else(|| {
-                    OperationOutcomeError::fatal(
-                        IssueType::INVALID,
-                        "decimal value is missing.".to_string(),
-                    )
-                })
+        "base64Binary" => {
+            stringify_with::<FHIRBase64Binary, _>(value, "base64Binary", |v| v.value.clone())
         }
-
-        "boolean" => downcast_meta_value::<FHIRBoolean>(value)
-            .and_then(|b| b.value)
-            .map(|b| b.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "boolean value is missing.".to_string(),
-                )
-            }),
-
-        "url" => downcast_meta_value::<FHIRUrl>(value)
-            .and_then(|u| u.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "url value is missing.".to_string(),
-                )
-            }),
-
-        "code" => downcast_meta_value::<haste_fhir_model::r4::generated::types::FHIRCode>(value)
-            .and_then(|c| c.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "code value is missing.".to_string(),
-                )
-            }),
-
-        "string" => downcast_meta_value::<FHIRString>(value)
-            .and_then(|s| s.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "string value is missing.".to_string(),
-                )
-            }),
-
-        "integer" => downcast_meta_value::<FHIRInteger>(value)
-            .and_then(|i| i.value)
-            .map(|i| i.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "integer value is missing.".to_string(),
-                )
-            }),
-
-        "uri" => downcast_meta_value::<FHIRUri>(value)
-            .and_then(|u| u.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "uri value is missing.".to_string(),
-                )
-            }),
-
-        "canonical" => downcast_meta_value::<FHIRCanonical>(value)
-            .and_then(|c| c.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "canonical value is missing.".to_string(),
-                )
-            }),
-
-        "markdown" => downcast_meta_value::<FHIRMarkdown>(value)
-            .and_then(|m| m.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "markdown value is missing.".to_string(),
-                )
-            }),
-
-        "id" => downcast_meta_value::<FHIRId>(value)
-            .and_then(|id| id.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(IssueType::INVALID, "id value is missing.".to_string())
-            }),
-
-        "oid" => downcast_meta_value::<FHIROid>(value)
-            .and_then(|o| o.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "oid value is missing.".to_string(),
-                )
-            }),
-
-        "uuid" => downcast_meta_value::<FHIRUuid>(value)
-            .and_then(|u| u.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "uuid value is missing.".to_string(),
-                )
-            }),
-
-        "unsignedInt" => downcast_meta_value::<FHIRUnsignedInt>(value)
-            .and_then(|i| i.value)
-            .map(|i| i.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "unsignedInt value is missing.".to_string(),
-                )
-            }),
-        "positiveInt" => downcast_meta_value::<FHIRPositiveInt>(value)
-            .and_then(|i| i.value)
-            .map(|i| i.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "positiveInt value is missing.".to_string(),
-                )
-            }),
-
-        "instant" => downcast_meta_value::<FHIRInstant>(value)
-            .and_then(|dt| dt.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "instant value is missing.".to_string(),
-                )
-            }),
-        "date" => downcast_meta_value::<FHIRDate>(value)
-            .and_then(|dt| dt.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "date value is missing.".to_string(),
-                )
-            }),
-        "time" => downcast_meta_value::<FHIRTime>(value)
-            .and_then(|t| t.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "time value is missing.".to_string(),
-                )
-            }),
-        "dateTime" => downcast_meta_value::<FHIRDateTime>(value)
-            .and_then(|dt| dt.value.as_ref())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "dateTime value is missing.".to_string(),
-                )
-            }),
-
+        "decimal" => {
+            stringify_with::<FHIRDecimal, _>(value, "decimal", |v| v.value.map(|x| x.to_string()))
+        }
+        "boolean" => {
+            stringify_with::<FHIRBoolean, _>(value, "boolean", |v| v.value.map(|x| x.to_string()))
+        }
+        "url" => stringify_with::<FHIRUrl, _>(value, "url", |v| v.value.clone()),
+        "code" => stringify_with::<FHIRCode, _>(value, "code", |v| v.value.clone()),
+        "string" => stringify_with::<FHIRString, _>(value, "string", |v| v.value.clone()),
+        "integer" => {
+            stringify_with::<FHIRInteger, _>(value, "integer", |v| v.value.map(|x| x.to_string()))
+        }
+        "uri" => stringify_with::<FHIRUri, _>(value, "uri", |v| v.value.clone()),
+        "canonical" => stringify_with::<FHIRCanonical, _>(value, "canonical", |v| v.value.clone()),
+        "markdown" => stringify_with::<FHIRMarkdown, _>(value, "markdown", |v| v.value.clone()),
+        "id" => stringify_with::<FHIRId, _>(value, "id", |v| v.value.clone()),
+        "oid" => stringify_with::<FHIROid, _>(value, "oid", |v| v.value.clone()),
+        "uuid" => stringify_with::<FHIRUuid, _>(value, "uuid", |v| v.value.clone()),
+        "unsignedInt" => stringify_with::<FHIRUnsignedInt, _>(value, "unsignedInt", |v| {
+            v.value.map(|x| x.to_string())
+        }),
+        "positiveInt" => stringify_with::<FHIRPositiveInt, _>(value, "positiveInt", |v| {
+            v.value.map(|x| x.to_string())
+        }),
+        "instant" => stringify_with::<FHIRInstant, _>(value, "instant", |v| {
+            v.value.as_ref().map(ToString::to_string)
+        }),
+        "date" => stringify_with::<FHIRDate, _>(value, "date", |v| {
+            v.value.as_ref().map(ToString::to_string)
+        }),
+        "time" => stringify_with::<FHIRTime, _>(value, "time", |v| {
+            v.value.as_ref().map(ToString::to_string)
+        }),
+        "dateTime" => stringify_with::<FHIRDateTime, _>(value, "dateTime", |v| {
+            v.value.as_ref().map(ToString::to_string)
+        }),
         typename => Err(OperationOutcomeError::fatal(
             IssueType::INVALID,
-            format!(
-                "Unsupported MetaValue type for stringification: '{}'",
-                typename
-            ),
+            format!("Unsupported MetaValue type for stringification: '{typename}'"),
         )),
     }
+}
+
+fn stringify_with<T, F>(
+    value: &dyn MetaValue,
+    type_name: &str,
+    extractor: F,
+) -> Result<String, OperationOutcomeError>
+where
+    T: MetaValue + 'static,
+    F: FnOnce(&T) -> Option<String>,
+{
+    downcast_meta_value::<T>(value)
+        .and_then(extractor)
+        .ok_or_else(|| {
+            OperationOutcomeError::fatal(
+                IssueType::INVALID,
+                format!("{type_name} value is missing."),
+            )
+        })
 }

--- a/backend/crates/x-fhir-query/src/lib.rs
+++ b/backend/crates/x-fhir-query/src/lib.rs
@@ -10,8 +10,19 @@ use crate::conversion::stringify_meta_value;
 pub mod conversion;
 
 static FP_EXPRESSION_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"\{\{([^}]*)\}\}"#).expect("Failed to compile regex"));
+    LazyLock::new(|| Regex::new(r"\{\{([^}]*)\}\}").expect("Failed to compile regex"));
 
+/// Evaluates `FHIRPath` expressions embedded in an x-fhir-query string.
+///
+/// Replaces each `FHIRPath` expression found in the query with the evaluated
+/// string representation of its result.
+///
+/// # Errors
+///
+/// Returns an [`OperationOutcomeError`] if:
+/// - the embedded `FHIRPath` expression is empty,
+/// - `FHIRPath` evaluation fails,
+/// - a result value cannot be converted into a string representation.
 pub async fn evaluation<'a, 'b>(
     x_fhir_query: &str,
     values: Vec<&'a dyn MetaValue>,
@@ -25,11 +36,11 @@ where
     let mut result = x_fhir_query.to_string();
 
     for expression in FP_EXPRESSION_REGEX.captures_iter(x_fhir_query) {
-        let full_match = expression.get(0).map(|m| m.as_str()).unwrap_or("");
+        let full_match = expression.get(0).map_or("", |m| m.as_str());
 
-        let expr = expression.get(1).map(|m| m.as_str()).unwrap_or("");
+        let expr = expression.get(1).map_or("", |m| m.as_str());
 
-        println!("Evaluating FHIRPath expression: '{}'", expr);
+        println!("Evaluating FHIRPath expression: '{expr}'");
 
         if expr.is_empty() {
             return Err(OperationOutcomeError::fatal(
@@ -44,13 +55,13 @@ where
             .map_err(|e| {
                 OperationOutcomeError::fatal(
                     IssueType::INVALID,
-                    format!("FHIRPath evaluation error: {}", e),
+                    format!("FHIRPath evaluation error: {e}"),
                 )
             })?;
 
         let fp_string_result = fp_result
             .iter()
-            .map(|v| stringify_meta_value(v))
+            .map(stringify_meta_value)
             .collect::<Result<Vec<String>, OperationOutcomeError>>()?
             .join(",");
 


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.