### PR TITLE
Resolve `clippy` lints for `access-control` crate

### DIFF
--- a/backend/crates/access-control/src/context.rs
+++ b/backend/crates/access-control/src/context.rs
@@ -63,6 +63,7 @@ pub struct PolicyEnvironment {
 }
 
 impl PolicyEnvironment {
+    #[must_use]
     pub fn new(
         tenant: TenantId,
         project: ProjectId,

--- a/backend/crates/access-control/src/engine/full_access/mod.rs
+++ b/backend/crates/access-control/src/engine/full_access/mod.rs
@@ -1,16 +1,15 @@
 use haste_fhir_model::r4::generated::{
     resources::AccessPolicyV2, terminology::AccessPolicyv2Engine,
 };
-use haste_fhir_operation_error::OperationOutcomeError;
 
 use crate::context::PermissionLevel;
 
-pub async fn evaluate(policy: &AccessPolicyV2) -> Result<PermissionLevel, OperationOutcomeError> {
+pub fn evaluate(policy: &AccessPolicyV2) -> PermissionLevel {
     // Sanity check to ensure we are only evaluating FullAccess policies here.
     // Note this is done on root lib.rs evaluation of policy.
     if AccessPolicyv2Engine::FULL_ACCESS == policy.engine {
-        Ok(PermissionLevel::Allow)
+        PermissionLevel::Allow
     } else {
-        Ok(PermissionLevel::Deny)
+        PermissionLevel::Deny
     }
 }

--- a/backend/crates/access-control/src/engine/rule_engine/expression.rs
+++ b/backend/crates/access-control/src/engine/rule_engine/expression.rs
@@ -22,11 +22,10 @@ pub fn create_config<
             let pointer = pointer.clone();
             let context = context.clone();
             Box::pin(async move {
-                if let Some(result) = pip(context, pointer, &variable_id).await.ok() {
-                    result
-                } else {
-                    None
-                }
+                pip(context, pointer, &variable_id)
+                    .await
+                    .ok()
+                    .unwrap_or_default()
             })
         }),
     ))
@@ -56,12 +55,7 @@ pub async fn evaluate_expression<
     expression: &Expression,
 ) -> Result<ExpressionResult<'a>, OperationOutcomeError> {
     match (
-        expression
-            .language
-            .as_ref()
-            .value
-            .as_ref()
-            .map(|s| s.as_str()),
+        expression.language.as_ref().value.as_deref(),
         expression
             .expression
             .as_ref()
@@ -79,7 +73,7 @@ pub async fn evaluate_expression<
                 .map_err(|e: FHIRPathError| {
                     OperationOutcomeError::fatal(
                         IssueType::NOT_SUPPORTED,
-                        format!("FHIRPath evaluation error: '{}'", e),
+                        format!("FHIRPath evaluation error: '{e}'"),
                     )
                 })?;
 
@@ -103,7 +97,6 @@ pub async fn evaluate_expression<
 }
 
 pub async fn evaluate_to_string<
-    'a,
     CTX: Sync + Send + Clone + 'static,
     Client: FHIRClient<CTX, OperationOutcomeError> + 'static,
 >(

--- a/backend/crates/access-control/src/engine/rule_engine/pdp.rs
+++ b/backend/crates/access-control/src/engine/rule_engine/pdp.rs
@@ -25,7 +25,6 @@ pub enum PDPError {
 type PolicyResult<T, Context> = (T, Context);
 
 async fn should_evaluate_rule<
-    'a,
     CTX: Send + Sync + Clone + 'static,
     Client: FHIRClient<CTX, OperationOutcomeError> + Send + Sync + 'static,
 >(
@@ -84,7 +83,7 @@ fn coalesce_boolean(
         ));
     }
 
-    let Some(value) = values.get(0) else {
+    let Some(value) = values.first() else {
         return Err(OperationOutcomeError::fatal(
             haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
             "Condition expression did not evaluate to a value.".to_string(),
@@ -112,17 +111,14 @@ fn coalesce_boolean(
                     "Condition expression evaluated to a System.Boolean with no value.".to_string(),
                 )
             }),
-        _ => {
-            return Err(OperationOutcomeError::fatal(
-                haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                "Condition expression did not evaluate to a boolean value.".to_string(),
-            ));
-        }
+        _ => Err(OperationOutcomeError::fatal(
+            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+            "Condition expression did not evaluate to a boolean value.".to_string(),
+        )),
     }
 }
 
 async fn evaluate_condition<
-    'a,
     CTX: Send + Sync + Clone + 'static,
     Client: FHIRClient<CTX, OperationOutcomeError> + Send + Sync + 'static,
 >(
@@ -174,7 +170,6 @@ async fn evaluate_condition<
 }
 
 async fn evaluate_access_policy_rule<
-    'a,
     CTX: Send + Sync + Clone + 'static,
     Client: FHIRClient<CTX, OperationOutcomeError> + Send + Sync + 'static,
 >(
@@ -185,7 +180,7 @@ async fn evaluate_access_policy_rule<
         .value()
         .ok_or(PDPError::PointerError(rule_pointer.path().to_string()))?;
 
-    let (should_evaluate, mut policy_context) = should_evaluate_rule(
+    let (should_evaluate, policy_context) = should_evaluate_rule(
         policy_context,
         rule_pointer
             .descend::<AccessPolicyV2RuleTarget>(&haste_pointer::Key::Field("target".to_string())),
@@ -198,128 +193,132 @@ async fn evaluate_access_policy_rule<
 
     match rule.combineBehavior.as_ref() {
         combine_behavior if combine_behavior == Some(&AccessPolicyv2CombineBehavior::ANY) => {
-            let mut result = PermissionLevel::Deny;
-            if rule.condition.is_some() {
-                return Err(OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "Condition is not supported when combineBehavior is 'any'.".to_string(),
-                ));
-            }
-
-            for (nested_index, _) in rule.rule.as_ref().unwrap_or(&vec![]).iter().enumerate() {
-                let nested_rule_pointer = rule_pointer
-                    .descend::<Vec<AccessPolicyV2Rule>>(&haste_pointer::Key::Field(
-                        "rule".to_string(),
-                    ))
-                    .and_then(|p| {
-                        p.descend::<AccessPolicyV2Rule>(&haste_pointer::Key::Index(nested_index))
-                    })
-                    .ok_or_else(|| {
-                        PDPError::PointerError(format!(
-                            "{}/rule/{}",
-                            rule_pointer.path(),
-                            nested_index
-                        ))
-                    })?;
-
-                let context = policy_context.clone();
-
-                let rule_result: Result<
-                    (PermissionLevel, Arc<PolicyContext<CTX, Client>>),
-                    OperationOutcomeError,
-                > = Box::pin(async move {
-                    let nested_rule_result =
-                        evaluate_access_policy_rule(context.clone(), nested_rule_pointer).await?;
-
-                    Ok(nested_rule_result)
-                })
-                .await;
-
-                let (rule_result, next_context) = rule_result?;
-
-                // Any logic means if any rule grants access, access is granted. So we can just take the max permission allowed.
-                result = get_max(&result, &rule_result)?;
-
-                policy_context = next_context;
-            }
-
-            Ok((result, policy_context))
+            evaluate_any_rules(policy_context, rule_pointer).await
         }
+
         combine_behavior if combine_behavior == Some(&AccessPolicyv2CombineBehavior::ALL_OF) => {
-            // Set as allowed because doing min logic below.
-            let mut result = PermissionLevel::Allow;
-            if rule.condition.is_some() {
-                return Err(OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "Condition is not supported when combineBehavior is 'any'.".to_string(),
-                ));
-            }
-
-            for (nested_index, _) in rule.rule.as_ref().unwrap_or(&vec![]).iter().enumerate() {
-                let nested_rule_pointer = rule_pointer
-                    .descend::<Vec<AccessPolicyV2Rule>>(&haste_pointer::Key::Field(
-                        "rule".to_string(),
-                    ))
-                    .and_then(|p| {
-                        p.descend::<AccessPolicyV2Rule>(&haste_pointer::Key::Index(nested_index))
-                    })
-                    .ok_or_else(|| {
-                        PDPError::PointerError(format!(
-                            "{}/rule/{}",
-                            rule_pointer.path(),
-                            nested_index
-                        ))
-                    })?;
-                let context = policy_context.clone();
-
-                let rule_result: Result<
-                    (PermissionLevel, Arc<PolicyContext<CTX, Client>>),
-                    OperationOutcomeError,
-                > = Box::pin(async move {
-                    let nested_rule_result =
-                        evaluate_access_policy_rule(context.clone(), nested_rule_pointer).await?;
-
-                    Ok(nested_rule_result)
-                })
-                .await;
-
-                let (rule_result, next_context) = rule_result?;
-
-                // Shortcircuit deny.
-                if rule_result == PermissionLevel::Deny {
-                    // Short-circuit deny.
-                    return Ok((PermissionLevel::Deny, next_context));
-                }
-
-                // And logic means minimum permission level is taken.
-                result = get_min(&result, &rule_result)?;
-
-                policy_context = next_context;
-            }
-
-            Ok((result, policy_context))
+            evaluate_all_of_rules(policy_context, rule_pointer).await
         }
+
         combine_behavior
             if combine_behavior == Some(&AccessPolicyv2CombineBehavior::NULL)
                 || combine_behavior == None =>
         {
-            if rule.rule.is_some() {
-                return Err(OperationOutcomeError::fatal(
-                    IssueType::INVALID,
-                    "Nested rules are not supported when combineBehavior is 'null' or unspecified."
-                        .to_string(),
-                ));
-            }
-
-            let result = evaluate_condition(policy_context, rule_pointer).await?;
-
-            Ok(result)
+            evaluate_leaf_rule(policy_context, rule_pointer).await
         }
         _ => Err(OperationOutcomeError::fatal(
             IssueType::INVALID,
             "Unsupported combineBehavior value.".to_string(),
         )),
     }
+}
+
+async fn evaluate_any_rules<
+    CTX: Send + Sync + Clone + 'static,
+    Client: FHIRClient<CTX, OperationOutcomeError> + Send + Sync + 'static,
+>(
+    mut policy_context: Arc<PolicyContext<CTX, Client>>,
+    rule_pointer: TypedPointer<AccessPolicyV2, AccessPolicyV2Rule>,
+) -> Result<PolicyResult<PermissionLevel, Arc<PolicyContext<CTX, Client>>>, OperationOutcomeError> {
+    let rule = rule_pointer
+        .value()
+        .ok_or(PDPError::PointerError(rule_pointer.path().to_string()))?;
+
+    if rule.condition.is_some() {
+        return Err(OperationOutcomeError::fatal(
+            IssueType::INVALID,
+            "Condition is not supported when combineBehavior is 'any'.".to_string(),
+        ));
+    }
+
+    let mut result = PermissionLevel::Deny;
+
+    for (index, _) in rule.rule.as_ref().unwrap_or(&vec![]).iter().enumerate() {
+        let nested_rule_pointer = get_nested_rule_pointer(&rule_pointer, index)?;
+
+        let (permission, next_context) = Box::pin(evaluate_access_policy_rule(
+            policy_context.clone(),
+            nested_rule_pointer,
+        ))
+        .await?;
+
+        result = get_max(&result, &permission)?;
+        policy_context = next_context;
+    }
+
+    Ok((result, policy_context))
+}
+
+async fn evaluate_all_of_rules<
+    CTX: Send + Sync + Clone + 'static,
+    Client: FHIRClient<CTX, OperationOutcomeError> + Send + Sync + 'static,
+>(
+    mut policy_context: Arc<PolicyContext<CTX, Client>>,
+    rule_pointer: TypedPointer<AccessPolicyV2, AccessPolicyV2Rule>,
+) -> Result<PolicyResult<PermissionLevel, Arc<PolicyContext<CTX, Client>>>, OperationOutcomeError> {
+    let rule = rule_pointer
+        .value()
+        .ok_or(PDPError::PointerError(rule_pointer.path().to_string()))?;
+
+    if rule.condition.is_some() {
+        return Err(OperationOutcomeError::fatal(
+            IssueType::INVALID,
+            "Condition is not supported when combineBehavior is 'allOf'.".to_string(),
+        ));
+    }
+
+    let mut result = PermissionLevel::Allow;
+
+    for (index, _) in rule.rule.as_ref().unwrap_or(&vec![]).iter().enumerate() {
+        let nested_rule_pointer = get_nested_rule_pointer(&rule_pointer, index)?;
+
+        let (permission, next_context) = Box::pin(evaluate_access_policy_rule(
+            policy_context.clone(),
+            nested_rule_pointer,
+        ))
+        .await?;
+
+        if permission == PermissionLevel::Deny {
+            return Ok((PermissionLevel::Deny, next_context));
+        }
+
+        result = get_min(&result, &permission)?;
+        policy_context = next_context;
+    }
+
+    Ok((result, policy_context))
+}
+
+async fn evaluate_leaf_rule<
+    CTX: Send + Sync + Clone + 'static,
+    Client: FHIRClient<CTX, OperationOutcomeError> + Send + Sync + 'static,
+>(
+    policy_context: Arc<PolicyContext<CTX, Client>>,
+    rule_pointer: TypedPointer<AccessPolicyV2, AccessPolicyV2Rule>,
+) -> Result<PolicyResult<PermissionLevel, Arc<PolicyContext<CTX, Client>>>, OperationOutcomeError> {
+    let rule = rule_pointer
+        .value()
+        .ok_or(PDPError::PointerError(rule_pointer.path().to_string()))?;
+
+    if rule.rule.is_some() {
+        return Err(OperationOutcomeError::fatal(
+            IssueType::INVALID,
+            "Nested rules are not supported when combineBehavior is 'null' or unspecified."
+                .to_string(),
+        ));
+    }
+
+    evaluate_condition(policy_context, rule_pointer).await
+}
+
+fn get_nested_rule_pointer(
+    rule_pointer: &TypedPointer<AccessPolicyV2, AccessPolicyV2Rule>,
+    index: usize,
+) -> Result<TypedPointer<AccessPolicyV2, AccessPolicyV2Rule>, PDPError> {
+    rule_pointer
+        .descend::<Vec<AccessPolicyV2Rule>>(&haste_pointer::Key::Field("rule".to_string()))
+        .and_then(|p| p.descend::<AccessPolicyV2Rule>(&haste_pointer::Key::Index(index)))
+        .ok_or_else(|| PDPError::PointerError(format!("{}/rule/{}", rule_pointer.path(), index)))
 }
 
 pub async fn evaluate<
@@ -330,23 +329,24 @@ pub async fn evaluate<
     policy: Arc<AccessPolicyV2>,
 ) -> Result<PermissionLevel, OperationOutcomeError> {
     let pointer = TypedPointer::<AccessPolicyV2, AccessPolicyV2>::new(policy.clone());
-    let rules_pointer = pointer
+
+    let rules_collection_pointer = pointer
         .descend::<Vec<AccessPolicyV2Rule>>(&haste_pointer::Key::Field("rule".to_string()))
         .ok_or_else(|| PDPError::PointerError("rule".to_string()))?;
 
     let mut result = PermissionLevel::Deny;
 
     for (index, _) in policy.rule.as_ref().unwrap_or(&vec![]).iter().enumerate() {
-        let rule_pointer = rules_pointer
+        let rule_pointer = rules_collection_pointer
             .descend::<AccessPolicyV2Rule>(&haste_pointer::Key::Index(index))
-            .ok_or_else(|| PDPError::PointerError(format!("{}/{}", rules_pointer.path(), index)))?;
+            .ok_or_else(|| {
+                PDPError::PointerError(format!("{}/{}", rules_collection_pointer.path(), index))
+            })?;
 
         match evaluate_access_policy_rule(policy_context.clone(), rule_pointer).await? {
             (PermissionLevel::Deny, _) => return Ok(PermissionLevel::Deny),
             (permission_level, context) => {
-                // Continue evaluating other rules
                 policy_context = context;
-
                 result = get_max(&result, &permission_level)?;
             }
         }

--- a/backend/crates/access-control/src/engine/rule_engine/pip.rs
+++ b/backend/crates/access-control/src/engine/rule_engine/pip.rs
@@ -2,7 +2,9 @@
 //! This module is responsible for retrieving contextual information that can be used during policy evaluation.
 use haste_fhir_client::{FHIRClient, url::ParsedParameters};
 use haste_fhir_model::r4::generated::{
-    resources::{AccessPolicyV2, AccessPolicyV2Attribute, ResourceType},
+    resources::{
+        AccessPolicyV2, AccessPolicyV2Attribute, AccessPolicyV2AttributeOperation, ResourceType,
+    },
     terminology::AccessPolicyAttributeOperationTypes,
 };
 use haste_fhir_operation_error::OperationOutcomeError;
@@ -20,12 +22,11 @@ fn find_attribute<'a>(
     access_policy.attribute.as_ref().and_then(|attributes| {
         attributes
             .iter()
-            .find(|a| a.attributeId.value.as_ref().map(|s| s.as_str()) == Some(variable_id))
+            .find(|a| a.attributeId.value.as_deref() == Some(variable_id))
     })
 }
 
 pub async fn pip<
-    'a,
     CTX: Sync + Send + Clone + 'static,
     Client: FHIRClient<CTX, OperationOutcomeError> + 'static,
 >(
@@ -33,194 +34,211 @@ pub async fn pip<
     pointer: TypedPointer<AccessPolicyV2, AccessPolicyV2>,
     variable_id: &str,
 ) -> Result<Option<ResolvedValue>, OperationOutcomeError> {
-    let root = pointer.clone();
-
     match variable_id {
         "request" => Ok(Some(ResolvedValue::Arc(
             policy_context.environment.request.clone() as Arc<dyn MetaValue>,
         ))),
+
         "user" => Ok(Some(ResolvedValue::Arc(
             policy_context.environment.user.clone() as Arc<dyn MetaValue>,
         ))),
-        _ => {
-            let access_policy = root.value().ok_or_else(|| {
-                OperationOutcomeError::fatal(
-                    haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                    "Pointer root does not contain an AccessPolicyV2 resource.".to_string(),
-                )
-            })?;
 
-            let Some(attribute) = find_attribute(access_policy, variable_id) else {
-                return Ok(None);
-            };
-
-            let Some(attribute_operation) = &attribute.operation else {
-                return Err(OperationOutcomeError::fatal(
-                    haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                    format!(
-                        "Attribute operation is not specified for attribute '{}'.",
-                        variable_id
-                    ),
-                ));
-            };
-
-            match &attribute_operation.type_ {
-                attribute_type if attribute_type == &AccessPolicyAttributeOperationTypes::READ => {
-                    let path_expression = attribute_operation.path.as_ref().ok_or_else(|| {
-                        OperationOutcomeError::fatal(
-                            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                            format!(
-                                "Attribute operation path is not specified for attribute '{}'.",
-                                variable_id
-                            ),
-                        )
-                    })?;
-
-                    let path =
-                        evaluate_to_string(policy_context.clone(), pointer, &path_expression)
-                            .await?;
-                    let reference_chunks = path.split("/").collect::<Vec<_>>();
-
-                    let [resource_type, id] = reference_chunks.as_slice() else {
-                        return Err(OperationOutcomeError::fatal(
-                            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                            format!(
-                                "Attribute operation path '{}' is not a valid resource path for attribute '{}'.",
-                                path, variable_id
-                            ),
-                        ));
-                    };
-
-                    let resource_type = ResourceType::try_from(*resource_type).map_err(|_| {
-                        OperationOutcomeError::fatal(
-                            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                            format!(
-                                "Resource type '{}' is not valid for attribute '{}'.",
-                                resource_type, variable_id
-                            ),
-                        )
-                    })?;
-
-                    let result = policy_context
-                        .client
-                        .read(
-                            policy_context.client_context.clone(),
-                            resource_type,
-                            id.to_string(),
-                        )
-                        .await?;
-
-                    Ok(Some(ResolvedValue::Box(
-                        Box::new(result) as Box<dyn MetaValue>
-                    )))
-                }
-                attribute_type
-                    if attribute_type == &AccessPolicyAttributeOperationTypes::SEARCH_SYSTEM =>
-                {
-                    let parameter_expression =
-                        attribute_operation.params.as_ref().ok_or_else(|| {
-                            OperationOutcomeError::fatal(
-                                haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                                format!(
-                                    "Attribute operation path is not specified for attribute '{}'.",
-                                    variable_id
-                                ),
-                            )
-                        })?;
-
-                    let parameters =
-                        evaluate_to_string(policy_context.clone(), pointer, &parameter_expression)
-                            .await?;
-
-                    let parsed_parameters = ParsedParameters::try_from(parameters.as_str())?;
-
-                    let result = policy_context
-                        .client
-                        .search_system(policy_context.client_context.clone(), parsed_parameters)
-                        .await?;
-
-                    Ok(Some(ResolvedValue::Box(
-                        Box::new(result) as Box<dyn MetaValue>
-                    )))
-                }
-                attribute_type
-                    if attribute_type == &AccessPolicyAttributeOperationTypes::SEARCH_TYPE =>
-                {
-                    let path_expression = attribute_operation.path.as_ref().ok_or_else(|| {
-                        OperationOutcomeError::fatal(
-                            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                            format!(
-                                "Attribute operation path is not specified for attribute '{}'.",
-                                variable_id
-                            ),
-                        )
-                    })?;
-
-                    let resource_type = evaluate_to_string(
-                        policy_context.clone(),
-                        pointer.clone(),
-                        &path_expression,
-                    )
-                    .await?;
-
-                    let resource_type =
-                        ResourceType::try_from(resource_type.as_str()).map_err(|_| {
-                            OperationOutcomeError::fatal(
-                                haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                                format!(
-                                    "Resource type '{}' is not valid for attribute '{}'.",
-                                    resource_type, variable_id
-                                ),
-                            )
-                        })?;
-
-                    let parameter_expression =
-                        attribute_operation.params.as_ref().ok_or_else(|| {
-                            OperationOutcomeError::fatal(
-                                haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                                format!(
-                                    "Attribute operation param is not specified for attribute '{}'.",
-                                    variable_id
-                                ),
-                            )
-                        })?;
-
-                    let parameters =
-                        evaluate_to_string(policy_context.clone(), pointer, &parameter_expression)
-                            .await?;
-
-                    let parsed_parameters = ParsedParameters::try_from(parameters.as_str())?;
-
-                    let result = policy_context
-                        .client
-                        .search_type(
-                            policy_context.client_context.clone(),
-                            resource_type,
-                            parsed_parameters,
-                        )
-                        .await?;
-
-                    Ok(Some(ResolvedValue::Box(
-                        Box::new(result) as Box<dyn MetaValue>
-                    )))
-                }
-                attribute_type if attribute_type == &AccessPolicyAttributeOperationTypes::NULL => {
-                    Err(OperationOutcomeError::fatal(
-                        haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                        format!(
-                            "Attribute operation type is not specified for attribute '{}'.",
-                            variable_id
-                        ),
-                    ))
-                }
-                _ => Err(OperationOutcomeError::fatal(
-                    haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
-                    format!(
-                        "Attribute operation type '{:?}' is not supported for attribute '{}'.",
-                        attribute_operation.type_, variable_id
-                    ),
-                )),
-            }
-        }
+        _ => evaluate_attribute(policy_context, pointer, variable_id).await,
     }
+}
+
+async fn evaluate_attribute<
+    CTX: Sync + Send + Clone + 'static,
+    Client: FHIRClient<CTX, OperationOutcomeError> + 'static,
+>(
+    policy_context: Arc<PolicyContext<CTX, Client>>,
+    pointer: TypedPointer<AccessPolicyV2, AccessPolicyV2>,
+    variable_id: &str,
+) -> Result<Option<ResolvedValue>, OperationOutcomeError> {
+    let access_policy = pointer.value().ok_or_else(|| {
+        OperationOutcomeError::fatal(
+            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+            "Pointer root does not contain an AccessPolicyV2 resource.".to_string(),
+        )
+    })?;
+
+    let Some(attribute) = find_attribute(access_policy, variable_id) else {
+        return Ok(None);
+    };
+
+    let Some(attribute_operation) = &attribute.operation else {
+        return Err(OperationOutcomeError::fatal(
+            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+            format!("Attribute operation is not specified for attribute '{variable_id}'."),
+        ));
+    };
+
+    match &attribute_operation.type_ {
+        attribute_type if attribute_type == &AccessPolicyAttributeOperationTypes::READ => {
+            evaluate_read(policy_context, &pointer, variable_id, attribute_operation).await
+        }
+
+        attribute_type if attribute_type == &AccessPolicyAttributeOperationTypes::SEARCH_SYSTEM => {
+            evaluate_search_system(policy_context, &pointer, variable_id, attribute_operation).await
+        }
+
+        attribute_type if attribute_type == &AccessPolicyAttributeOperationTypes::SEARCH_TYPE => {
+            evaluate_search_type(policy_context, &pointer, variable_id, attribute_operation).await
+        }
+
+        attribute_type if attribute_type == &AccessPolicyAttributeOperationTypes::NULL => {
+            Err(OperationOutcomeError::fatal(
+                haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+                format!("Attribute operation type is not specified for attribute '{variable_id}'."),
+            ))
+        }
+        _ => Err(OperationOutcomeError::fatal(
+            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+            format!(
+                "Attribute operation type '{:?}' is not supported for attribute '{}'.",
+                attribute_operation.type_, variable_id
+            ),
+        )),
+    }
+}
+
+async fn evaluate_read<
+    CTX: Sync + Send + Clone + 'static,
+    Client: FHIRClient<CTX, OperationOutcomeError> + 'static,
+>(
+    policy_context: Arc<PolicyContext<CTX, Client>>,
+    pointer: &TypedPointer<AccessPolicyV2, AccessPolicyV2>,
+    variable_id: &str,
+    operation: &AccessPolicyV2AttributeOperation,
+) -> Result<Option<ResolvedValue>, OperationOutcomeError> {
+    let path_expression = operation.path.as_ref().ok_or_else(|| {
+        OperationOutcomeError::fatal(
+            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+            format!("Attribute operation path is not specified for attribute '{variable_id}'."),
+        )
+    })?;
+
+    let path = evaluate_to_string(policy_context.clone(), pointer.clone(), path_expression).await?;
+
+    let reference_chunks = path.split('/').collect::<Vec<_>>();
+
+    let [resource_type, id] = reference_chunks.as_slice() else {
+        return Err(OperationOutcomeError::fatal(
+            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+            format!(
+                "Attribute operation path '{path}' is not a valid resource path for attribute '{variable_id}'."
+            ),
+        ));
+    };
+
+    let resource_type = ResourceType::try_from(*resource_type).map_err(|_| {
+        OperationOutcomeError::fatal(
+            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+            format!("Resource type '{resource_type}' is not valid for attribute '{variable_id}'."),
+        )
+    })?;
+
+    let result = policy_context
+        .client
+        .read(
+            policy_context.client_context.clone(),
+            resource_type,
+            (*id).to_string(),
+        )
+        .await?;
+
+    Ok(Some(ResolvedValue::Box(
+        Box::new(result) as Box<dyn MetaValue>
+    )))
+}
+
+async fn evaluate_search_system<
+    CTX: Sync + Send + Clone + 'static,
+    Client: FHIRClient<CTX, OperationOutcomeError> + 'static,
+>(
+    policy_context: Arc<PolicyContext<CTX, Client>>,
+    pointer: &TypedPointer<AccessPolicyV2, AccessPolicyV2>,
+    variable_id: &str,
+    operation: &AccessPolicyV2AttributeOperation,
+) -> Result<Option<ResolvedValue>, OperationOutcomeError> {
+    let parameter_expression = operation.params.as_ref().ok_or_else(|| {
+        OperationOutcomeError::fatal(
+            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+            format!("Attribute operation params are not specified for attribute '{variable_id}'."),
+        )
+    })?;
+
+    let parameters = evaluate_to_string(
+        policy_context.clone(),
+        pointer.clone(),
+        parameter_expression,
+    )
+    .await?;
+
+    let parsed_parameters = ParsedParameters::try_from(parameters.as_str())?;
+
+    let result = policy_context
+        .client
+        .search_system(policy_context.client_context.clone(), parsed_parameters)
+        .await?;
+
+    Ok(Some(ResolvedValue::Box(
+        Box::new(result) as Box<dyn MetaValue>
+    )))
+}
+
+async fn evaluate_search_type<
+    CTX: Sync + Send + Clone + 'static,
+    Client: FHIRClient<CTX, OperationOutcomeError> + 'static,
+>(
+    policy_context: Arc<PolicyContext<CTX, Client>>,
+    pointer: &TypedPointer<AccessPolicyV2, AccessPolicyV2>,
+    variable_id: &str,
+    operation: &AccessPolicyV2AttributeOperation,
+) -> Result<Option<ResolvedValue>, OperationOutcomeError> {
+    let path_expression = operation.path.as_ref().ok_or_else(|| {
+        OperationOutcomeError::fatal(
+            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+            format!("Attribute operation path is not specified for attribute '{variable_id}'."),
+        )
+    })?;
+
+    let resource_type =
+        evaluate_to_string(policy_context.clone(), pointer.clone(), path_expression).await?;
+
+    let resource_type = ResourceType::try_from(resource_type.as_str()).map_err(|_| {
+        OperationOutcomeError::fatal(
+            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+            format!("Resource type '{resource_type}' is not valid for attribute '{variable_id}'."),
+        )
+    })?;
+
+    let parameter_expression = operation.params.as_ref().ok_or_else(|| {
+        OperationOutcomeError::fatal(
+            haste_fhir_model::r4::generated::terminology::IssueType::INVALID,
+            format!("Attribute operation params are not specified for attribute '{variable_id}'."),
+        )
+    })?;
+
+    let parameters = evaluate_to_string(
+        policy_context.clone(),
+        pointer.clone(),
+        parameter_expression,
+    )
+    .await?;
+
+    let parsed_parameters = ParsedParameters::try_from(parameters.as_str())?;
+
+    let result = policy_context
+        .client
+        .search_type(
+            policy_context.client_context.clone(),
+            resource_type,
+            parsed_parameters,
+        )
+        .await?;
+
+    Ok(Some(ResolvedValue::Box(
+        Box::new(result) as Box<dyn MetaValue>
+    )))
 }

--- a/backend/crates/access-control/src/lib.rs
+++ b/backend/crates/access-control/src/lib.rs
@@ -12,8 +12,15 @@ mod engine;
 mod request_reflection;
 mod utilities;
 
+/// Evaluates an access policy using the configured policy engine.
+///
+/// # Errors
+///
+/// Returns an [`OperationOutcomeError`] when:
+/// - the policy engine denies access,
+/// - the rule engine fails while evaluating rules,
+/// - the policy contains an invalid or unsupported configuration.
 pub async fn evaluate_policy<
-    'a,
     CTX: Send + Sync + Clone + 'static,
     Client: FHIRClient<CTX, OperationOutcomeError> + Send + Sync + 'static,
 >(
@@ -22,7 +29,7 @@ pub async fn evaluate_policy<
 ) -> Result<PermissionLevel, OperationOutcomeError> {
     match &policy.engine {
         policy_engine if policy_engine == &AccessPolicyv2Engine::FULL_ACCESS => {
-            engine::full_access::evaluate(policy.as_ref()).await
+            Ok(engine::full_access::evaluate(policy.as_ref()))
         }
         policy_engine if policy_engine == &AccessPolicyv2Engine::RULE_ENGINE => {
             Ok(engine::rule_engine::pdp::evaluate(context, policy).await?)
@@ -40,39 +47,49 @@ pub async fn evaluate_policy<
     }
 }
 
-pub fn evaluate_policies<
+/// Evaluates a list of access policies and returns the updated policy context
+/// when access is granted.
+///
+/// Policies are evaluated in order. The first policy returning
+/// [`PermissionLevel::Allow`] grants access.
+///
+/// # Errors
+///
+/// Returns [`OperationOutcomeError`] when:
+/// - no policy grants access,
+/// - the evaluated policy returns an evaluation error,
+/// - the policy context cannot be recovered after granting access.
+pub async fn evaluate_policies<
     CTX: Send + Sync + Clone + 'static,
     Client: FHIRClient<CTX, OperationOutcomeError> + Send + Sync + 'static,
 >(
     context: context::PolicyContext<CTX, Client>,
     policies: &Vec<Arc<AccessPolicyV2>>,
-) -> impl Future<Output = Result<context::PolicyContext<CTX, Client>, OperationOutcomeError>> {
-    async move {
-        let mut outcomes = vec![];
-        let context = Arc::new(context);
+) -> Result<context::PolicyContext<CTX, Client>, OperationOutcomeError> {
+    let mut outcomes = vec![];
+    let context = Arc::new(context);
 
-        for policy in policies {
-            let result = evaluate_policy(context.clone(), policy.clone()).await;
-            if let Ok(permission) = result {
-                match permission {
-                    PermissionLevel::Allow => {
-                        return Arc::into_inner(context).ok_or_else(|| {
-                            OperationOutcomeError::error(
-                                IssueType::FORBIDDEN,
-                                "Failed to retrieve policy context.".to_string(),
-                            )
-                        });
-                    }
-                    _ => {}
+    for policy in policies {
+        let result = evaluate_policy(context.clone(), policy.clone()).await;
+        if let Ok(permission) = result {
+            match permission {
+                PermissionLevel::Allow => {
+                    return Arc::into_inner(context).ok_or_else(|| {
+                        OperationOutcomeError::error(
+                            IssueType::FORBIDDEN,
+                            "Failed to retrieve policy context.".to_string(),
+                        )
+                    });
                 }
-            } else if let Err(e) = result {
-                outcomes.push(e);
+                _ => {}
             }
+        } else if let Err(e) = result {
+            outcomes.push(e);
         }
-
-        Err(OperationOutcomeError::error(
-            IssueType::FORBIDDEN,
-            format!("No policy has granted access to your request."),
-        ))
     }
+
+    Err(OperationOutcomeError::error(
+        IssueType::FORBIDDEN,
+        format!("No policy has granted access to your request."),
+    ))
 }

--- a/backend/crates/access-control/src/request_reflection.rs
+++ b/backend/crates/access-control/src/request_reflection.rs
@@ -79,8 +79,8 @@ fn request_resource_type_string(fhir_request: &FHIRRequest) -> Option<String> {
 static SHARED_FIELDS: &[&str] = &["type", "level"];
 
 // Type codes pulled from https://hl7.org/fhir/R4/http.html
-///
-/// Instance Level Interactions
+//
+// Instance Level Interactions
 // read	Read the current state of the resource
 // vread	Read the state of a specific version of the resource
 // update	Update an existing resource by its id (or create it if it is new)
@@ -96,7 +96,6 @@ static SHARED_FIELDS: &[&str] = &["type", "level"];
 // batch/transaction	Update, create or delete a set of resources in a single interaction
 // history	Retrieve the change history for all resources
 // search	Search across all resource types based on some filter criteria
-
 fn request_to_request_type(request: &FHIRRequest) -> &'static str {
     match request {
         FHIRRequest::Create(_) => "create",
@@ -150,15 +149,9 @@ fn get_request_id(fhir_request: &FHIRRequest) -> Option<&String> {
     match fhir_request {
         FHIRRequest::Read(fhirread_request) => Some(&fhirread_request.id),
         FHIRRequest::VersionRead(fhirversion_read_request) => Some(&fhirversion_read_request.id),
-        FHIRRequest::Update(update_request) => match update_request {
-            UpdateRequest::Instance(instance) => Some(&instance.id),
-            _ => None,
-        },
+        FHIRRequest::Update(UpdateRequest::Instance(instance)) => Some(&instance.id),
         FHIRRequest::Patch(fhirpatch_request) => Some(&fhirpatch_request.id),
-        FHIRRequest::Delete(delete_request) => match delete_request {
-            DeleteRequest::Instance(instance) => Some(&instance.id),
-            _ => None,
-        },
+        FHIRRequest::Delete(DeleteRequest::Instance(instance)) => Some(&instance.id),
         FHIRRequest::Compartment(comp) => get_request_id(&comp.request),
         _ => None,
     }
@@ -173,36 +166,30 @@ impl MetaValue for RequestReflection {
         match field {
             "type" => Some(&self.1.request_type),
             "level" => Some(&self.1.request_level),
-            "resource_type" => {
-                if let Some(v) = self.1.resource_type.as_ref() {
-                    Some(v)
-                } else {
-                    None
-                }
-            }
+            "resource_type" => self.1.resource_type.as_ref().map(|v| v as &dyn MetaValue),
             "resource" => match &self.0 {
                 FHIRRequest::Create(fhircreate_request) => Some(&fhircreate_request.resource),
                 FHIRRequest::Batch(fhirbatch_request) => Some(&fhirbatch_request.resource),
                 FHIRRequest::Transaction(fhirtransaction_request) => {
                     Some(&fhirtransaction_request.resource)
                 }
-                FHIRRequest::Update(update_request) => match update_request {
-                    UpdateRequest::Conditional(conditional_update) => {
-                        Some(&conditional_update.resource)
-                    }
-                    UpdateRequest::Instance(instance_update) => Some(&instance_update.resource),
-                },
-                FHIRRequest::Invocation(invocation_request) => match invocation_request {
-                    InvocationRequest::Instance(invocation_request) => {
-                        Some(&invocation_request.parameters)
-                    }
-                    InvocationRequest::Type(invocation_request) => {
-                        Some(&invocation_request.parameters)
-                    }
-                    InvocationRequest::System(invocation_request) => {
-                        Some(&invocation_request.parameters)
-                    }
-                },
+
+                FHIRRequest::Update(UpdateRequest::Conditional(conditional_update)) => {
+                    Some(&conditional_update.resource)
+                }
+                FHIRRequest::Update(UpdateRequest::Instance(instance_update)) => {
+                    Some(&instance_update.resource)
+                }
+
+                FHIRRequest::Invocation(InvocationRequest::Instance(invocation_request)) => {
+                    Some(&invocation_request.parameters)
+                }
+                FHIRRequest::Invocation(InvocationRequest::Type(invocation_request)) => {
+                    Some(&invocation_request.parameters)
+                }
+                FHIRRequest::Invocation(InvocationRequest::System(invocation_request)) => {
+                    Some(&invocation_request.parameters)
+                }
                 FHIRRequest::Compartment(_)
                 | FHIRRequest::Read(_)
                 | FHIRRequest::VersionRead(_)
@@ -212,40 +199,27 @@ impl MetaValue for RequestReflection {
                 | FHIRRequest::Search(_)
                 | FHIRRequest::History(_) => None,
             },
-            "id" => {
-                if let Some(id) = get_request_id(&self.0) {
-                    Some(id)
-                } else {
-                    None
-                }
-            }
+            "id" => get_request_id(&self.0).map(|id| id as &dyn MetaValue),
             "parameters" => match &self.0 {
-                FHIRRequest::Search(search_request) => match search_request {
-                    SearchRequest::Type(type_search_request) => {
-                        Some(&type_search_request.parameters)
-                    }
-                    SearchRequest::System(system_search_request) => {
-                        Some(&system_search_request.parameters)
-                    }
-                },
-                FHIRRequest::Update(update_request) => match update_request {
-                    UpdateRequest::Conditional(conditional_update) => {
-                        Some(&conditional_update.parameters)
-                    }
-                    _ => None,
-                },
-                FHIRRequest::Delete(delete_request) => match delete_request {
-                    DeleteRequest::Type(type_delete_request) => {
-                        Some(&type_delete_request.parameters)
-                    }
-                    DeleteRequest::System(system_delete_request) => {
-                        Some(&system_delete_request.parameters)
-                    }
-                    _ => None,
-                },
+                FHIRRequest::Search(SearchRequest::Type(type_search_request)) => {
+                    Some(&type_search_request.parameters)
+                }
+                FHIRRequest::Search(SearchRequest::System(system_search_request)) => {
+                    Some(&system_search_request.parameters)
+                }
+
+                FHIRRequest::Update(UpdateRequest::Conditional(conditional_update)) => {
+                    Some(&conditional_update.parameters)
+                }
+
+                FHIRRequest::Delete(DeleteRequest::Type(type_delete_request)) => {
+                    Some(&type_delete_request.parameters)
+                }
+                FHIRRequest::Delete(DeleteRequest::System(system_delete_request)) => {
+                    Some(&system_delete_request.parameters)
+                }
                 _ => None,
             },
-
             _ => None,
         }
     }
@@ -254,11 +228,11 @@ impl MetaValue for RequestReflection {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.