### PR TITLE
Resolve last `clippy` lints in `access-control` crate

### DIFF
--- a/backend/crates/access-control/src/engine/rule_engine/pdp.rs
+++ b/backend/crates/access-control/src/engine/rule_engine/pdp.rs
@@ -202,7 +202,7 @@ async fn evaluate_access_policy_rule<
 
         combine_behavior
             if combine_behavior == Some(&AccessPolicyv2CombineBehavior::null())
-                || combine_behavior == None =>
+                || combine_behavior.is_none() =>
         {
             evaluate_leaf_rule(policy_context, rule_pointer).await
         }

--- a/backend/crates/access-control/src/lib.rs
+++ b/backend/crates/access-control/src/lib.rs
@@ -72,16 +72,13 @@ pub async fn evaluate_policies<
     for policy in policies {
         let result = evaluate_policy(context.clone(), policy.clone()).await;
         if let Ok(permission) = result {
-            match permission {
-                PermissionLevel::Allow => {
-                    return Arc::into_inner(context).ok_or_else(|| {
-                        OperationOutcomeError::error(
-                            IssueType::forbidden(),
-                            "Failed to retrieve policy context.".to_string(),
-                        )
-                    });
-                }
-                _ => {}
+            if permission == PermissionLevel::Allow {
+                return Arc::into_inner(context).ok_or_else(|| {
+                    OperationOutcomeError::error(
+                        IssueType::forbidden(),
+                        "Failed to retrieve policy context.".to_string(),
+                    )
+                });
             }
         } else if let Err(e) = result {
             outcomes.push(e);
@@ -90,6 +87,6 @@ pub async fn evaluate_policies<
 
     Err(OperationOutcomeError::error(
         IssueType::forbidden(),
-        format!("No policy has granted access to your request."),
+        "No policy has granted access to your request.".to_string(),
     ))
 }


### PR DESCRIPTION
After #834, these are the last `clippy` lints