### PR TITLE
Resolve `clippy` lints for `fhir-model` crate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
           -p haste-encryption \
           -p haste-fhir-client \
           -p haste-fhir-converter \
+          -p haste-fhir-model \
           -p haste-fhir-operation-error \
           -p haste-fhir-operation-error-derive \
           -p haste-fhir-ops \
@@ -58,7 +59,7 @@ jobs:
           -p haste-reflect-derive \
           -p haste-repository \
           -p haste-sd-to-json-schema \
-          # -p haste-sql-on-fhir \
+# -p haste-sql-on-fhir \
           -p haste-testscript-runner \
           -p haste-wal-worker \
           -p haste-worker \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,6 @@ jobs:
           -p haste-reflect-derive \
           -p haste-repository \
           -p haste-sd-to-json-schema \
-# -p haste-sql-on-fhir \
           -p haste-testscript-runner \
           -p haste-wal-worker \
           -p haste-worker \

--- a/backend/crates/fhir-model/src/lib.rs
+++ b/backend/crates/fhir-model/src/lib.rs
@@ -15,7 +15,6 @@ mod tests {
     };
     use haste_reflect::MetaValue;
     use r4::generated::{resources::Patient, types::Address};
-    use serde_json;
 
     #[test]
     fn test_enum_with_extension() {
@@ -61,7 +60,6 @@ mod tests {
                     "state": "CA",
                     "postalCode": "12345"
                 }]
-            
             }"#,
         );
 
@@ -219,7 +217,7 @@ mod tests {
 
         let address = serde_json::from_str::<Address>(address_string);
 
-        assert!(matches!(address, Err(_)));
+        assert!(address.is_err());
     }
 
     #[test]
@@ -414,11 +412,10 @@ mod tests {
             "John"
         );
 
-        assert_eq!(
+        assert!(
             patient.name.as_ref().unwrap()[0].given.as_ref().unwrap()[0]
                 .id
-                .is_none(),
-            true,
+                .is_none()
         );
 
         assert_eq!(
@@ -471,7 +468,7 @@ mod tests {
 
         let admin_gender = serde_json::from_str::<BoundCode<AdministrativeGender>>("\"male\"");
 
-        assert!(admin_gender.unwrap() == AdministrativeGender::male());
+        assert_eq!(admin_gender.unwrap(), AdministrativeGender::male());
     }
 
     #[test]
@@ -493,7 +490,7 @@ mod tests {
 
         let date = serde_json::from_str::<FHIRDate>("\"bad\"");
 
-        assert!(matches!(date, Err(_)));
+        assert!(date.is_err());
 
         let fhir_string = serde_json::from_str::<FHIRString>("\"hello\"");
 
@@ -550,16 +547,16 @@ mod tests {
         ));
 
         let invalid_fhir_positive_int = serde_json::from_str::<FHIRPositiveInt>("42.5");
-        assert!(matches!(invalid_fhir_positive_int, Err(_)));
+        assert!(invalid_fhir_positive_int.is_err());
 
         let invalid_positive_int = serde_json::from_str::<FHIRPositiveInt>("-1");
-        assert!(matches!(invalid_positive_int, Err(_)));
+        assert!(invalid_positive_int.is_err());
 
         let fhir_decimal = serde_json::from_str::<FHIRDecimal>("3.14");
         assert!(matches!(
             fhir_decimal,
             Ok(FHIRDecimal {
-                value: Some(3.14),
+                value: Some(std::f64::consts::PI),
                 id: None,
                 extension: None
             })
@@ -569,43 +566,43 @@ mod tests {
     #[test]
     fn test_cardinality() {
         let client_application_string = r#"{
-	    "id": "cli",
+        "id": "cli",
         "resourceType": "ClientApplication",
         "name": "CLI",
         "grantType": ["authorization_code"],
         "responseTypes": "token",
         "secret": "testing",
         "redirectUri": [
-          "http://localhost:8080/1", 
-          "http://localhost:8080/2", 
-          "http://localhost:8080/3", 
-          "http://localhost:8080/4", 
+          "http://localhost:8080/1",
+          "http://localhost:8080/2",
+          "http://localhost:8080/3",
+          "http://localhost:8080/4",
           "http://localhost:8080/5"],
         "scope": "openid system/*.*"
       }"#;
 
-        let client_app = serde_json::from_str::<ClientApplication>(&client_application_string);
+        let client_app = serde_json::from_str::<ClientApplication>(client_application_string);
 
         assert!(client_app.is_ok());
 
         let client_application_string = r#"{
-	    "id": "cli",
+        "id": "cli",
         "resourceType": "ClientApplication",
         "name": "CLI",
         "grantType": ["authorization_code"],
         "responseTypes": "token",
         "secret": "testing",
         "redirectUri": [
-          "http://localhost:8080/1", 
-          "http://localhost:8080/2", 
-          "http://localhost:8080/3", 
-          "http://localhost:8080/4", 
-          "http://localhost:8080/5", 
+          "http://localhost:8080/1",
+          "http://localhost:8080/2",
+          "http://localhost:8080/3",
+          "http://localhost:8080/4",
+          "http://localhost:8080/5",
           "http://localhost:8080/6"],
         "scope": "openid system/*.*"
       }"#;
 
-        let client_app = serde_json::from_str::<ClientApplication>(&client_application_string);
+        let client_app = serde_json::from_str::<ClientApplication>(client_application_string);
 
         assert!(client_app.is_err());
     }
@@ -620,7 +617,7 @@ mod tests {
         let patient =
             serde_json::from_str::<Patient>(patient).expect("failed to deserialize patient");
 
-        assert_eq!(patient.name.is_none(), true);
+        assert!(patient.name.is_none());
     }
 
     #[test]
@@ -632,7 +629,7 @@ mod tests {
         }"#;
         let patient = serde_json::from_str::<Patient>(patient).unwrap();
 
-        assert_eq!(patient.name.is_none(), true);
+        assert!(patient.name.is_none());
 
         let patient = r#"{
             "id": "",
@@ -646,11 +643,11 @@ mod tests {
             name.family
                 .as_ref()
                 .and_then(|s| s.value.as_ref())
-                .map(|s| s.as_str()),
+                .map(std::string::String::as_str),
             Some("test")
         );
-        assert_eq!(name.given.is_none(), true);
-        assert_eq!(name.prefix.is_none(), true);
+        assert!(name.given.is_none());
+        assert!(name.prefix.is_none());
 
         let patient = r#"{
             "id": "",
@@ -660,15 +657,9 @@ mod tests {
         let patient = serde_json::from_str::<Patient>(patient).unwrap();
         let name = patient.name.unwrap()[0].clone();
 
-        assert_eq!(
-            name.prefix.clone().unwrap()[0]
-                .value
-                .as_ref()
-                .map(|s| s.as_str()),
-            Some("mr")
-        );
-        assert_eq!(name.family.is_none(), true);
-        assert_eq!(name.given.is_none(), true);
+        assert_eq!(name.prefix.clone().unwrap()[0].value.as_deref(), Some("mr"));
+        assert!(name.family.is_none());
+        assert!(name.given.is_none());
     }
     #[test]
     fn serialize_typechoicie() {

--- a/backend/crates/fhir-model/src/lib.rs
+++ b/backend/crates/fhir-model/src/lib.rs
@@ -556,10 +556,10 @@ mod tests {
         assert!(matches!(
             fhir_decimal,
             Ok(FHIRDecimal {
-                value: Some(std::f64::consts::PI),
+                value: Some(value),
                 id: None,
                 extension: None
-            })
+            }) if (value - 3.14).abs() < f64::EPSILON
         ));
     }
 

--- a/backend/crates/fhir-model/src/r4/conversion.rs
+++ b/backend/crates/fhir-model/src/r4/conversion.rs
@@ -64,19 +64,28 @@ pub static STRING_TYPES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
 
 pub static PRIMITIVE_TYPES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     let mut res = BOOLEAN_TYPES.clone();
-    res.extend(NUMBER_TYPES.iter().map(|s| *s));
-    res.extend(DATE_TIME_TYPES.iter().map(|s| *s));
-    res.extend(STRING_TYPES.iter().map(|s| *s));
+    res.extend(NUMBER_TYPES.iter().copied());
+    res.extend(DATE_TIME_TYPES.iter().copied());
+    res.extend(STRING_TYPES.iter().copied());
 
     res
 });
 
+/// Downcasts a FHIR boolean value to a `bool`.
+///
+/// Supports both the FHIR primitive `boolean` type and the `FHIRPath`
+/// `System.Boolean` type.
+///
+/// # Errors
+///
+/// Returns [`DowncastError`] if `value` is not a supported boolean type or if
+/// the underlying value cannot be downcast to the expected concrete type.
 pub fn downcast_bool(value: &dyn MetaValue) -> Result<bool, DowncastError> {
     match value.fhir_type() {
         "http://hl7.org/fhirpath/System.Boolean" => value
             .as_any()
             .downcast_ref::<bool>()
-            .map(|v| *v)
+            .copied()
             .ok_or_else(|| DowncastError::FailedDowncast(value.fhir_type().to_string())),
         "boolean" => {
             let fp_bool = value
@@ -89,21 +98,41 @@ pub fn downcast_bool(value: &dyn MetaValue) -> Result<bool, DowncastError> {
     }
 }
 
+/// Downcasts a FHIR string value to a `String`.
+///
+/// Supports FHIR primitive string-based types (`canonical`, `base64Binary`,
+/// `code`, `string`, `oid`, `uri`, `url`, `uuid`, `id`, and `xhtml`) as well
+/// as the `FHIRPath` `System.String` type.
+///
+/// # Errors
+///
+/// Returns [`DowncastError`] if `value` is not a supported string type or if
+/// the underlying value cannot be downcast to the expected concrete type.
 pub fn downcast_string(value: &dyn MetaValue) -> Result<String, DowncastError> {
     match value.fhir_type() {
         "canonical" | "base64Binary" | "code" | "string" | "oid" | "uri" | "url" | "uuid"
-        | "id" | "xhtml" => downcast_string(value.get_field("value").unwrap_or(&"".to_string())),
+        | "id" | "xhtml" => downcast_string(value.get_field("value").unwrap_or(&String::new())),
 
         "http://hl7.org/fhirpath/System.String" => value
             .as_any()
             .downcast_ref::<String>()
-            .map(|v| v.clone())
+            .cloned()
             .ok_or_else(|| DowncastError::FailedDowncast(value.fhir_type().to_string())),
 
         type_name => Err(DowncastError::FailedDowncast(type_name.to_string())),
     }
 }
 
+/// Downcasts a FHIR numeric value to an `f64`.
+///
+/// Supports FHIR primitive numeric types (`integer`, `decimal`,
+/// `positiveInt`, and `unsignedInt`) as well as the corresponding `FHIRPath`
+/// system types.
+///
+/// # Errors
+///
+/// Returns [`DowncastError`] if `value` is not a supported numeric type or if
+/// the underlying value cannot be downcast to the expected concrete type.
 pub fn downcast_number(value: &dyn MetaValue) -> Result<f64, DowncastError> {
     match value.fhir_type() {
         "integer" => {
@@ -136,6 +165,7 @@ pub fn downcast_number(value: &dyn MetaValue) -> Result<f64, DowncastError> {
 
             downcast_number(fp_unsigned_int.value.as_ref().unwrap_or(&0))
         }
+        #[allow(clippy::cast_precision_loss)]
         "http://hl7.org/fhirpath/System.Integer" => value
             .as_any()
             .downcast_ref::<i64>()
@@ -145,17 +175,27 @@ pub fn downcast_number(value: &dyn MetaValue) -> Result<f64, DowncastError> {
         "http://hl7.org/fhirpath/System.Decimal" => value
             .as_any()
             .downcast_ref::<f64>()
-            .map(|v| *v)
+            .copied()
             .ok_or_else(|| DowncastError::FailedDowncast(value.fhir_type().to_string())),
         type_name => Err(DowncastError::FailedDowncast(type_name.to_string())),
     }
 }
 
+/// Downcasts a FHIR date/time value to its string representation.
+///
+/// Supports FHIR primitive `date`, `dateTime`, `instant`, and `time` values,
+/// as well as the corresponding `FHIRPath` system types.
+///
+/// # Errors
+///
+/// Returns [`DowncastError`] if `value` is not one of the supported date/time
+/// types or if the underlying value cannot be downcast to the expected concrete
+/// type.
 pub fn downcast_datetime(value: &dyn MetaValue) -> Result<String, DowncastError> {
     // For simplicity, we will just downcast to string for date and datetime types, as FHIRPath evaluation only requires string representation of dates.
     match value.fhir_type() {
         "date" | "dateTime" | "instant" | "time" => {
-            downcast_datetime(value.get_field("value").unwrap_or(&"".to_string()))
+            downcast_datetime(value.get_field("value").unwrap_or(&String::new()))
         }
         "http://hl7.org/fhirpath/System.Date" => {
             let fp_date = value

--- a/backend/crates/fhir-model/src/r4/datetime/mod.rs
+++ b/backend/crates/fhir-model/src/r4/datetime/mod.rs
@@ -1,4 +1,5 @@
 use regex::Regex;
+use std::fmt;
 use std::sync::LazyLock;
 
 mod reflect;
@@ -12,15 +13,19 @@ pub enum DateTime {
     Iso8601(chrono::DateTime<chrono::Utc>),
 }
 
-impl ToString for DateTime {
-    fn to_string(&self) -> String {
+impl fmt::Display for DateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DateTime::Year(year) => year.to_string(),
-            DateTime::YearMonth(year, month) => format!("{:04}-{:02}", year, month),
-            DateTime::YearMonthDay(year, month, day) => {
-                format!("{:04}-{:02}-{:02}", year, month, day)
+            DateTime::Year(year) => write!(f, "{year}"),
+            DateTime::YearMonth(year, month) => {
+                write!(f, "{year:04}-{month:02}")
             }
-            DateTime::Iso8601(dt) => dt.to_rfc3339(),
+            DateTime::YearMonthDay(year, month, day) => {
+                write!(f, "{year:04}-{month:02}-{day:02}")
+            }
+            DateTime::Iso8601(dt) => {
+                write!(f, "{}", dt.to_rfc3339())
+            }
         }
     }
 }
@@ -33,7 +38,7 @@ impl TryFrom<DateTime> for chrono::DateTime<chrono::Utc> {
             // "1996-12-19T16:39:57-08:00"
             DateTime::Year(year) => {
                 let datetime = chrono::DateTime::parse_from_rfc3339(
-                    format!("{}-01-01T00:00:00Z", year).as_str(),
+                    format!("{year}-01-01T00:00:00Z").as_str(),
                 )
                 .map_err(|_| ParseError::InvalidFormat)?;
 
@@ -41,7 +46,7 @@ impl TryFrom<DateTime> for chrono::DateTime<chrono::Utc> {
             }
             DateTime::YearMonth(year, month) => {
                 let datetime = chrono::DateTime::parse_from_rfc3339(
-                    format!("{}-{:02}-01T00:00:00Z", year, month).as_str(),
+                    format!("{year}-{month:02}-01T00:00:00Z").as_str(),
                 )
                 .map_err(|_| ParseError::InvalidFormat)?;
 
@@ -49,7 +54,7 @@ impl TryFrom<DateTime> for chrono::DateTime<chrono::Utc> {
             }
             DateTime::YearMonthDay(year, month, day) => {
                 let datetime = chrono::DateTime::parse_from_rfc3339(
-                    format!("{}-{:02}-{:02}T00:00:00Z", year, month, day).as_str(),
+                    format!("{year}-{month:02}-{day:02}T00:00:00Z").as_str(),
                 )
                 .map_err(|_| ParseError::InvalidFormat)?;
 
@@ -67,13 +72,15 @@ pub enum Date {
     YearMonthDay(u16, u8, u8),
 }
 
-impl ToString for Date {
-    fn to_string(&self) -> String {
+impl fmt::Display for Date {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Date::Year(year) => year.to_string(),
-            Date::YearMonth(year, month) => format!("{:04}-{:02}", year, month),
+            Date::Year(year) => write!(f, "{year}"),
+            Date::YearMonth(year, month) => {
+                write!(f, "{year:04}-{month:02}")
+            }
             Date::YearMonthDay(year, month, day) => {
-                format!("{:04}-{:02}-{:02}", year, month, day)
+                write!(f, "{year:04}-{month:02}-{day:02}")
             }
         }
     }
@@ -85,6 +92,7 @@ pub enum Instant {
 }
 
 impl Instant {
+    #[must_use]
     pub fn format(&self, fmt: &str) -> String {
         match self {
             Instant::Iso8601(dt) => dt.to_utc().format(fmt).to_string(),
@@ -92,10 +100,10 @@ impl Instant {
     }
 }
 
-impl ToString for Instant {
-    fn to_string(&self) -> String {
+impl fmt::Display for Instant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Instant::Iso8601(dt) => dt.to_rfc3339(),
+            Instant::Iso8601(dt) => write!(f, "{}", dt.to_rfc3339()),
         }
     }
 }
@@ -103,9 +111,9 @@ impl ToString for Instant {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Time(chrono::NaiveTime);
 
-impl ToString for Time {
-    fn to_string(&self) -> String {
-        self.0.format("%H:%M:%S%.f").to_string()
+impl fmt::Display for Time {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.format("%H:%M:%S%.f"))
     }
 }
 
@@ -136,6 +144,15 @@ pub static TIME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?$").unwrap()
 });
 
+/// Parses an FHIR instant string into an [`Instant`].
+///
+/// The input must conform to the FHIR instant format and contain a valid
+/// RFC 3339 timestamp.
+///
+/// # Errors
+///
+/// Returns [`ParseError::InvalidFormat`] if the input does not match the
+/// expected instant format or cannot be parsed as a valid RFC 3339 datetime.
 pub fn parse_instant(instant_string: &str) -> Result<Instant, ParseError> {
     if INSTANT_REGEX.is_match(instant_string) {
         let datetime = chrono::DateTime::parse_from_rfc3339(instant_string)
@@ -146,6 +163,15 @@ pub fn parse_instant(instant_string: &str) -> Result<Instant, ParseError> {
     }
 }
 
+/// Parses an FHIR time string into a [`Time`].
+///
+/// The input must conform to the FHIR time format and is parsed using the
+/// `HH:MM:SS` format with optional fractional seconds.
+///
+/// # Errors
+///
+/// Returns [`ParseError::InvalidFormat`] if the input does not match the
+/// expected time format or cannot be parsed as a valid time value.
 pub fn parse_time(time_string: &str) -> Result<Time, ParseError> {
     if TIME_REGEX.is_match(time_string) {
         let time = Time(
@@ -158,6 +184,24 @@ pub fn parse_time(time_string: &str) -> Result<Time, ParseError> {
     }
 }
 
+fn parse_u16(value: &str) -> Result<u16, ParseError> {
+    value.parse::<u16>().map_err(|_| ParseError::InvalidFormat)
+}
+
+fn parse_u8(value: &str) -> Result<u8, ParseError> {
+    value.parse::<u8>().map_err(|_| ParseError::InvalidFormat)
+}
+
+/// Parses an FHIR date/time string into a [`DateTime`].
+///
+/// Supports FHIR date precision levels including year, year-month, and
+/// year-month-day values, as well as full RFC 3339 date-time values.
+///
+/// # Errors
+///
+/// Returns [`ParseError::InvalidFormat`] if the input does not match a
+/// supported FHIR date/time format or cannot be parsed as a valid RFC 3339
+/// datetime.
 pub fn parse_datetime(datetime_string: &str) -> Result<DateTime, ParseError> {
     if let Some(captures) = DATETIME_REGEX.captures(datetime_string) {
         match (
@@ -166,24 +210,23 @@ pub fn parse_datetime(datetime_string: &str) -> Result<DateTime, ParseError> {
             captures.name("day"),
             captures.name("time"),
         ) {
-            (Some(year), None, None, None) => {
-                let year = year.as_str().parse::<u16>().unwrap();
-                Ok(DateTime::Year(year))
-            }
-            (Some(year), Some(month), None, None) => {
-                let year = year.as_str().parse::<u16>().unwrap();
-                let month = month.as_str().parse::<u8>().unwrap();
-                Ok(DateTime::YearMonth(year, month))
-            }
-            (Some(year), Some(month), Some(day), None) => {
-                let year = year.as_str().parse::<u16>().unwrap();
-                let month = month.as_str().parse::<u8>().unwrap();
-                let day = day.as_str().parse::<u8>().unwrap();
-                Ok(DateTime::YearMonthDay(year, month, day))
-            }
+            (Some(year), None, None, None) => Ok(DateTime::Year(parse_u16(year.as_str())?)),
+
+            (Some(year), Some(month), None, None) => Ok(DateTime::YearMonth(
+                parse_u16(year.as_str())?,
+                parse_u8(month.as_str())?,
+            )),
+
+            (Some(year), Some(month), Some(day), None) => Ok(DateTime::YearMonthDay(
+                parse_u16(year.as_str())?,
+                parse_u8(month.as_str())?,
+                parse_u8(day.as_str())?,
+            )),
+
             _ => {
                 let datetime = chrono::DateTime::parse_from_rfc3339(datetime_string)
                     .map_err(|_| ParseError::InvalidFormat)?;
+
                 Ok(DateTime::Iso8601(datetime.with_timezone(&chrono::Utc)))
             }
         }
@@ -192,6 +235,23 @@ pub fn parse_datetime(datetime_string: &str) -> Result<DateTime, ParseError> {
     }
 }
 
+fn parse_year(value: &str) -> Result<u16, ParseError> {
+    value.parse::<u16>().map_err(|_| ParseError::InvalidFormat)
+}
+
+fn parse_month_or_day(value: &str) -> Result<u8, ParseError> {
+    value.parse::<u8>().map_err(|_| ParseError::InvalidFormat)
+}
+
+/// Parses an FHIR date string into a [`Date`].
+///
+/// Supports FHIR date precision levels including year, year-month, and
+/// year-month-day values.
+///
+/// # Errors
+///
+/// Returns [`ParseError::InvalidFormat`] if the input does not match a
+/// supported FHIR date format or if any date component cannot be parsed.
 pub fn parse_date(date_string: &str) -> Result<Date, ParseError> {
     if let Some(captures) = DATE_REGEX.captures(date_string) {
         match (
@@ -199,21 +259,19 @@ pub fn parse_date(date_string: &str) -> Result<Date, ParseError> {
             captures.name("month"),
             captures.name("day"),
         ) {
-            (Some(year), None, None) => {
-                let year = year.as_str().parse::<u16>().unwrap();
-                Ok(Date::Year(year))
-            }
-            (Some(year), Some(month), None) => {
-                let year = year.as_str().parse::<u16>().unwrap();
-                let month = month.as_str().parse::<u8>().unwrap();
-                Ok(Date::YearMonth(year, month))
-            }
-            (Some(year), Some(month), Some(day)) => {
-                let year = year.as_str().parse::<u16>().unwrap();
-                let month = month.as_str().parse::<u8>().unwrap();
-                let day = day.as_str().parse::<u8>().unwrap();
-                Ok(Date::YearMonthDay(year, month, day))
-            }
+            (Some(year), None, None) => Ok(Date::Year(parse_year(year.as_str())?)),
+
+            (Some(year), Some(month), None) => Ok(Date::YearMonth(
+                parse_year(year.as_str())?,
+                parse_month_or_day(month.as_str())?,
+            )),
+
+            (Some(year), Some(month), Some(day)) => Ok(Date::YearMonthDay(
+                parse_year(year.as_str())?,
+                parse_month_or_day(month.as_str())?,
+                parse_month_or_day(day.as_str())?,
+            )),
+
             _ => Err(ParseError::InvalidFormat),
         }
     } else {
@@ -221,6 +279,7 @@ pub fn parse_date(date_string: &str) -> Result<Date, ParseError> {
     }
 }
 
+#[derive(Clone, Copy)]
 pub enum DateKind {
     DateTime,
     Date,
@@ -235,6 +294,20 @@ pub enum DateResult {
     Instant(Instant),
 }
 
+/// Parses an input string into a date-related value based on the provided
+/// [`DateKind`].
+///
+/// The parser delegates to the appropriate function depending on the requested
+/// kind:
+/// - [`DateKind::DateTime`] uses [`parse_datetime`].
+/// - [`DateKind::Date`] uses [`parse_date`].
+/// - [`DateKind::Time`] uses [`parse_time`].
+/// - [`DateKind::Instant`] uses [`parse_instant`].
+///
+/// # Errors
+///
+/// Returns [`ParseError`] if the input does not match the expected format for
+/// the requested [`DateKind`].
 pub fn parse(kind: DateKind, input: &str) -> Result<DateResult, ParseError> {
     match kind {
         DateKind::DateTime => Ok(DateResult::DateTime(parse_datetime(input)?)),

--- a/backend/crates/fhir-model/src/r4/datetime/reflect.rs
+++ b/backend/crates/fhir-model/src/r4/datetime/reflect.rs
@@ -11,7 +11,7 @@ impl MetaValue for Time {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -19,7 +19,7 @@ impl MetaValue for Time {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -48,7 +48,7 @@ impl MetaValue for DateTime {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -56,7 +56,7 @@ impl MetaValue for DateTime {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -85,7 +85,7 @@ impl MetaValue for Date {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -93,7 +93,7 @@ impl MetaValue for Date {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 
@@ -122,7 +122,7 @@ impl MetaValue for Instant {
         None
     }
 
-    fn get_index<'a>(&'a self, _index: usize) -> Option<&'a dyn MetaValue> {
+    fn get_index(&self, _index: usize) -> Option<&dyn MetaValue> {
         None
     }
 
@@ -130,7 +130,7 @@ impl MetaValue for Instant {
         None
     }
 
-    fn get_index_mut<'a>(&'a mut self, _index: usize) -> Option<&'a mut dyn MetaValue> {
+    fn get_index_mut(&mut self, _index: usize) -> Option<&mut dyn MetaValue> {
         None
     }
 

--- a/backend/crates/fhir-model/src/r4/sqlx.rs
+++ b/backend/crates/fhir-model/src/r4/sqlx.rs
@@ -37,7 +37,8 @@ where
 
 // More effecient impl to avoid cloning the value. No need to own as writing bytes and non mutating.
 pub struct FHIRJsonRef<'a, T: ?Sized>(pub &'a T);
-impl<'a, T> sqlx::Type<Postgres> for FHIRJsonRef<'a, T>
+
+impl<T> sqlx::Type<Postgres> for FHIRJsonRef<'_, T>
 where
     T: serde::Serialize + serde::de::DeserializeOwned,
 {
@@ -68,7 +69,7 @@ where
         buf.push(1);
 
         // the JSON data written to the buffer is the same regardless of parameter type
-        serde_json::to_writer(&mut **buf, &*self.0)?;
+        serde_json::to_writer(&mut **buf, self.0)?;
 
         Ok(IsNull::No)
     }
@@ -86,12 +87,12 @@ where
     }
 }
 
-impl<'r> Encode<'r, Postgres> for ResourceType {
+impl Encode<'_, Postgres> for ResourceType {
     fn encode_by_ref(
         &self,
         buf: &mut PgArgumentBuffer,
     ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-        buf.write(self.as_ref().as_bytes())?;
+        buf.write_all(self.as_ref().as_bytes())?;
         Ok(sqlx::encode::IsNull::No)
     }
 }


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.

This PR is currently in draft because there are lint issues in the `generated` directory that should be resolved through the `codegen` crate. I also added a GitHub Action to surface these lints. Below is a list of recurring lint issues that affect many generated structs:

- [ ] Use of wildcard import
```rust
error: usage of wildcard import
 --> crates/fhir-model/src/r4/generated/resources.rs:4:5
  |
4 | use self::super::types::*;
  |     ^^^^^^^^^^^^^^^^^^^^^ help: try: `self::super::types::{Expression, Element, FHIRId, FHIRString, Reference, Meta, FHIRUri, ContactPoint, FHIRBoolean, HumanName, Extension, FHIRPositiveInt, Period, FHIRCode, Narrative, Identifier, CodeableConcept, Timing, FHIRDateTime, Age, Range, Duration, ContactDetail, FHIRMarkdown, UsageContext, FHIRDate, RelatedArtifact, FHIRCanonical, Quantity, Dosage, Annotation, FHIRUnsignedInt, FHIRInstant, Coding, FHIRBase64Binary, FHIRDecimal, FHIRInteger, Attachment, Signature, FHIRUrl, Money, Address, FHIRTime, ProductShelfLife, ProdCharacteristic, TriggerDefinition, DataRequirement, Ratio, ParameterDefinition, MarketingStatus, Population, SampledData, FHIROid, FHIRUuid, Count, Distance, Contributor, ElementDefinition, SubstanceAmount}`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#wildcard_imports
  = note: `-D clippy::wildcard-imports` implied by `-D clippy::pedantic`
  = help: to override `-D clippy::pedantic` add `#[allow(clippy::wildcard_imports)]`
```

- [ ] Empty `[doc = ""]` attributes. These could be replaced with `fhir_type` for struct definitions while for struct fields with the corresponding field name
- [x] Defaults trait
```rust
error: `Box::new(_)` of default value
    --> crates/fhir-model/src/r4/generated/types.rs:3072:51
     |
3072 |         TriggerDefinitionTimingTypeChoice::Timing(Box::new(Default::default()))
     |                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#box_default

error: calling `Timing::default()` is more clear than this expression
    --> crates/fhir-model/src/r4/generated/types.rs:3072:60
     |
3072 |         TriggerDefinitionTimingTypeChoice::Timing(Box::new(Default::default()))
     |                                                            ^^^^^^^^^^^^^^^^^^ help: try: `Timing::default()`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#default_trait_access

error: `Box::new(_)` of default value
    --> crates/fhir-model/src/r4/generated/types.rs:3124:54
     |
3124 |         UsageContextValueTypeChoice::CodeableConcept(Box::new(Default::default()))
     |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#box_default

error: calling `CodeableConcept::default()` is more clear than this expression
    --> crates/fhir-model/src/r4/generated/types.rs:3124:63
     |
3124 |         UsageContextValueTypeChoice::CodeableConcept(Box::new(Default::default()))
     |                                                               ^^^^^^^^^^^^^^^^^^ help: try: `CodeableConcept::default()`
```
- [ ] Missing backticks for important keywords
```rust
error: item in documentation is missing backticks
    --> crates/fhir-model/src/r4/generated/types.rs:2101:195
     |
2101 | ...t element. ContentReferences bring across all the rules that are in the ElementDefinition for the element, including definitions, cardinality constraints, bindin...
     |                                                                            ^^^^^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#doc_markdown
help: try
     |
2101 -     #[doc = "Identifies an element defined elsewhere in the definition whose content rules should be applied to the current element. ContentReferences bring across all the rules that are in the ElementDefinition for the element, including definitions, cardinality constraints, bindings, invariants etc."]
2101 +     #[doc = "Identifies an element defined elsewhere in the definition whose content rules should be applied to the current element. ContentReferences bring across all the rules that are in the `ElementDefinition` for the element, including definitions, cardinality constraints, bindings, invariants etc."]
```
- [x] Field assignments outside of initializer
```rust
error: field assignment outside of initializer for an instance created with Default::default()
   --> crates/fhir-model/src/r4/generated/types.rs:583:9
    |
583 |         instance.value = Some(value);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: consider initializing the variable with `r4::generated::types::FHIRUnsignedInt { value: Some(value), ..Default::default() }` and removing relevant reassignments
   --> crates/fhir-model/src/r4/generated/types.rs:582:9
    |
582 |         let mut instance = Self::default();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#field_reassign_with_default
```
- [ ] Wrong markdown links
```rust
error: you should put bare URLs between `<`/`>` or make a proper Markdown link
      --> crates/fhir-model/src/r4/generated/terminology.rs:132859:10
       |
132859 | #[doc = "https://haste.health/fhir/ValueSet/SupportedFHIRVersion"]
       |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `<https://haste.health/fhir/ValueSet/SupportedFHIRVersion>`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#doc_markdown
```