### PR TITLE
Resolve `clippy` lints for `fhir-client`, `fhir-operation` and `fhirpath` crates

### DIFF
--- a/backend/crates/fhir-client/src/http.rs
+++ b/backend/crates/fhir-client/src/http.rs
@@ -796,9 +796,9 @@ fn http_response_to_fhir_response<'a>(
                     let resource =
                         serde_json::from_slice::<Resource>(&body).map_err(FHIRHTTPError::from)?;
 
-                    Ok(FHIRResponse::Delete(DeleteResponse::Instance(
+                    Ok(FHIRResponse::Delete(DeleteResponse::Instance(Box::new(
                         request::FHIRDeleteInstanceResponse { resource },
-                    )))
+                    ))))
                 }
                 DeleteRequest::Type(_) => {
                     let status = response.status();
@@ -1454,12 +1454,7 @@ impl<CTX: 'static + Send + Sync + Debug> FHIRClient<CTX, OperationOutcomeError>
                     request::FHIRInvokeInstanceRequest {
                         resource_type,
                         id,
-                        operation: Operation::new(&operation).map_err(|_e| {
-                            OperationOutcomeError::error(
-                                IssueType::EXCEPTION,
-                                "invalid operation".to_string(),
-                            )
-                        })?,
+                        operation: Operation::new(&operation),
                         parameters,
                     },
                 )),
@@ -1488,12 +1483,7 @@ impl<CTX: 'static + Send + Sync + Debug> FHIRClient<CTX, OperationOutcomeError>
                 ctx,
                 FHIRRequest::Invocation(InvocationRequest::Type(request::FHIRInvokeTypeRequest {
                     resource_type,
-                    operation: Operation::new(&operation).map_err(|_e| {
-                        OperationOutcomeError::error(
-                            IssueType::EXCEPTION,
-                            "invalid operation".to_string(),
-                        )
-                    })?,
+                    operation: Operation::new(&operation),
                     parameters,
                 })),
             )
@@ -1520,12 +1510,7 @@ impl<CTX: 'static + Send + Sync + Debug> FHIRClient<CTX, OperationOutcomeError>
                 ctx,
                 FHIRRequest::Invocation(InvocationRequest::System(
                     request::FHIRInvokeSystemRequest {
-                        operation: Operation::new(&operation).map_err(|_e| {
-                            OperationOutcomeError::error(
-                                IssueType::EXCEPTION,
-                                "invalid operation".to_string(),
-                            )
-                        })?,
+                        operation: Operation::new(&operation),
                         parameters,
                     },
                 )),

--- a/backend/crates/fhir-client/src/middleware.rs
+++ b/backend/crates/fhir-client/src/middleware.rs
@@ -22,6 +22,9 @@ pub type MiddlewareChainOld<State, CTX, Request, Response, Error> = Box<
         + Sync,
 >;
 
+pub type MiddlewareNext<'a, State, CTX, Request, Response, Error> =
+    Arc<Next<State, Context<CTX, Request, Response>, Error>>;
+
 pub trait MiddlewareChain<State, CTX: Debug, Request: Debug, Response: Debug, Error>:
     Send + Sync
 {
@@ -29,14 +32,14 @@ pub trait MiddlewareChain<State, CTX: Debug, Request: Debug, Response: Debug, Er
         &self,
         state: State,
         ctx: Context<CTX, Request, Response>,
-        next: Option<Arc<Next<State, Context<CTX, Request, Response>, Error>>>,
+        next: Option<MiddlewareNext<State, CTX, Request, Response, Error>>,
     ) -> MiddlewareOutput<Context<CTX, Request, Response>, Error>;
 }
 
 pub struct Middleware<State, CTX: Debug, Request: Debug, Response: Debug, Error> {
     _state: std::marker::PhantomData<State>,
     _phantom: std::marker::PhantomData<CTX>,
-    _execute: Arc<Next<State, Context<CTX, Request, Response>, Error>>,
+    execute: Arc<Next<State, Context<CTX, Request, Response>, Error>>,
 }
 
 impl<
@@ -47,15 +50,22 @@ impl<
     Error: 'static + Send + Sync,
 > Middleware<State, CTX, Request, Response, Error>
 {
+    /// Create a new [`Middleware`] execution chain.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the provided `middleware` vector is empty,
+    /// as an empty chain cannot be unwrapped into an execution target.
+    #[must_use]
     pub fn new(
         mut middleware: Vec<Box<dyn MiddlewareChain<State, CTX, Request, Response, Error>>>,
     ) -> Self {
         middleware.reverse();
-        let next: Option<Arc<Next<State, Context<CTX, Request, Response>, Error>>> = middleware
+        let next: Option<MiddlewareNext<State, CTX, Request, Response, Error>> = middleware
             .into_iter()
             .fold(
             None,
-            |prev_next: Option<Arc<Next<State, Context<CTX, Request, Response>, Error>>>,
+            |prev_next: Option<MiddlewareNext<State, CTX, Request, Response, Error>>,
              middleware: Box<dyn MiddlewareChain<State, CTX, Request, Response, Error>>| {
                 Some(Arc::new(Box::new(move |state, ctx| {
                     middleware.call(state, ctx, prev_next.clone())
@@ -66,17 +76,23 @@ impl<
         Middleware {
             _state: std::marker::PhantomData,
             _phantom: std::marker::PhantomData,
-            _execute: next.unwrap(),
+            execute: next.unwrap(),
         }
     }
 
+    /// Executes the middleware chain for the given request.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any `MiddlewareChain` in the execution pipeline fails
+    /// while processing the state or request context.
     pub async fn call(
         &self,
         state: State,
         ctx: CTX,
         request: Request,
     ) -> Result<Context<CTX, Request, Response>, Error> {
-        (self._execute)(
+        (self.execute)(
             state,
             Context {
                 ctx,

--- a/backend/crates/fhir-client/src/request.rs
+++ b/backend/crates/fhir-client/src/request.rs
@@ -129,10 +129,12 @@ pub enum OperationParseError {
 #[derivative(Debug)]
 pub struct Operation(String);
 impl Operation {
-    pub fn new(name: &str) -> Result<Self, OperationParseError> {
+    #[must_use]
+    pub fn new(name: &str) -> Self {
         let operation_name = name.trim_start_matches('$');
-        Ok(Operation(operation_name.to_string()))
+        Operation(operation_name.to_string())
     }
+    #[must_use]
     pub fn name(&self) -> &str {
         &self.0
     }
@@ -402,7 +404,7 @@ pub enum SearchResponse {
 #[derivative(Debug = "transparent")]
 pub enum DeleteResponse {
     #[derivative(Debug = "transparent")]
-    Instance(FHIRDeleteInstanceResponse),
+    Instance(Box<FHIRDeleteInstanceResponse>),
     #[derivative(Debug = "transparent")]
     Type(FHIRDeleteTypeResponse),
     #[derivative(Debug = "transparent")]

--- a/backend/crates/fhir-client/src/url.rs
+++ b/backend/crates/fhir-client/src/url.rs
@@ -84,6 +84,7 @@ impl<T: Into<Parameter>> From<T> for ParsedParameter {
 }
 
 impl ParsedParameter {
+    #[must_use]
     pub fn name(&self) -> &str {
         match self {
             ParsedParameter::Result(p) | ParsedParameter::Resource(p) => &p.name,
@@ -110,13 +111,13 @@ impl MetaValue for ParsedParameter {
         }
     }
 
-    fn get_index<'a>(&'a self, index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, index: usize) -> Option<&dyn MetaValue> {
         match self {
             ParsedParameter::Result(p) | ParsedParameter::Resource(p) => p.get_index(index),
         }
     }
 
-    fn get_index_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, index: usize) -> Option<&mut dyn MetaValue> {
         match self {
             ParsedParameter::Result(p) | ParsedParameter::Resource(p) => p.get_index_mut(index),
         }
@@ -158,7 +159,7 @@ impl Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ParseError::InvalidParameter(param) => {
-                write!(f, "Invalid query parameter: {}", param)
+                write!(f, "Invalid query parameter: {param}")
             }
         }
     }
@@ -172,22 +173,26 @@ pub struct ParsedParameters(Vec<ParsedParameter>);
 
 impl<T: Into<ParsedParameter>> From<Vec<T>> for ParsedParameters {
     fn from(params: Vec<T>) -> Self {
-        let parsed_params = params.into_iter().map(|p| p.into()).collect();
+        let parsed_params = params.into_iter().map(std::convert::Into::into).collect();
         ParsedParameters(parsed_params)
     }
 }
 
 impl ParsedParameters {
+    #[must_use]
     pub fn new(params: Vec<ParsedParameter>) -> Self {
         Self(params)
     }
-    pub fn parameters<'a>(&'a self) -> &'a Vec<ParsedParameter> {
+    #[must_use]
+    pub fn parameters(&self) -> &Vec<ParsedParameter> {
         &self.0
     }
-    pub fn owned_parameters<'a>(self) -> Vec<ParsedParameter> {
+    #[must_use]
+    pub fn owned_parameters(self) -> Vec<ParsedParameter> {
         self.0
     }
-    pub fn get<'a>(&'a self, name: &str) -> Option<&'a ParsedParameter> {
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&ParsedParameter> {
         self.0.iter().find(|p| match p {
             ParsedParameter::Resource(param) | ParsedParameter::Result(param) => param.name == name,
         })
@@ -211,11 +216,11 @@ impl MetaValue for ParsedParameters {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -248,21 +253,14 @@ impl TryFrom<&str> for ParsedParameters {
             query_string = &query_string[1..];
         }
 
-        let query_map = query_string.split('&').fold(
-            Ok(HashMap::new()),
-            |acc: Result<HashMap<String, String>, ParseError>, pair| {
-                let mut map = acc?;
-                let mut split = pair.splitn(2, '=');
-                let key = split
-                    .next()
-                    .ok_or_else(|| ParseError::InvalidParameter(pair.to_string()))?;
-                let value = split
-                    .next()
-                    .ok_or_else(|| ParseError::InvalidParameter(pair.to_string()))?;
-                map.insert(key.to_string(), value.to_string());
-                Ok(map)
-            },
-        )?;
+        let query_map = query_string
+            .split('&')
+            .map(|pair| {
+                pair.split_once('=')
+                    .map(|(key, value)| (key.to_string(), value.to_string()))
+                    .ok_or_else(|| ParseError::InvalidParameter(pair.to_string()))
+            })
+            .collect::<Result<std::collections::HashMap<String, String>, ParseError>>()?;
 
         Self::try_from(&query_map)
     }
@@ -282,25 +280,30 @@ impl TryFrom<&HashMap<String, String>> for ParsedParameters {
 
                 let chain = param_name
                     .split('.')
-                    .map(|s| s.to_string())
+                    .map(std::string::ToString::to_string)
                     .collect::<Vec<String>>();
 
                 if chain.is_empty() {
-                    return Err(ParseError::InvalidParameter(param_name.to_string()));
+                    return Err(ParseError::InvalidParameter(param_name.clone()));
                 }
 
                 let name_and_modifier = chain[0].split(':').collect::<Vec<&str>>();
 
                 if name_and_modifier.len() > 2 || name_and_modifier.is_empty() {
-                    return Err(ParseError::InvalidParameter(param_name.to_string()));
+                    return Err(ParseError::InvalidParameter(param_name.clone()));
                 }
 
                 let name = name_and_modifier[0].to_string();
 
                 let param = Parameter {
                     name,
-                    modifier: name_and_modifier.get(1).map(|s| s.to_string()),
-                    value: value.split(',').map(|v| v.to_string()).collect(),
+                    modifier: name_and_modifier
+                        .get(1)
+                        .map(std::string::ToString::to_string),
+                    value: value
+                        .split(',')
+                        .map(std::string::ToString::to_string)
+                        .collect(),
                     chains: if chain.len() > 1 {
                         Some(chain[1..].to_vec())
                     } else {
@@ -320,7 +323,8 @@ impl TryFrom<&HashMap<String, String>> for ParsedParameters {
     }
 }
 
-pub fn parse_prefix<'a>(v: &'a str) -> (Option<&'a str>, &'a str) {
+#[must_use]
+pub fn parse_prefix(v: &str) -> (Option<&str>, &str) {
     if v.len() < 3 {
         return (None, v);
     }
@@ -329,12 +333,7 @@ pub fn parse_prefix<'a>(v: &'a str) -> (Option<&'a str>, &'a str) {
     let remainder = &v[2..];
 
     match sub_str {
-        "lt" => (Some(sub_str), remainder),
-        "le" => (Some(sub_str), remainder),
-        "gt" => (Some(sub_str), remainder),
-        "ge" => (Some(sub_str), remainder),
-        "eq" => (Some(sub_str), remainder),
-        "ne" => (Some(sub_str), remainder),
+        "lt" | "le" | "gt" | "ge" | "eq" | "ne" => (Some(sub_str), remainder),
         _ => (None, v),
     }
 }

--- a/backend/crates/fhir-operation-error-derive/src/lib.rs
+++ b/backend/crates/fhir-operation-error-derive/src/lib.rs
@@ -10,7 +10,7 @@ static ERROR: &str = "error";
 static WARNING: &str = "warning";
 static INFORMATION: &str = "information";
 
-fn get_issue_list(attrs: &[Attribute]) -> Option<Vec<MetaList>> {
+fn get_issue_list(attrs: &[Attribute]) -> Vec<MetaList> {
     let issues: Vec<MetaList> = attrs
         .iter()
         .filter_map(|attr| match &attr.meta {
@@ -26,7 +26,7 @@ fn get_issue_list(attrs: &[Attribute]) -> Option<Vec<MetaList>> {
         })
         .collect();
 
-    Some(issues)
+    issues
 }
 
 const CODES_ALLOWED: &[&str] = &[
@@ -64,11 +64,12 @@ const CODES_ALLOWED: &[&str] = &[
 ];
 
 fn get_expr_string(expr: &Expr) -> Option<String> {
-    if let Expr::Lit(lit) = expr {
-        if let Lit::Str(lit_str) = &lit.lit {
-            return Some(lit_str.value());
-        }
+    if let Expr::Lit(lit) = expr
+        && let Lit::Str(lit_str) = &lit.lit
+    {
+        return Some(lit_str.value());
     }
+
     None
 }
 
@@ -80,14 +81,15 @@ enum Severity {
     Information,
 }
 
-impl Into<String> for Severity {
-    fn into(self) -> String {
-        match self {
-            Severity::Fatal => "fatal".to_string(),
-            Severity::Error => "error".to_string(),
-            Severity::Warning => "warning".to_string(),
-            Severity::Information => "information".to_string(),
+impl From<Severity> for String {
+    fn from(severity: Severity) -> Self {
+        match severity {
+            Severity::Fatal => "fatal",
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+            Severity::Information => "information",
         }
+        .to_string()
     }
 }
 
@@ -115,70 +117,66 @@ fn get_severity(meta_list: &MetaList) -> Severity {
     }
 }
 
-fn get_issue_attributes(attrs: &[Attribute]) -> Option<Vec<SimpleIssue>> {
+fn get_issue_attributes(attrs: &[Attribute]) -> Vec<SimpleIssue> {
     let mut simple_issue = vec![];
-    if let Some(issue_attributes) = get_issue_list(&attrs) {
-        for issues in issue_attributes {
-            let parsed_arguments = issues
-                .parse_args_with(Punctuated::<Expr, Token![,]>::parse_terminated)
-                .unwrap();
+    let issue_attributes = get_issue_list(attrs);
+    for issues in issue_attributes {
+        let parsed_arguments = issues
+            .parse_args_with(Punctuated::<Expr, Token![,]>::parse_terminated)
+            .unwrap();
 
-            if parsed_arguments.len() > 2 {
-                panic!("Expected exactly 2 arguments for issue attributes");
-            }
+        assert!(
+            parsed_arguments.len() <= 2,
+            "Expected exactly 2 arguments for issue attributes"
+        );
 
-            let severity = get_severity(&issues);
-            let mut code: Option<String> = None;
-            let mut diagnostic: Option<String> = None;
+        let severity = get_severity(&issues);
+        let mut code: Option<String> = None;
+        let mut diagnostic: Option<String> = None;
 
-            for expression in parsed_arguments {
-                match expression {
-                    Expr::Assign(expr_assign) => match expr_assign.left.as_ref() {
-                        Expr::Path(path) => {
-                            match path.path.get_ident().unwrap().to_string().as_str() {
-                                "code" => {
-                                    code = get_expr_string(expr_assign.right.as_ref());
-                                    if let Some(code) = code.as_ref() {
-                                        if !CODES_ALLOWED.contains(&code.as_str()) {
-                                            panic!(
-                                                "Invalid code: '{}' Must be one of '{:?}'",
-                                                code, CODES_ALLOWED
-                                            );
-                                        }
-                                    }
-                                }
-                                "diagnostic" => {
-                                    diagnostic = get_expr_string(expr_assign.right.as_ref());
-                                }
-                                _ => panic!(
-                                    "Unknown error attribute: {}",
-                                    path.path.get_ident().unwrap()
-                                ),
+        for expression in parsed_arguments {
+            match expression {
+                Expr::Assign(expr_assign) => match expr_assign.left.as_ref() {
+                    Expr::Path(path) => match path.path.get_ident().unwrap().to_string().as_str() {
+                        "code" => {
+                            code = get_expr_string(expr_assign.right.as_ref());
+                            if let Some(code) = code.as_ref() {
+                                assert!(
+                                    CODES_ALLOWED.contains(&code.as_str()),
+                                    "Invalid code: '{code}' Must be one of '{CODES_ALLOWED:?}'",
+                                );
                             }
                         }
-                        _ => panic!("Expected an assignment expression"),
+                        "diagnostic" => {
+                            diagnostic = get_expr_string(expr_assign.right.as_ref());
+                        }
+                        _ => panic!(
+                            "Unknown error attribute: {}",
+                            path.path.get_ident().unwrap()
+                        ),
                     },
-                    _ => {
-                        panic!("Expected an assignment expression");
-                    }
+                    _ => panic!("Expected an assignment expression"),
+                },
+                _ => {
+                    panic!("Expected an assignment expression");
                 }
             }
-
-            simple_issue.push(SimpleIssue {
-                severity,
-                code: code.unwrap_or_else(|| "error".to_string()),
-                diagnostic: diagnostic,
-            });
         }
+
+        simple_issue.push(SimpleIssue {
+            severity,
+            code: code.unwrap_or_else(|| "error".to_string()),
+            diagnostic,
+        });
     }
 
-    Some(simple_issue)
+    simple_issue
 }
 
 /// Derive the operatiooutcome issues from the
 /// attributes issue, fatal, error, warning, information
 fn derive_operation_issues(v: &Variant) -> proc_macro2::TokenStream {
-    let issues = get_issue_attributes(&v.attrs).unwrap_or(vec![]);
+    let issues = get_issue_attributes(&v.attrs);
     let invariant_operation_outcome_issues = issues.iter().map(|simple_issue: &SimpleIssue| {
         let severity_string: String = simple_issue.severity.clone().into();
         let severity = quote!{ haste_fhir_model::r4::generated::terminology::BoundCode::<haste_fhir_model::r4::generated::terminology::IssueSeverity>::new(#severity_string).unwrap() };
@@ -241,10 +239,7 @@ fn get_from_error(v: &Variant) -> Option<FromInformation> {
         .iter()
         .enumerate()
         .filter_map(|(i, field)| {
-            let from_attr = field.attrs.iter().find(|attr| {
-                let p = attr.path().is_ident("from");
-                p
-            });
+            let from_attr = field.attrs.iter().find(|attr| attr.path().is_ident("from"));
 
             if from_attr.is_some() {
                 if from_attr.is_some() {
@@ -262,11 +257,12 @@ fn get_from_error(v: &Variant) -> Option<FromInformation> {
         })
         .collect();
 
-    if from_fields.len() > 1 {
-        panic!("Expected only one field with 'from' attribute");
-    }
+    assert!(
+        from_fields.len() <= 1,
+        "Expected only one field with 'from' attribute"
+    );
 
-    from_fields.get(0).cloned()
+    from_fields.first().cloned()
 }
 
 /// Instantiate the arguments for the variant
@@ -274,7 +270,7 @@ fn get_from_error(v: &Variant) -> Option<FromInformation> {
 /// Format is arg0, arg1, arg2, ...
 fn instantiate_args(v: &Variant) -> proc_macro2::TokenStream {
     let arg_identifiers = (0..v.fields.len())
-        .map(|i| get_arg_identifier(i))
+        .map(get_arg_identifier)
         .collect::<Vec<_>>();
     if arg_identifiers.is_empty() {
         quote! {}
@@ -285,6 +281,12 @@ fn instantiate_args(v: &Variant) -> proc_macro2::TokenStream {
     }
 }
 
+/// Derives the [`OperationOutcomeError`] trait for an enum.
+///
+/// # Panics
+///
+/// This macro will panic at compile time if it is applied to a struct or a union,
+/// as it can only be derived from an enum definition.
 #[proc_macro_derive(
     OperationOutcomeError,
     attributes(fatal, error, warning, information, from)

--- a/backend/crates/fhir-operation-error/src/lib.rs
+++ b/backend/crates/fhir-operation-error/src/lib.rs
@@ -25,8 +25,8 @@ fn create_operation_outcome(
 ) -> OperationOutcome {
     OperationOutcome {
         issue: vec![OperationOutcomeIssue {
-            severity: severity,
-            code: code,
+            severity,
+            code,
             diagnostics: Some(Box::new(FHIRString {
                 value: Some(diagnostic),
                 ..Default::default()

--- a/backend/crates/fhir-operation-error/src/lib.rs
+++ b/backend/crates/fhir-operation-error/src/lib.rs
@@ -14,8 +14,8 @@ pub mod axum;
 
 #[derive(Debug)]
 pub struct OperationOutcomeError {
-    _source: Option<anyhow::Error>,
-    outcome: OperationOutcome,
+    source: Option<anyhow::Error>,
+    outcome: Box<OperationOutcome>,
 }
 
 fn create_operation_outcome(
@@ -38,13 +38,15 @@ fn create_operation_outcome(
 }
 
 impl OperationOutcomeError {
+    #[must_use]
     pub fn new(source: Option<anyhow::Error>, outcome: OperationOutcome) -> Self {
         OperationOutcomeError {
-            _source: source,
-            outcome,
+            source,
+            outcome: Box::new(outcome),
         }
     }
 
+    #[must_use]
     pub fn outcome(&self) -> &OperationOutcome {
         &self.outcome
     }
@@ -56,28 +58,33 @@ impl OperationOutcomeError {
         self.outcome.issue.push(issue);
     }
 
+    #[must_use]
     pub fn backtrace(&self) -> Option<&std::backtrace::Backtrace> {
-        self._source.as_ref().map(|s| s.backtrace())
+        self.source.as_ref().map(anyhow::Error::backtrace)
     }
 
+    #[must_use]
     pub fn fatal(code: BoundCode<IssueType>, diagnostic: String) -> Self {
         OperationOutcomeError::new(
             None,
             create_operation_outcome(IssueSeverity::FATAL, code, diagnostic),
         )
     }
+    #[must_use]
     pub fn error(code: BoundCode<IssueType>, diagnostic: String) -> Self {
         OperationOutcomeError::new(
             None,
             create_operation_outcome(IssueSeverity::ERROR, code, diagnostic),
         )
     }
+    #[must_use]
     pub fn warning(code: BoundCode<IssueType>, diagnostic: String) -> Self {
         OperationOutcomeError::new(
             None,
             create_operation_outcome(IssueSeverity::WARNING, code, diagnostic),
         )
     }
+    #[must_use]
     pub fn information(code: BoundCode<IssueType>, diagnostic: String) -> Self {
         OperationOutcomeError::new(
             None,
@@ -86,13 +93,10 @@ impl OperationOutcomeError {
     }
 }
 
-fn get_issue_diagnostics<'a>(
-    issue: &'a haste_fhir_model::r4::generated::resources::OperationOutcomeIssue,
-) -> Option<&'a str> {
-    issue
-        .diagnostics
-        .as_ref()
-        .and_then(|d| d.value.as_ref().map(|v| v.as_str()))
+fn get_issue_diagnostics(
+    issue: &haste_fhir_model::r4::generated::resources::OperationOutcomeIssue,
+) -> Option<&str> {
+    issue.diagnostics.as_ref().and_then(|d| d.value.as_deref())
 }
 
 impl Display for OperationOutcomeError {
@@ -103,8 +107,7 @@ impl Display for OperationOutcomeError {
             self.outcome
                 .issue
                 .iter()
-                .map(get_issue_diagnostics)
-                .filter_map(|d| d)
+                .filter_map(get_issue_diagnostics)
                 .collect::<Vec<_>>()
                 .join(", ")
         )
@@ -113,8 +116,8 @@ impl Display for OperationOutcomeError {
 
 impl Error for OperationOutcomeError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        if let Some(source) = self._source.as_ref() {
-            return Some(&**source);
+        if let Some(source) = self.source.as_ref() {
+            Some(&**source)
         } else {
             None
         }
@@ -125,9 +128,8 @@ impl Error for OperationOutcomeError {
             if let Some(diagnostics) = &issue.diagnostics {
                 diagnostics
                     .value
-                    .as_ref()
-                    .map(|v| v.as_str())
-                    .unwrap_or("No diagnostics available")
+                    .as_deref()
+                    .map_or("No diagnostics available", |v| v)
             } else {
                 "No diagnostics available"
             }

--- a/backend/crates/fhirpath/src/allocators/bumpalo.rs
+++ b/backend/crates/fhirpath/src/allocators/bumpalo.rs
@@ -3,32 +3,32 @@ use haste_reflect::MetaValue;
 use crate::{ResolvedValue, allocators::AllocatorTrait};
 
 pub struct Allocator {
-    _arena: bumpalo::Bump,
+    arena: bumpalo::Bump,
 }
 
 impl Allocator {
     pub fn new() -> Self {
         Allocator {
-            _arena: bumpalo::Bump::new(),
+            arena: bumpalo::Bump::new(),
         }
     }
 }
 
 impl<'a> AllocatorTrait<'a> for Allocator {
     fn allocate_literal<T: MetaValue>(&mut self, value: T) -> &'a dyn MetaValue {
-        let literal_ref = self._arena.alloc(value);
+        let literal_ref = self.arena.alloc(value);
 
-        let literal_ptr = literal_ref as *const _;
+        let literal_ptr = std::ptr::from_ref(literal_ref);
 
         unsafe { &*literal_ptr }
     }
 
     fn allocate_resolved(&mut self, value: ResolvedValue) -> &'a dyn MetaValue {
-        let value = self._arena.alloc(value);
+        let value = self.arena.alloc(value);
 
         let ptr = match value {
-            ResolvedValue::Box(b) => &**b as *const _,
-            ResolvedValue::Arc(a) => &**a,
+            ResolvedValue::Box(b) => &raw const **b,
+            ResolvedValue::Arc(a) => &raw const **a,
         };
 
         unsafe { &*ptr }

--- a/backend/crates/fhirpath/src/allocators/vec_allocator.rs
+++ b/backend/crates/fhirpath/src/allocators/vec_allocator.rs
@@ -11,7 +11,7 @@ pub struct Allocator<'a> {
     _marker: PhantomData<&'a dyn MetaValue>,
 }
 
-impl<'a> Allocator<'a> {
+impl Allocator<'_> {
     #[allow(dead_code)]
     pub fn new() -> Self {
         Allocator {
@@ -32,8 +32,8 @@ impl<'a> AllocatorTrait<'a> for Allocator<'a> {
 
         // Should be safe to unwrap as value guaranteed to be non-empty from above call.
         let ptr = match &self.context.last().unwrap() {
-            ResolvedValue::Box(b) => &**b as *const _,
-            ResolvedValue::Arc(a) => &**a,
+            ResolvedValue::Box(b) => &raw const **b,
+            ResolvedValue::Arc(a) => &raw const **a,
         };
 
         unsafe { &*ptr }

--- a/backend/crates/fhirpath/src/error.rs
+++ b/backend/crates/fhirpath/src/error.rs
@@ -13,6 +13,12 @@ pub enum OperationError {
     InvalidType(&'static str, &'static str),
     #[error("Operand has invalid cardinality")]
     InvalidCardinality,
+    #[error("Collection size exceeds the maximum allowed integer limit (i64::MAX)")]
+    SizeOverflow,
+    #[error("Index must be a non-negative integer without decimal parts")]
+    InvalidIndex,
+    #[error("Index is out of bounds for the target pointer width")]
+    IndexOutOfBounds,
 }
 
 #[derive(Debug, Error)]

--- a/backend/crates/fhirpath/src/lib.rs
+++ b/backend/crates/fhirpath/src/lib.rs
@@ -2,7 +2,10 @@ mod error;
 mod parser;
 use crate::{
     error::{FunctionError, OperationError},
-    parser::{Expression, FunctionInvocation, Identifier, Invocation, Literal, Operation, Term},
+    parser::{
+        Expression, FunctionInvocation, Identifier, Invocation, Literal, Operation,
+        QualifiedIdentifier, Term,
+    },
 };
 use dashmap::DashMap;
 pub use error::FHIRPathError;
@@ -43,7 +46,7 @@ async fn evaluate_literal<'b>(
         Literal::Integer(int) => Ok(context.new_context_from(vec![
             context
                 .allocate_literal(FHIRInteger {
-                    value: Some(int.clone()),
+                    value: Some(*int),
                     ..Default::default()
                 })
                 .await,
@@ -51,7 +54,7 @@ async fn evaluate_literal<'b>(
         Literal::Float(decimal) => Ok(context.new_context_from(vec![
             context
                 .allocate_literal(FHIRDecimal {
-                    value: Some(decimal.clone()),
+                    value: Some(*decimal),
                     ..Default::default()
                 })
                 .await,
@@ -59,7 +62,7 @@ async fn evaluate_literal<'b>(
         Literal::Boolean(bool) => Ok(context.new_context_from(vec![
             context
                 .allocate_literal(FHIRBoolean {
-                    value: Some(bool.clone()),
+                    value: Some(*bool),
                     ..Default::default()
                 })
                 .await,
@@ -83,7 +86,21 @@ async fn evaluate_invocation<'a>(
                     OperationError::InvalidCardinality,
                 ));
             }
-            let index = downcast_number(index.values[0])? as usize;
+
+            let float_index = downcast_number(index.values[0])?;
+
+            // Ensure the index is non-negative and has no fractional part
+            if float_index < 0.0 || float_index.fract() != 0.0 {
+                return Err(FHIRPathError::OperationError(OperationError::InvalidIndex));
+            }
+
+            // Suppress clippy warnings because the float is guaranteed to be a valid,
+            // non-negative integer index by the safety checks immediately above.
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let index: usize = (float_index as u64)
+                .try_into()
+                .map_err(|_| FHIRPathError::OperationError(OperationError::IndexOutOfBounds))?;
+
             if let Some(value) = context.values.get(index) {
                 Ok(context.new_context_from(vec![*value]))
             } else {
@@ -96,11 +113,7 @@ async fn evaluate_invocation<'a>(
             context
                 .values
                 .iter()
-                .flat_map(|v| {
-                    v.get_field(id)
-                        .map(|v| v.flatten())
-                        .unwrap_or_else(|| vec![])
-                })
+                .flat_map(|v| v.get_field(id).map_or_else(Vec::new, |v| v.flatten()))
                 .collect(),
         )),
         Invocation::Function(function) => evaluate_function(function, context, config).await,
@@ -138,10 +151,10 @@ async fn evaluate_first_term<'a>(
         Term::Invocation(invocation) => match invocation {
             Invocation::Identifier(identifier) => {
                 let type_filter = filter_by_type(&identifier.0, &context);
-                if !type_filter.values.is_empty() {
-                    Ok(type_filter)
-                } else {
+                if type_filter.values.is_empty() {
                     evaluate_invocation(invocation, context, config).await
+                } else {
+                    Ok(type_filter)
                 }
             }
             _ => evaluate_invocation(invocation, context, config).await,
@@ -151,7 +164,7 @@ async fn evaluate_first_term<'a>(
 }
 
 async fn evaluate_singular<'a>(
-    expression: &Vec<Term>,
+    expression: &[Term],
     context: Context<'a>,
     config: Option<Arc<Config<'a>>>,
 ) -> Result<Context<'a>, FHIRPathError> {
@@ -185,7 +198,7 @@ async fn operation_2<'a>(
     let right = evaluate_expression(right, context, config).await?;
 
     // If one of operands is empty per spec return an empty collection
-    if left.values.len() == 0 || right.values.len() == 0 {
+    if left.values.is_empty() || right.values.is_empty() {
         return Ok(left.new_context_from(vec![]));
     }
 
@@ -218,12 +231,12 @@ enum Cardinality {
 }
 
 fn validate_arguments(
-    ast_arguments: &Vec<Expression>,
+    ast_arguments: &[Expression],
     cardinality: &Cardinality,
 ) -> Result<(), FHIRPathError> {
     match cardinality {
         Cardinality::Zero => {
-            if ast_arguments.len() != 0 {
+            if !ast_arguments.is_empty() {
                 return Err(FHIRPathError::OperationError(
                     OperationError::InvalidCardinality,
                 ));
@@ -254,7 +267,7 @@ fn derive_typename(expression_ast: &Expression) -> Result<String, FHIRPathError>
             Term::Invocation(Invocation::Identifier(type_id)) => Ok(type_id.0.clone()),
             _ => Err(FHIRPathError::FailedTypeNameDerivation),
         },
-        _ => Err(FHIRPathError::FailedTypeNameDerivation),
+        Expression::Operation(_) => Err(FHIRPathError::FailedTypeNameDerivation),
     }
 }
 
@@ -273,15 +286,14 @@ fn check_type(value: &dyn MetaValue, type_to_check: &str) -> bool {
         "Reference" => {
             if type_to_check == "Reference" {
                 return true;
-            } else if let Some(reference) = value.as_any().downcast_ref::<Reference>() {
-                if let Some(resource_type) = reference
+            } else if let Some(reference) = value.as_any().downcast_ref::<Reference>()
+                && let Some(resource_type) = reference
                     .reference
                     .as_ref()
                     .and_then(|r| r.value.as_ref())
-                    .and_then(|r| r.split("/").next())
-                {
-                    return check_type_name(resource_type, type_to_check);
-                }
+                    .and_then(|r| r.split('/').next())
+            {
+                return check_type_name(resource_type, type_to_check);
             }
             false
         }
@@ -295,7 +307,7 @@ fn filter_by_type<'a>(type_name: &str, context: &Context<'a>) -> Context<'a> {
             .values
             .iter()
             .filter(|v| check_type(**v, type_name))
-            .map(|v| *v)
+            .copied()
             .collect(),
     )
 }
@@ -312,343 +324,413 @@ async fn evaluate_function<'a>(
     config: Option<Arc<Config<'a>>>,
 ) -> Result<Context<'a>, FHIRPathError> {
     match function.name.0.as_str() {
-        // Faking resolve to just return current context.
         "resolve" => Ok(context),
-        "where" => {
-            validate_arguments(&function.arguments, &Cardinality::One)?;
+        "where" => evaluate_where(function, context, config).await,
+        "ofType" | "as" => evaluate_of_type(function, &context),
+        "count" => evaluate_count(function, context).await,
+        "upper" | "lower" => evaluate_case(function, context).await,
+        "empty" => evaluate_empty(function, context).await,
+        "join" => evaluate_join(function, context, config).await,
+        "exists" => evaluate_exists(function, context, config).await,
+        "children" => evaluate_children(function, &context),
+        "repeat" => evaluate_repeat(function, context, config).await,
+        "descendants" => evaluate_descendants(context, config).await,
+        "type" => evaluate_type(function, context).await,
+        "first" => evaluate_first(function, &context),
+        "getReferenceKey" => evaluate_get_reference_key(function, context).await,
+        "getResourceKey" => evaluate_get_resource_key(function, context, config).await,
 
-            let where_condition = &function.arguments[0];
-            let mut new_context = vec![];
-            for value in context.values.iter() {
-                let result = evaluate_expression(
-                    where_condition,
-                    context.new_context_from(vec![*value]),
-                    config.clone(),
-                )
-                .await?;
+        _ => Err(FHIRPathError::NotImplemented(format!(
+            "Function '{}' is not implemented",
+            function.name.0
+        ))),
+    }
+}
 
-                if result.values.len() > 1 {
-                    return Err(FHIRPathError::InternalError(
-                        "Where condition did not return a single value".to_string(),
-                    ));
-                    // Empty set effectively means no match and treat as false.
-                } else if !result.values.is_empty() && downcast_bool(result.values[0])? == true {
-                    new_context.push(*value);
-                }
+async fn evaluate_where<'a>(
+    function: &FunctionInvocation,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::One)?;
+
+    let where_condition = &function.arguments[0];
+    let mut new_context = vec![];
+
+    for value in &context.values {
+        let result = evaluate_expression(
+            where_condition,
+            context.new_context_from(vec![*value]),
+            config.clone(),
+        )
+        .await?;
+
+        if result.values.len() > 1 {
+            return Err(FHIRPathError::InternalError(
+                "Where condition did not return a single value".to_string(),
+            ));
+        }
+
+        // Empty result is treated as false.
+        if !result.values.is_empty() && downcast_bool(result.values[0])? {
+            new_context.push(*value);
+        }
+    }
+
+    Ok(context.new_context_from(new_context))
+}
+
+fn evaluate_of_type<'a>(
+    function: &FunctionInvocation,
+    context: &Context<'a>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::One)?;
+
+    let type_name = derive_typename(&function.arguments[0])?;
+
+    Ok(filter_by_type(&type_name, context))
+}
+
+async fn evaluate_count<'a>(
+    function: &FunctionInvocation,
+    context: Context<'a>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::Zero)?;
+
+    let count: i64 = context
+        .values
+        .len()
+        .try_into()
+        .map_err(|_| FHIRPathError::OperationError(OperationError::SizeOverflow))?;
+
+    Ok(context.new_context_from(vec![
+        context
+            .allocate_literal(FHIRInteger {
+                value: Some(count),
+                ..Default::default()
+            })
+            .await,
+    ]))
+}
+
+async fn evaluate_case<'a>(
+    function: &FunctionInvocation,
+    context: Context<'a>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::Zero)?;
+
+    let op = function.name.0.as_str();
+
+    if context.values.is_empty() {
+        return Ok(context.new_context_from(vec![]));
+    }
+
+    if context.values.len() > 1 {
+        return Err(FunctionError::InvalidCardinality(op.to_string(), context.values.len()).into());
+    }
+
+    let input = downcast_string(context.values[0])?;
+
+    let transformed = match op {
+        "upper" => input.to_uppercase(),
+        "lower" => input.to_lowercase(),
+        _ => unreachable!(),
+    };
+
+    Ok(context.new_context_from(vec![
+        context
+            .allocate_literal(FHIRString {
+                value: Some(transformed),
+                ..Default::default()
+            })
+            .await,
+    ]))
+}
+
+async fn evaluate_empty<'a>(
+    function: &FunctionInvocation,
+    context: Context<'a>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::Zero)?;
+
+    Ok(context.new_context_from(vec![
+        context
+            .allocate_literal(FHIRBoolean {
+                value: Some(context.values.is_empty()),
+                ..Default::default()
+            })
+            .await,
+    ]))
+}
+
+async fn evaluate_join<'a>(
+    function: &FunctionInvocation,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::Custom(0, 1))?;
+
+    let separator = if let Some(separator_expression) = function.arguments.first() {
+        let separator_context =
+            evaluate_expression(separator_expression, context.clone(), config).await?;
+
+        if separator_context.values.len() != 1 {
+            return Err(FHIRPathError::OperationError(
+                OperationError::InvalidCardinality,
+            ));
+        }
+
+        downcast_string(separator_context.values[0])?
+    } else {
+        String::new()
+    };
+
+    let joined = context
+        .values
+        .iter()
+        .map(|v| downcast_string(*v))
+        .collect::<Result<Vec<_>, _>>()?
+        .join(&separator);
+
+    Ok(context.new_context_from(vec![
+        context
+            .allocate_literal(FHIRString {
+                value: Some(joined),
+                ..Default::default()
+            })
+            .await,
+    ]))
+}
+
+async fn evaluate_exists<'a>(
+    function: &FunctionInvocation,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::Many)?;
+
+    if function.arguments.len() > 1 {
+        return Err(FunctionError::InvalidCardinality(
+            "exists".to_string(),
+            function.arguments.len(),
+        )
+        .into());
+    }
+
+    if let Some(condition) = function.arguments.first() {
+        for value in &context.values {
+            let result = evaluate_expression(
+                condition,
+                context.new_context_from(vec![*value]),
+                config.clone(),
+            )
+            .await?;
+
+            if result.values.len() > 1 {
+                return Err(FHIRPathError::InternalError(
+                    "Exists condition did not return a single value".to_string(),
+                ));
             }
-            Ok(context.new_context_from(new_context))
-        }
-        "ofType" => {
-            validate_arguments(&function.arguments, &Cardinality::One)?;
 
-            let type_name = derive_typename(&function.arguments[0])?;
-            Ok(filter_by_type(&type_name, &context))
-        }
-        "count" => {
-            validate_arguments(&function.arguments, &Cardinality::Zero)?;
-
-            let count = context.values.len() as i64;
-            Ok(context.new_context_from(vec![
-                context
-                    .allocate_literal(FHIRInteger {
-                        value: Some(count),
-                        ..Default::default()
-                    })
-                    .await,
-            ]))
-        }
-        op @ ("upper" | "lower") => {
-            validate_arguments(&function.arguments, &Cardinality::Zero)?;
-
-            if context.values.is_empty() {
-                return Ok(context.new_context_from(vec![]));
-            }
-            if context.values.len() > 1 {
-                return Err(FunctionError::InvalidCardinality(
-                    op.to_string(),
-                    context.values.len(),
-                )
-                .into());
-            }
-
-            let input = downcast_string(context.values[0])?;
-            let transformed = match op {
-                "upper" => input.to_uppercase(),
-                "lower" => input.to_lowercase(),
-                _ => unreachable!(),
-            };
-            Ok(context.new_context_from(vec![
-                context
-                    .allocate_literal(FHIRString {
-                        value: Some(transformed),
-                        ..Default::default()
-                    })
-                    .await,
-            ]))
-        }
-        "as" => {
-            validate_arguments(&function.arguments, &Cardinality::One)?;
-
-            let type_name = derive_typename(&function.arguments[0])?;
-            Ok(filter_by_type(&type_name, &context))
-        }
-        "empty" => {
-            validate_arguments(&function.arguments, &Cardinality::Zero)?;
-            let res = Ok(context.new_context_from(vec![
-                context
-                    .allocate_literal(FHIRBoolean {
-                        value: Some(context.values.is_empty()),
-                        ..Default::default()
-                    })
-                    .await,
-            ]));
-
-            res
-        }
-        // https://build.fhir.org/ig/HL7/FHIRPath/en/#joinseparator-string--string
-        "join" => {
-            validate_arguments(&function.arguments, &Cardinality::Custom(0, 1))?;
-
-            let separator = if let Some(separator_expression) = function.arguments.get(0) {
-                let separator_context =
-                    evaluate_expression(separator_expression, context.clone(), config).await?;
-                if separator_context.values.len() != 1 {
-                    return Err(FHIRPathError::OperationError(
-                        OperationError::InvalidCardinality,
-                    ));
-                }
-                downcast_string(separator_context.values[0])?
-            } else {
-                "".to_string()
-            };
-
-            let joined = context
-                .values
-                .iter()
-                .map(|v| downcast_string(*v))
-                .collect::<Result<Vec<_>, _>>()?
-                .join(&separator);
-
-            Ok(context.new_context_from(vec![
-                context
-                    .allocate_literal(FHIRString {
-                        value: Some(joined),
-                        ..Default::default()
-                    })
-                    .await,
-            ]))
-        }
-        "exists" => {
-            validate_arguments(&function.arguments, &Cardinality::Many)?;
-
-            if function.arguments.len() > 1 {
-                return Err(FunctionError::InvalidCardinality(
-                    "exists".to_string(),
-                    function.arguments.len(),
-                )
-                .into());
-            }
-
-            let context = if function.arguments.len() == 1 {
-                for value in context.values.iter() {
-                    let result = evaluate_expression(
-                        &function.arguments[0],
-                        context.new_context_from(vec![*value]),
-                        config.clone(),
-                    )
-                    .await?;
-
-                    if result.values.len() > 1 {
-                        return Err(FHIRPathError::InternalError(
-                            "Exists condition did not return a single value".to_string(),
-                        ));
-                        // Empty set effectively means no match and treat as false.
-                    } else if !result.values.is_empty() && downcast_bool(result.values[0])? == true
-                    {
-                        return Ok(context.new_context_from(vec![
-                            context
-                                .allocate_literal(FHIRBoolean {
-                                    value: Some(true),
-                                    ..Default::default()
-                                })
-                                .await,
-                        ]));
-                    }
-                }
+            if !result.values.is_empty() && downcast_bool(result.values[0])? {
                 return Ok(context.new_context_from(vec![
                     context
                         .allocate_literal(FHIRBoolean {
-                            value: Some(false),
+                            value: Some(true),
                             ..Default::default()
                         })
                         .await,
                 ]));
-            } else {
-                context
-            };
-
-            let res = Ok(context.new_context_from(vec![
-                context
-                    .allocate_literal(FHIRBoolean {
-                        value: Some(!context.values.is_empty()),
-                        ..Default::default()
-                    })
-                    .await,
-            ]));
-
-            res
-        }
-        "children" => {
-            validate_arguments(&function.arguments, &Cardinality::Zero)?;
-
-            Ok(context.new_context_from(
-                context
-                    .values
-                    .iter()
-                    .flat_map(|value| {
-                        let result = value
-                            .fields()
-                            .iter()
-                            .filter_map(|f| value.get_field(f).map(|v| v.flatten()))
-                            .flatten()
-                            .collect::<Vec<_>>();
-                        result
-                    })
-                    .collect(),
-            ))
-        }
-        "repeat" => {
-            validate_arguments(&function.arguments, &Cardinality::One)?;
-
-            let projection = &function.arguments[0];
-            let mut end_result = vec![];
-            let mut cur = context;
-
-            while cur.values.len() != 0 {
-                cur = evaluate_expression(projection, cur, config.clone()).await?;
-                end_result.extend_from_slice(cur.values.as_slice());
-            }
-
-            Ok(cur.new_context_from(end_result))
-        }
-        "descendants" => {
-            validate_arguments(&function.arguments, &Cardinality::Zero)?;
-
-            // Descendants is shorthand for repeat(children()) see [https://hl7.org/fhirpath/N1/#descendants-collection].
-            let result = evaluate_expression(
-                &Expression::Singular(vec![Term::Invocation(Invocation::Function(
-                    FunctionInvocation {
-                        name: Identifier("repeat".to_string()),
-                        arguments: vec![Expression::Singular(vec![Term::Invocation(
-                            Invocation::Function(FunctionInvocation {
-                                name: Identifier("children".to_string()),
-                                arguments: vec![],
-                            }),
-                        )])],
-                    },
-                ))]),
-                context,
-                config,
-            )
-            .await?;
-
-            Ok(result)
-        }
-        "type" => {
-            validate_arguments(&function.arguments, &Cardinality::Zero)?;
-
-            let mut next_ctx = Vec::with_capacity(context.values.len());
-            for v in context.values.iter() {
-                let type_name = v.fhir_type();
-                next_ctx.push(
-                    context
-                        .allocate_literal(Reflection {
-                            name: type_name.to_string(),
-                        })
-                        .await,
-                );
-            }
-
-            Ok(context.new_context_from(next_ctx))
-        }
-        "first" => {
-            validate_arguments(&function.arguments, &Cardinality::Zero)?;
-
-            if let Some(first_value) = context.values.get(0) {
-                Ok(context.new_context_from(vec![*first_value]))
-            } else {
-                Ok(context.new_context_from(vec![]))
             }
         }
-        // Functions for viewDefinitions
-        "getReferenceKey" => {
-            validate_arguments(&function.arguments, &Cardinality::Custom(0, 1))?;
 
-            let type_to_filter_by = if let Some(resource_type) = function.arguments.get(0) {
-                let resource_type = derive_typename(resource_type)?;
-                Some(resource_type)
-            } else {
-                None
-            };
-
-            let ids = context
-                .iter()
-                .filter_map(|d| {
-                    let reference = d.as_any().downcast_ref::<Reference>()?;
-                    let mut pieces = reference
-                        .reference
-                        .as_ref()
-                        .and_then(|r| r.value.as_ref())
-                        .map(|r| r.split("/"))?;
-
-                    let resource_type = pieces.next()?;
-                    let id = pieces.next()?;
-
-                    if let Some(type_to_filter_by) = &type_to_filter_by
-                        && !check_type_name(resource_type, type_to_filter_by)
-                    {
-                        return None;
-                    }
-
-                    Some(FHIRId {
-                        value: Some(id.to_string()),
-                        ..Default::default()
-                    })
+        return Ok(context.new_context_from(vec![
+            context
+                .allocate_literal(FHIRBoolean {
+                    value: Some(false),
+                    ..Default::default()
                 })
-                .collect::<Vec<_>>();
+                .await,
+        ]));
+    }
 
-            let mut next_context = Vec::with_capacity(ids.len());
+    Ok(context.new_context_from(vec![
+        context
+            .allocate_literal(FHIRBoolean {
+                value: Some(!context.values.is_empty()),
+                ..Default::default()
+            })
+            .await,
+    ]))
+}
 
-            for id in ids {
-                next_context.push(context.allocate_literal(id).await);
+fn evaluate_children<'a>(
+    function: &FunctionInvocation,
+    context: &Context<'a>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::Zero)?;
+
+    let children = context
+        .values
+        .iter()
+        .flat_map(|value| {
+            value
+                .fields()
+                .iter()
+                .filter_map(|f| value.get_field(f).map(|v| v.flatten()))
+                .flatten()
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    Ok(context.new_context_from(children))
+}
+
+async fn evaluate_repeat<'a>(
+    function: &FunctionInvocation,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::One)?;
+
+    let projection = &function.arguments[0];
+    let mut end_result = vec![];
+    let mut cur = context;
+
+    while !cur.values.is_empty() {
+        cur = evaluate_expression(projection, cur, config.clone()).await?;
+        end_result.extend_from_slice(cur.values.as_slice());
+    }
+
+    Ok(cur.new_context_from(end_result))
+}
+
+async fn evaluate_descendants<'a>(
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    let result = evaluate_expression(
+        &Expression::Singular(vec![Term::Invocation(Invocation::Function(
+            FunctionInvocation {
+                name: Identifier("repeat".to_string()),
+                arguments: vec![Expression::Singular(vec![Term::Invocation(
+                    Invocation::Function(FunctionInvocation {
+                        name: Identifier("children".to_string()),
+                        arguments: vec![],
+                    }),
+                )])],
+            },
+        ))]),
+        context,
+        config,
+    )
+    .await?;
+
+    Ok(result)
+}
+
+async fn evaluate_type<'a>(
+    function: &FunctionInvocation,
+    context: Context<'a>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::Zero)?;
+
+    let mut next_ctx = Vec::with_capacity(context.values.len());
+
+    for value in &context.values {
+        let type_name = value.fhir_type();
+
+        next_ctx.push(
+            context
+                .allocate_literal(Reflection {
+                    name: type_name.to_string(),
+                })
+                .await,
+        );
+    }
+
+    Ok(context.new_context_from(next_ctx))
+}
+
+fn evaluate_first<'a>(
+    function: &FunctionInvocation,
+    context: &Context<'a>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::Zero)?;
+
+    match context.values.first() {
+        Some(value) => Ok(context.new_context_from(vec![*value])),
+        None => Ok(context.new_context_from(vec![])),
+    }
+}
+
+async fn evaluate_get_reference_key<'a>(
+    function: &FunctionInvocation,
+    context: Context<'a>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::Custom(0, 1))?;
+
+    let type_to_filter_by = if let Some(resource_type) = function.arguments.first() {
+        Some(derive_typename(resource_type)?)
+    } else {
+        None
+    };
+
+    let ids = context
+        .iter()
+        .filter_map(|value| {
+            let reference = value.as_any().downcast_ref::<Reference>()?;
+
+            let mut pieces = reference
+                .reference
+                .as_ref()
+                .and_then(|r| r.value.as_ref())
+                .map(|r| r.split('/'))?;
+
+            let resource_type = pieces.next()?;
+            let id = pieces.next()?;
+
+            if let Some(type_to_filter_by) = &type_to_filter_by
+                && !check_type_name(resource_type, type_to_filter_by)
+            {
+                return None;
             }
 
-            return Ok(context.new_context_from(next_context));
-        }
-        "getResourceKey" => {
-            validate_arguments(&function.arguments, &Cardinality::Zero)?;
-
-            let Some(id) = config.and_then(|c| c.resource_id.clone()) else {
-                return Err(FHIRPathError::InternalError(
-                    "getResourceKey function requires resource_id in config".to_string(),
-                ));
-            };
-
-            let resource_key = FHIRId {
-                value: Some(id),
+            Some(FHIRId {
+                value: Some(id.to_string()),
                 ..Default::default()
-            };
+            })
+        })
+        .collect::<Vec<_>>();
 
-            let next_context = vec![context.allocate_literal(resource_key).await];
-            return Ok(context.new_context_from(next_context));
-        }
-        _ => {
-            return Err(FHIRPathError::NotImplemented(format!(
-                "Function '{}' is not implemented",
-                function.name.0
-            )));
-        }
+    let mut next_context = Vec::with_capacity(ids.len());
+
+    for id in ids {
+        next_context.push(context.allocate_literal(id).await);
     }
+
+    Ok(context.new_context_from(next_context))
+}
+
+async fn evaluate_get_resource_key<'a>(
+    function: &FunctionInvocation,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    validate_arguments(&function.arguments, &Cardinality::Zero)?;
+
+    let Some(id) = config.and_then(|c| c.resource_id.clone()) else {
+        return Err(FHIRPathError::InternalError(
+            "getResourceKey function requires resource_id in config".to_string(),
+        ));
+    };
+
+    let resource_key = FHIRId {
+        value: Some(id),
+        ..Default::default()
+    };
+
+    Ok(context.new_context_from(vec![context.allocate_literal(resource_key).await]))
 }
 
 fn equal_check<'b>(left: &Context<'b>, right: &Context<'b>) -> Result<bool, FHIRPathError> {
@@ -657,6 +739,7 @@ fn equal_check<'b>(left: &Context<'b>, right: &Context<'b>) -> Result<bool, FHIR
     {
         let left_value = downcast_number(left.values[0])?;
         let right_value = downcast_number(right.values[0])?;
+        #[allow(clippy::float_cmp)]
         Ok(left_value == right_value)
     } else if STRING_TYPES.contains(left.values[0].fhir_type())
         && STRING_TYPES.contains(right.values[0].fhir_type())
@@ -669,6 +752,9 @@ fn equal_check<'b>(left: &Context<'b>, right: &Context<'b>) -> Result<bool, FHIR
     {
         let left_value = downcast_bool(left.values[0])?;
         let right_value = downcast_bool(right.values[0])?;
+        // Suppress clippy warning because strict equality comparison for float values
+        // is intentional and required by the FHIRPath specification.
+        #[allow(clippy::float_cmp)]
         Ok(left_value == right_value)
     } else {
         // https://hl7.org/fhirpath/N1/#conversion for implicit conversion rules todo.
@@ -687,242 +773,306 @@ async fn evaluate_operation<'a>(
     config: Option<Arc<Config<'a>>>,
 ) -> Result<Context<'a>, FHIRPathError> {
     match operation {
-        Operation::Add(left, right) => {
-            operation_2(left, right, context, config, |left, right| {
-                Box::pin(async move {
-                    if NUMBER_TYPES.contains(left.values[0].fhir_type())
-                        && NUMBER_TYPES.contains(right.values[0].fhir_type())
-                    {
-                        let left_value = downcast_number(left.values[0])?;
-                        let right_value = downcast_number(right.values[0])?;
-                        Ok(left.new_context_from(vec![
-                            left.allocate_literal(FHIRDecimal {
-                                value: Some(left_value + right_value),
-                                ..Default::default()
-                            })
-                            .await,
-                        ]))
-                    } else if STRING_TYPES.contains(left.values[0].fhir_type())
-                        && STRING_TYPES.contains(right.values[0].fhir_type())
-                    {
-                        let left_string = downcast_string(left.values[0])?;
-                        let right_string = downcast_string(right.values[0])?;
-
-                        Ok(left.new_context_from(vec![
-                            left.allocate_literal(FHIRString {
-                                value: Some(left_string + &right_string),
-                                ..Default::default()
-                            })
-                            .await,
-                        ]))
-                    } else {
-                        Err(FHIRPathError::OperationError(OperationError::TypeMismatch(
-                            left.values[0].fhir_type(),
-                            right.values[0].fhir_type(),
-                        )))
-                    }
-                })
-            })
-            .await
-        }
+        Operation::Add(left, right) => evaluate_add(left, right, context, config).await,
         Operation::Subtraction(left, right) => {
-            operation_2(left, right, context, config, |left, right| {
-                Box::pin(async move {
-                    let left_value = downcast_number(left.values[0])?;
-                    let right_value = downcast_number(right.values[0])?;
-
-                    Ok(left.new_context_from(vec![
-                        left.allocate_literal(FHIRDecimal {
-                            value: Some(left_value - right_value),
-                            ..Default::default()
-                        })
-                        .await,
-                    ]))
-                })
-            })
-            .await
+            evaluate_subtraction(left, right, context, config).await
         }
         Operation::Multiplication(left, right) => {
-            operation_2(left, right, context, config, |left, right| {
-                Box::pin(async move {
-                    let left_value = downcast_number(left.values[0])?;
-                    let right_value = downcast_number(right.values[0])?;
+            evaluate_multiplication(left, right, context, config).await
+        }
+        Operation::Division(left, right) => evaluate_division(left, right, context, config).await,
+        Operation::Equal(left, right) => evaluate_equal(left, right, context, config).await,
+        Operation::NotEqual(left, right) => evaluate_not_equal(left, right, context, config).await,
+        Operation::And(left, right) => evaluate_and(left, right, context, config).await,
+        Operation::Or(left, right) => evaluate_or(left, right, context, config).await,
+        Operation::Union(left, right) => evaluate_union(left, right, context, config).await,
+        Operation::Is(expr, ty) => evaluate_is(expr, ty, context, config).await,
+        Operation::As(expr, ty) => evaluate_as(expr, ty, context, config).await,
+        Operation::XOr(left, right) => evaluate_xor(left, right, context, config).await,
 
-                    Ok(left.new_context_from(vec![
-                        left.allocate_literal(FHIRDecimal {
-                            value: Some(left_value * right_value),
-                            ..Default::default()
-                        })
-                        .await,
-                    ]))
-                })
-            })
-            .await
-        }
-        Operation::Division(left, right) => {
-            operation_2(left, right, context, config, |left, right| {
-                Box::pin(async move {
-                    let left_value = downcast_number(left.values[0])?;
-                    let right_value = downcast_number(right.values[0])?;
-
-                    Ok(left.new_context_from(vec![
-                        left.allocate_literal(FHIRDecimal {
-                            value: Some(left_value / right_value),
-                            ..Default::default()
-                        })
-                        .await,
-                    ]))
-                })
-            })
-            .await
-        }
-        Operation::Equal(left, right) => {
-            operation_2(left, right, context, config, |left, right| {
-                Box::pin(async move {
-                    let are_equal = FHIRBoolean {
-                        value: Some(equal_check(&left, &right)?),
-                        ..Default::default()
-                    };
-                    Ok(left.new_context_from(vec![left.allocate_literal(are_equal).await]))
-                })
-            })
-            .await
-        }
-        Operation::NotEqual(left, right) => {
-            operation_2(left, right, context, config, |left, right| {
-                Box::pin(async move {
-                    let not_equal = FHIRBoolean {
-                        value: Some(!equal_check(&left, &right)?),
-                        ..Default::default()
-                    };
-                    Ok(left.new_context_from(vec![left.allocate_literal(not_equal).await]))
-                })
-            })
-            .await
-        }
-        Operation::And(left, right) => {
-            operation_2(left, right, context, config, |left, right| {
-                Box::pin(async move {
-                    let left_value = downcast_bool(left.values[0])?;
-                    let right_value = downcast_bool(right.values[0])?;
-
-                    Ok(left.new_context_from(vec![
-                        left.allocate_literal(FHIRBoolean {
-                            value: Some(left_value && right_value),
-                            ..Default::default()
-                        })
-                        .await,
-                    ]))
-                })
-            })
-            .await
-        }
-        Operation::Or(left, right) => {
-            operation_2(left, right, context, config, |left, right| {
-                Box::pin(async move {
-                    let left_value = downcast_bool(left.values[0])?;
-                    let right_value = downcast_bool(right.values[0])?;
-
-                    Ok(left.new_context_from(vec![
-                        left.allocate_literal(FHIRBoolean {
-                            value: Some(left_value || right_value),
-                            ..Default::default()
-                        })
-                        .await,
-                    ]))
-                })
-            })
-            .await
-        }
-        Operation::Union(left, right) => {
-            operation_n(left, right, context, config, |left, right| {
-                let mut union = vec![];
-                union.extend(left.values.iter());
-                union.extend(right.values.iter());
-                Ok(left.new_context_from(union))
-            })
-            .await
-        }
-        Operation::Modulo(_, _) => Err(FHIRPathError::NotImplemented("Modulo".to_string())),
-        Operation::Is(expression, type_name) => {
-            let left = evaluate_expression(expression, context, config).await?;
-            if left.values.len() > 1 {
-                Err(FHIRPathError::OperationError(
-                    OperationError::InvalidCardinality,
-                ))
-            } else {
-                if let Some(type_name) = type_name.0.get(0).as_ref().map(|k| &k.0) {
-                    let next_context = filter_by_type(&type_name, &left);
-                    Ok(left.new_context_from(vec![
-                        left.allocate_literal(FHIRBoolean {
-                            value: Some(!next_context.values.is_empty()),
-                            ..Default::default()
-                        })
-                        .await,
-                    ]))
-                } else {
-                    Ok(left.new_context_from(vec![]))
-                }
-            }
-        }
-        Operation::As(expression, type_name) => {
-            let left = evaluate_expression(expression, context, config).await?;
-            if left.values.len() > 1 {
-                Err(FHIRPathError::OperationError(
-                    OperationError::InvalidCardinality,
-                ))
-            } else {
-                if let Some(type_name) = type_name.0.get(0).as_ref().map(|k| &k.0) {
-                    Ok(filter_by_type(&type_name, &left))
-                } else {
-                    Ok(left.new_context_from(vec![]))
-                }
-            }
-        }
-        Operation::Polarity(_, _) => Err(FHIRPathError::NotImplemented("Polarity".to_string())),
-        Operation::DivisionTruncated(_, _) => Err(FHIRPathError::NotImplemented(
-            "DivisionTruncated".to_string(),
-        )),
-        Operation::LessThan(_, _) => Err(FHIRPathError::NotImplemented("LessThan".to_string())),
-        Operation::GreaterThan(_, _) => {
-            Err(FHIRPathError::NotImplemented("GreaterThan".to_string()))
-        }
-        Operation::LessThanEqual(_, _) => {
-            Err(FHIRPathError::NotImplemented("LessThanEqual".to_string()))
-        }
-        Operation::GreaterThanEqual(_, _) => Err(FHIRPathError::NotImplemented(
-            "GreaterThanEqual".to_string(),
-        )),
-        Operation::Equivalent(_, _) => Err(FHIRPathError::NotImplemented("Equivalent".to_string())),
-
-        Operation::NotEquivalent(_, _) => {
-            Err(FHIRPathError::NotImplemented("NotEquivalent".to_string()))
-        }
-        Operation::In(_left, _right) => Err(FHIRPathError::NotImplemented("In".to_string())),
-        Operation::Contains(_left, _right) => {
-            Err(FHIRPathError::NotImplemented("Contains".to_string()))
-        }
-        Operation::XOr(left, right) => {
-            operation_2(left, right, context, config, |left, right| {
-                Box::pin(async move {
-                    let left_value = downcast_bool(left.values[0])?;
-                    let right_value = downcast_bool(right.values[0])?;
-
-                    Ok(left.new_context_from(vec![
-                        left.allocate_literal(FHIRBoolean {
-                            value: Some(left_value ^ right_value),
-                            ..Default::default()
-                        })
-                        .await,
-                    ]))
-                })
-            })
-            .await
-        }
-        Operation::Implies(_left, _right) => {
-            Err(FHIRPathError::NotImplemented("Implies".to_string()))
-        }
+        Operation::Modulo(_, _) => not_implemented("Modulo"),
+        Operation::Polarity(_, _) => not_implemented("Polarity"),
+        Operation::DivisionTruncated(_, _) => not_implemented("DivisionTruncated"),
+        Operation::LessThan(_, _) => not_implemented("LessThan"),
+        Operation::GreaterThan(_, _) => not_implemented("GreaterThan"),
+        Operation::LessThanEqual(_, _) => not_implemented("LessThanEqual"),
+        Operation::GreaterThanEqual(_, _) => not_implemented("GreaterThanEqual"),
+        Operation::Equivalent(_, _) => not_implemented("Equivalent"),
+        Operation::NotEquivalent(_, _) => not_implemented("NotEquivalent"),
+        Operation::In(_, _) => not_implemented("In"),
+        Operation::Contains(_, _) => not_implemented("Contains"),
+        Operation::Implies(_, _) => not_implemented("Implies"),
     }
+}
+
+fn not_implemented(name: &'static str) -> Result<Context<'static>, FHIRPathError> {
+    Err(FHIRPathError::NotImplemented(name.to_string()))
+}
+
+async fn evaluate_add<'a>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    operation_2(left, right, context, config, |left, right| {
+        Box::pin(async move {
+            if NUMBER_TYPES.contains(left.values[0].fhir_type())
+                && NUMBER_TYPES.contains(right.values[0].fhir_type())
+            {
+                let left_value = downcast_number(left.values[0])?;
+                let right_value = downcast_number(right.values[0])?;
+
+                Ok(left.new_context_from(vec![
+                    left.allocate_literal(FHIRDecimal {
+                        value: Some(left_value + right_value),
+                        ..Default::default()
+                    })
+                    .await,
+                ]))
+            } else if STRING_TYPES.contains(left.values[0].fhir_type())
+                && STRING_TYPES.contains(right.values[0].fhir_type())
+            {
+                let left_string = downcast_string(left.values[0])?;
+                let right_string = downcast_string(right.values[0])?;
+
+                Ok(left.new_context_from(vec![
+                    left.allocate_literal(FHIRString {
+                        value: Some(left_string + &right_string),
+                        ..Default::default()
+                    })
+                    .await,
+                ]))
+            } else {
+                Err(FHIRPathError::OperationError(OperationError::TypeMismatch(
+                    left.values[0].fhir_type(),
+                    right.values[0].fhir_type(),
+                )))
+            }
+        })
+    })
+    .await
+}
+
+async fn evaluate_numeric_binary<'a, F>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+    op: F,
+) -> Result<Context<'a>, FHIRPathError>
+where
+    F: FnOnce(f64, f64) -> f64 + Copy + Send + 'static,
+{
+    operation_2(left, right, context, config, move |left, right| {
+        Box::pin(async move {
+            let left_value = downcast_number(left.values[0])?;
+            let right_value = downcast_number(right.values[0])?;
+
+            Ok(left.new_context_from(vec![
+                left.allocate_literal(FHIRDecimal {
+                    value: Some(op(left_value, right_value)),
+                    ..Default::default()
+                })
+                .await,
+            ]))
+        })
+    })
+    .await
+}
+
+async fn evaluate_subtraction<'a>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    evaluate_numeric_binary(left, right, context, config, |l, r| l - r).await
+}
+
+async fn evaluate_multiplication<'a>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    evaluate_numeric_binary(left, right, context, config, |l, r| l * r).await
+}
+
+async fn evaluate_division<'a>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    evaluate_numeric_binary(left, right, context, config, |l, r| l / r).await
+}
+
+async fn evaluate_boolean_binary<'a, F>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+    op: F,
+) -> Result<Context<'a>, FHIRPathError>
+where
+    F: FnOnce(bool, bool) -> bool + Copy + Send + 'static,
+{
+    operation_2(left, right, context, config, move |left, right| {
+        Box::pin(async move {
+            let l = downcast_bool(left.values[0])?;
+            let r = downcast_bool(right.values[0])?;
+
+            Ok(left.new_context_from(vec![
+                left.allocate_literal(FHIRBoolean {
+                    value: Some(op(l, r)),
+                    ..Default::default()
+                })
+                .await,
+            ]))
+        })
+    })
+    .await
+}
+
+async fn evaluate_and<'a>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    evaluate_boolean_binary(left, right, context, config, |l, r| l && r).await
+}
+
+async fn evaluate_or<'a>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    evaluate_boolean_binary(left, right, context, config, |l, r| l || r).await
+}
+
+async fn evaluate_xor<'a>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    evaluate_boolean_binary(left, right, context, config, |l, r| l ^ r).await
+}
+
+async fn evaluate_equality<'a>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+    negate: bool,
+) -> Result<Context<'a>, FHIRPathError> {
+    operation_2(left, right, context, config, move |left, right| {
+        Box::pin(async move {
+            let mut result = equal_check(&left, &right)?;
+
+            if negate {
+                result = !result;
+            }
+
+            Ok(left.new_context_from(vec![
+                left.allocate_literal(FHIRBoolean {
+                    value: Some(result),
+                    ..Default::default()
+                })
+                .await,
+            ]))
+        })
+    })
+    .await
+}
+
+async fn evaluate_equal<'a>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    evaluate_equality(left, right, context, config, false).await
+}
+
+async fn evaluate_not_equal<'a>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    evaluate_equality(left, right, context, config, true).await
+}
+
+async fn evaluate_union<'a>(
+    left: &Expression,
+    right: &Expression,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    operation_n(left, right, context, config, |left, right| {
+        let mut union = Vec::with_capacity(left.values.len() + right.values.len());
+        union.extend(left.values.iter());
+        union.extend(right.values.iter());
+
+        Ok(left.new_context_from(union))
+    })
+    .await
+}
+
+async fn evaluate_type_operation<'a>(
+    expression: &Expression,
+    type_name: &QualifiedIdentifier,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+    return_context: bool,
+) -> Result<Context<'a>, FHIRPathError> {
+    let left = evaluate_expression(expression, context, config).await?;
+
+    if left.values.len() > 1 {
+        return Err(FHIRPathError::OperationError(
+            OperationError::InvalidCardinality,
+        ));
+    }
+
+    let Some(type_name) = type_name.0.first().map(|id| &id.0) else {
+        return Ok(left.new_context_from(vec![]));
+    };
+
+    let filtered = filter_by_type(type_name, &left);
+
+    if return_context {
+        Ok(filtered)
+    } else {
+        Ok(left.new_context_from(vec![
+            left.allocate_literal(FHIRBoolean {
+                value: Some(!filtered.values.is_empty()),
+                ..Default::default()
+            })
+            .await,
+        ]))
+    }
+}
+
+async fn evaluate_is<'a>(
+    expression: &Expression,
+    type_name: &QualifiedIdentifier,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    evaluate_type_operation(expression, type_name, context, config, false).await
+}
+
+async fn evaluate_as<'a>(
+    expression: &Expression,
+    type_name: &QualifiedIdentifier,
+    context: Context<'a>,
+    config: Option<Arc<Config<'a>>>,
+) -> Result<Context<'a>, FHIRPathError> {
+    evaluate_type_operation(expression, type_name, context, config, true).await
 }
 
 fn evaluate_expression<'a>(
@@ -949,7 +1099,8 @@ pub enum ResolvedValue {
 }
 
 impl ResolvedValue {
-    pub fn as_ref(&self) -> &dyn MetaValue {
+    #[must_use]
+    pub fn as_meta_value(&self) -> &dyn MetaValue {
         match self {
             ResolvedValue::Box(b) => &**b,
             ResolvedValue::Arc(a) => &**a,
@@ -962,42 +1113,34 @@ pub struct Context<'a> {
     values: Vec<&'a dyn MetaValue>,
 }
 
+pub type ResolvedValueFuture = Pin<Box<dyn Future<Output = Option<ResolvedValue>> + Send>>;
+pub type ResolveValueCallback = Box<dyn Fn(String) -> ResolvedValueFuture + Send + Sync>;
+
 pub enum ExternalConstantResolver<'a> {
-    Function(
-        Box<
-            dyn Fn(String) -> Pin<Box<dyn Future<Output = Option<ResolvedValue>> + Send>>
-                + Send
-                + Sync,
-        >,
-    ),
+    Function(ResolveValueCallback),
     Variable(Arc<HashMap<String, &'a dyn MetaValue>>),
 }
 
+#[derive(Default)]
 pub struct Config<'a> {
     // Used to resolve resource_id in getResourceKey for sql-on-fhir.
     resource_id: Option<String>,
     variable_resolver: Option<ExternalConstantResolver<'a>>,
 }
 
-impl Default for Config<'_> {
-    fn default() -> Self {
-        Self {
-            resource_id: None,
-            variable_resolver: None,
-        }
-    }
-}
-
 impl<'a> Config<'a> {
+    #[must_use]
     pub fn builder() -> Self {
         Config::default()
     }
 
+    #[must_use]
     pub fn with_variable_resolver(mut self, resolver: ExternalConstantResolver<'a>) -> Self {
         self.variable_resolver = Some(resolver);
         self
     }
 
+    #[must_use]
     pub fn with_resource_id(mut self, resource_id: String) -> Self {
         self.resource_id = Some(resource_id);
         self
@@ -1019,14 +1162,25 @@ async fn resolve_external_constant<'a>(
                 None
             }
         }
-        Some(ExternalConstantResolver::Variable(map)) => map.get(name).map(|s| *s),
+        Some(ExternalConstantResolver::Variable(map)) => map.get(name).copied(),
         None => None,
     };
 
     if let Some(result) = external_constant {
         return Ok(context.new_context_from(vec![result]));
-    } else {
-        return Ok(context.new_context_from(vec![]));
+    }
+    Ok(context.new_context_from(vec![]))
+}
+
+impl<'a> IntoIterator for &'a Context<'_> {
+    type Item = &'a dyn haste_reflect::MetaValue;
+
+    type IntoIter = std::boxed::Box<
+        dyn std::iter::Iterator<Item = &'a (dyn haste_reflect::MetaValue + 'static)> + 'a,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 
@@ -1035,15 +1189,12 @@ impl<'a> Context<'a> {
         values: Vec<&'a dyn MetaValue>,
         allocator: Arc<Mutex<allocators::bumpalo::Allocator>>,
     ) -> Self {
-        Self {
-            allocator,
-            values: values,
-        }
+        Self { allocator, values }
     }
     fn new_context_from(&self, values: Vec<&'a dyn MetaValue>) -> Self {
         Self {
             allocator: self.allocator.clone(),
-            values: values,
+            values,
         }
     }
     async fn allocate(&self, value: ResolvedValue) -> &'a dyn MetaValue {
@@ -1053,8 +1204,9 @@ impl<'a> Context<'a> {
     async fn allocate_literal<T: MetaValue>(&self, value: T) -> &'a dyn MetaValue {
         self.allocator.lock().await.allocate_literal(value)
     }
+    #[must_use]
     pub fn iter(&'a self) -> Box<dyn Iterator<Item = &'a dyn MetaValue> + 'a> {
-        Box::new(self.values.iter().map(|v| *v))
+        Box::new(self.values.iter().copied())
     }
 }
 
@@ -1079,24 +1231,35 @@ fn get_ast(
             expression_ast
         } else {
             AST.insert(path.to_string(), parser::parse(path)?);
-            let expression_ast = AST.get(path).ok_or_else(|| {
+            AST.get(path).ok_or_else(|| {
                 FHIRPathError::InternalError("Failed to find path post insert".to_string())
-            })?;
-            expression_ast
+            })?
         };
 
     Ok(ast)
 }
 
+impl Default for FPEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FPEngine {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
-    /// Evaluate a FHIRPath expression against a context.
-    /// The context is a vector of references to MetaValue objects.
-    /// The path is a FHIRPath expression.
-    /// The result is a vector of references to MetaValue objects.
+    /// Evaluate a `FHIRPath` expression against a context.
+    /// The context is a vector of references to `MetaValue` objects.
+    /// The path is a `FHIRPath` expression.
+    /// The result is a vector of references to `MetaValue` objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`FHIRPathError`] if the expression parsing fails (bad AST)
+    /// or if the evaluation engine encounters an error during execution.
     pub async fn evaluate<'a, 'b>(
         &self,
         path: &str,
@@ -1117,11 +1280,15 @@ impl FPEngine {
         Ok(result)
     }
 
-    /// Evaluate a FHIRPath expression against a context.
-    /// The context is a vector of references to MetaValue objects.
-    /// The path is a FHIRPath expression.
-    /// The result is a vector of references to MetaValue objects.
+    /// Evaluate a `FHIRPath` expression against a context.
+    /// The context is a vector of references to `MetaValue` objects.
+    /// The path is a `FHIRPath` expression.
+    /// The result is a vector of references to `MetaValue` objects.
     ///
+    /// # Errors
+    ///
+    /// Returns a [`FHIRPathError`] if the expression parsing fails (bad AST)
+    /// or if the evaluation engine encounters an error during execution.
     pub async fn evaluate_with_config<'a, 'b>(
         &self,
         path: &str,

--- a/backend/crates/fhirpath/src/parser.rs
+++ b/backend/crates/fhirpath/src/parser.rs
@@ -412,5 +412,5 @@ mod tests {
 }
 
 pub fn parse(input: &str) -> Result<Expression, FHIRPathError> {
-    parser::operations(input).map_err(|e| FHIRPathError::ParseError(e))
+    parser::operations(input).map_err(FHIRPathError::ParseError)
 }

--- a/backend/crates/server/src/fhir_client/middleware/storage.rs
+++ b/backend/crates/server/src/fhir_client/middleware/storage.rs
@@ -175,7 +175,7 @@ impl<
                         .await?;
                         if let Some(mut resource) = current_resource {
                             Ok(Some(FHIRResponse::Delete(DeleteResponse::Instance(
-                                FHIRDeleteInstanceResponse {
+                                Box::new(FHIRDeleteInstanceResponse {
                                     resource: FHIRRepository::delete(
                                         state.repo.as_ref(),
                                         &context.ctx.tenant,
@@ -186,7 +186,7 @@ impl<
                                         &delete_request.id,
                                     )
                                     .await?,
-                                },
+                                }),
                             ))))
                         } else {
                             Err(OperationOutcomeError::error(

--- a/backend/crates/server/src/fhir_http/mod.rs
+++ b/backend/crates/server/src/fhir_http/mod.rs
@@ -145,7 +145,7 @@ fn parse_request_1_non_empty(
                 // Handle operation request
                 Ok(FHIRRequest::Invocation(InvocationRequest::System(
                     FHIRInvokeSystemRequest {
-                        operation: Operation::new(&url_chunks[0])?,
+                        operation: Operation::new(&url_chunks[0]),
                         parameters: get_parameters(req)?,
                     },
                 )))
@@ -315,7 +315,7 @@ fn parse_request_2(
                 Ok(FHIRRequest::Invocation(InvocationRequest::Type(
                     FHIRInvokeTypeRequest {
                         resource_type: ResourceType::try_from(url_chunks[0].as_str())?,
-                        operation: Operation::new(&url_chunks[1])?,
+                        operation: Operation::new(&url_chunks[1]),
                         parameters: get_parameters(req)?,
                     },
                 )))
@@ -420,7 +420,7 @@ fn parse_request_3(
                     FHIRInvokeInstanceRequest {
                         resource_type: ResourceType::try_from(url_chunks[0].as_str())?,
                         id: url_chunks[1].to_string(),
-                        operation: Operation::new(&url_chunks[2])?,
+                        operation: Operation::new(&url_chunks[2]),
                         parameters: get_parameters(req)?,
                     },
                 )))

--- a/backend/crates/testscript-runner/src/lib.rs
+++ b/backend/crates/testscript-runner/src/lib.rs
@@ -699,12 +699,7 @@ async fn testscript_operation_to_fhir_request(
             )));
         };
 
-        let op_code = Operation::new(op_code).map_err(|_e| {
-            TestScriptError::ExecutionError(format!(
-                "Invalid operation code for invoke operation '{}'",
-                op_code
-            ))
-        })?;
+        let op_code = Operation::new(op_code);
 
         let Some(source_id) = operation.sourceId.as_ref().and_then(|id| id.value.as_ref()) else {
             return Err(TestScriptError::ExecutionError(format!(


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.