### PR TITLE
Resolve some `clippy` lints for `codegen` crate

### DIFF
--- a/backend/crates/codegen/src/testscript_gen/mod.rs
+++ b/backend/crates/codegen/src/testscript_gen/mod.rs
@@ -1,7 +1,10 @@
+//! Generate typescripts for testscript test cases by providing
+//! `resource_files`.
+
 use std::path::Path;
 
-use crate::utilities::load;
-/// Generate typescripts for testscript test cases by providing resource_files.
+use walkdir::WalkDir;
+
 use haste_fhir_model::r4::generated::{
     resources::{
         Resource, TestScript, TestScriptFixture, TestScriptSetupActionAssert,
@@ -12,7 +15,8 @@ use haste_fhir_model::r4::generated::{
     types::{Coding, Meta, Reference},
 };
 use haste_reflect::MetaValue;
-use walkdir::WalkDir;
+
+use crate::utilities::load;
 
 fn file_path_to_resources(file_path: &Path) -> Result<Vec<Box<Resource>>, String> {
     let resource = load::load_from_file(file_path)?;
@@ -28,7 +32,7 @@ fn file_path_to_resources(file_path: &Path) -> Result<Vec<Box<Resource>>, String
     })
 }
 
-fn get_meta_mutable<'a>(resource: &'a mut Resource) -> Result<&'a mut Meta, String> {
+fn get_meta_mutable(resource: &mut Resource) -> Result<&mut Meta, String> {
     let meta: &mut dyn std::any::Any = resource
         .get_field_mut("meta")
         .ok_or("Missing Meta Field".to_string())?;
@@ -37,7 +41,7 @@ fn get_meta_mutable<'a>(resource: &'a mut Resource) -> Result<&'a mut Meta, Stri
         .ok_or("Failed to downcast meta".to_string())?;
 
     if meta.is_none() {
-        *meta = Some(Box::new(Meta::default()))
+        *meta = Some(Box::new(Meta::default()));
     }
 
     Ok(meta.as_mut().unwrap())
@@ -69,7 +73,7 @@ fn set_resource_id(id: &str, resource: &mut Resource) -> Result<(), String> {
 }
 
 fn fixture_name(i: usize, resource_type: &str) -> String {
-    format!("fixture-{}-{}", resource_type, i)
+    format!("fixture-{resource_type}-{i}")
 }
 
 fn generate_testcases_for_resource(
@@ -84,7 +88,7 @@ fn generate_testcases_for_resource(
 
     vec![TestScriptTest {
         name: Some(Box::new(
-            format!("Test for resource with tag: {}", tag).into(),
+            format!("Test for resource with tag: {tag}").into(),
         )),
         action: vec![
             TestScriptTestAction {
@@ -100,9 +104,7 @@ fn generate_testcases_for_resource(
                     })),
                     resource: defined_type.clone(),
                     sourceId: Some(Box::new(
-                        fixture_name(index, resource_type.as_ref())
-                            .to_string()
-                            .into(),
+                        fixture_name(index, resource_type.as_ref()).clone().into(),
                     )),
                     responseId: Some(Box::new(fixture_name(index, resource_type.as_ref()).into())),
                     encodeRequestUrl: Box::new(true.into()),
@@ -132,10 +134,7 @@ fn generate_testcases_for_resource(
     }]
 }
 
-fn generate_fixtures_for_resource(
-    testscript: &mut TestScript,
-    resources: Vec<Box<Resource>>,
-) -> Result<(), String> {
+fn generate_fixtures_for_resource(testscript: &mut TestScript, resources: Vec<Box<Resource>>) {
     let mut contained = vec![];
     let mut fixtures = vec![];
 
@@ -148,7 +147,7 @@ fn generate_fixtures_for_resource(
             autocreate: Box::new(false.into()),
             autodelete: Box::new(false.into()),
             resource: Some(Box::new(Reference {
-                reference: Some(Box::new(format!("#{}", fixture_id).into())),
+                reference: Some(Box::new(format!("#{fixture_id}").into())),
                 ..Default::default()
             })),
             ..Default::default()
@@ -158,17 +157,10 @@ fn generate_fixtures_for_resource(
 
     testscript.contained = Some(contained);
     testscript.fixture = Some(fixtures);
-
-    Ok(())
 }
 
 fn create_tag(file_path: &Path) -> String {
-    file_path
-        .to_str()
-        .unwrap()
-        .replace("/", "-")
-        .replace("\\", "-")
-        .replace(".", "-")
+    file_path.to_str().unwrap().replace(['/', '\\', '.'], "-")
 }
 
 fn generate_testscript_from_file(file_path: &Path) -> Result<TestScript, String> {
@@ -177,28 +169,27 @@ fn generate_testscript_from_file(file_path: &Path) -> Result<TestScript, String>
 
     let tag = create_tag(file_path);
 
-    testscript.url = Box::new(tag.to_string().into());
+    testscript.url = Box::new(tag.clone().into());
     testscript.status = PublicationStatus::active();
-    testscript.id = Some(tag.to_string());
-    testscript.name = Box::new(tag.to_string().into());
+    testscript.id = Some(tag.clone());
+    testscript.name = Box::new(tag.clone().into());
 
     for (i, resource) in resources.iter_mut().enumerate() {
         set_resource_tag(&tag, resource).expect("Failed to set resource tag");
         set_resource_id(
-            &fixture_name(i, &resource.resource_type().as_ref()),
+            &fixture_name(i, resource.resource_type().as_ref()),
             resource,
         )
         .expect("Failed to set resource id");
     }
 
-    generate_fixtures_for_resource(&mut testscript, resources.clone())?;
+    generate_fixtures_for_resource(&mut testscript, resources.clone());
 
     testscript.test = Some(
         resources
             .iter()
             .enumerate()
-            .map(|(i, r)| generate_testcases_for_resource(&tag, i, r))
-            .flatten()
+            .flat_map(|(i, r)| generate_testcases_for_resource(&tag, i, r))
             .collect::<Vec<_>>(),
     );
 
@@ -216,7 +207,7 @@ fn generate_testscript_from_file(file_path: &Path) -> Result<TestScript, String>
                 })),
                 encodeRequestUrl: Box::new(true.into()),
                 resource: None,
-                params: Some(Box::new(format!("_tag={}", tag).into())),
+                params: Some(Box::new(format!("_tag={tag}").into())),
                 description: Some(Box::new(
                     "Delete resources created in test.".to_string().into(),
                 )),
@@ -231,15 +222,21 @@ fn generate_testscript_from_file(file_path: &Path) -> Result<TestScript, String>
     Ok(testscript)
 }
 
-pub fn generate_testscripts(file_paths: &Vec<String>) -> Result<Vec<TestScript>, String> {
-    let mut testscripts = vec![];
+/// Generates test scripts from the provided file paths.
+///
+/// # Errors
+///
+/// Returns an error if a test script cannot be generated from a file.
+pub fn generate_testscripts(file_paths: &[String]) -> Result<Vec<TestScript>, String> {
+    let mut testscripts = Vec::new();
+
     for dir_path in file_paths {
         let walker = WalkDir::new(dir_path).sort_by_file_name().into_iter();
         for entry in walker
-            .filter_map(|e| e.ok())
-            .filter(|e| e.metadata().unwrap().is_file())
+            .filter_map(std::result::Result::ok)
+            .filter(|e| e.metadata().is_ok_and(|metadata| metadata.is_file()))
         {
-            let testscript = generate_testscript_from_file(&entry.path().to_path_buf())?;
+            let testscript = generate_testscript_from_file(entry.path())?;
             testscripts.push(testscript);
         }
     }

--- a/backend/crates/codegen/src/traversal.rs
+++ b/backend/crates/codegen/src/traversal.rs
@@ -1,25 +1,33 @@
 use haste_fhir_model::r4::generated::{resources::StructureDefinition, types::ElementDefinition};
 use regex::Regex;
 
+/// Returns the indices of the direct child elements of the element at `index`.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - `index` is out of bounds.
+/// - An element does not contain a path.
+/// - The child matching regular expression cannot be compiled.
 pub fn ele_index_to_child_indices(
     elements: &[Box<ElementDefinition>],
     index: usize,
 ) -> Result<Vec<usize>, String> {
     let parent = elements
         .get(index)
-        .ok_or_else(|| format!("Index {} out of bounds", index))?;
+        .ok_or_else(|| format!("Index {index} out of bounds"))?;
 
     let parent_path: String = parent
         .path
         .value
         .as_ref()
         .ok_or("Element has no path")?
-        .to_string();
+        .clone();
 
     let depth = parent_path.matches('.').count();
     let parent_path_escaped = parent_path.replace('.', "\\.");
-    let child_regex = Regex::new(&format!("^{}\\.[^.]+$", parent_path_escaped))
-        .map_err(|e| format!("Failed to compile regex: {}", e))?;
+    let child_regex = Regex::new(&format!("^{parent_path_escaped}\\.[^.]+$"))
+        .map_err(|e| format!("Failed to compile regex: {e}"))?;
 
     let mut cur_index = index + 1;
     let mut children_indices = Vec::new();
@@ -66,6 +74,13 @@ where
     ))
 }
 
+/// Traverses the elements of a [`StructureDefinition`] in bottom-up order.
+///
+/// The visitor function is called after all child elements have been traversed.
+///
+/// # Errors
+///
+/// Returns an error if the [`StructureDefinition`] does not contain a snapshot.
 pub fn traversal<'a, F, V>(sd: &'a StructureDefinition, visitor: &mut F) -> Result<V, String>
 where
     F: FnMut(&'a ElementDefinition, Vec<V>, usize) -> V,
@@ -101,17 +116,18 @@ mod tests {
             .as_ref()
             .unwrap()
             .iter()
-            .filter_map(|e| match e.resource.as_ref().map(|r| r.as_ref()) {
-                Some(Resource::StructureDefinition(sd)) => Some(sd),
-                _ => None,
-            })
+            .filter_map(
+                |e| match e.resource.as_ref().map(std::convert::AsRef::as_ref) {
+                    Some(Resource::StructureDefinition(sd)) => Some(sd),
+                    _ => None,
+                },
+            )
             .collect();
 
         let mut visitor =
             |element: &ElementDefinition, children: Vec<String>, _index: usize| -> String {
-                let path: String = element.path.value.as_ref().unwrap().to_string();
-                let result = children.join("\n") + "\n" + &path;
-                result
+                let path: String = element.path.value.as_ref().unwrap().clone();
+                children.join("\n") + "\n" + &path
             };
 
         println!("StructureDefinitions: {}", sds.len());
@@ -119,7 +135,7 @@ mod tests {
         for sd in sds {
             let result = traversal(sd, &mut visitor);
 
-            println!("Result: {:?}", result);
+            println!("Result: {result:?}");
         }
     }
 }

--- a/backend/crates/codegen/src/type_gen/operation_definitions.rs
+++ b/backend/crates/codegen/src/type_gen/operation_definitions.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, path::Path};
+use std::path::Path;
 
 use crate::utilities::{FHIR_PRIMITIVES, RUST_KEYWORDS, generate::capitalize, load};
 use haste_fhir_model::r4::generated::{
@@ -9,9 +9,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use walkdir::WalkDir;
 
-fn get_operation_definitions<'a>(
-    resource: &'a Resource,
-) -> Result<Vec<&'a OperationDefinition>, String> {
+fn get_operation_definitions(resource: &Resource) -> Result<Vec<&OperationDefinition>, String> {
     match resource {
         Resource::Bundle(bundle) => {
             if let Some(entries) = bundle.entry.as_ref() {
@@ -27,11 +25,7 @@ fn get_operation_definitions<'a>(
                 Ok(vec![])
             }
         }
-        Resource::OperationDefinition(op_def) => {
-            let op_def = op_def;
-
-            Ok(vec![op_def])
-        }
+        Resource::OperationDefinition(op_def) => Ok(vec![op_def]),
         _ => Err("Resource is not a Bundle or OperationDefinition".to_string()),
     }
 }
@@ -41,13 +35,7 @@ fn get_name(op_def: &OperationDefinition) -> String {
         .id
         .clone()
         .expect("Operation definition must have an id.");
-    let interface_name = id
-        .split("-")
-        .into_iter()
-        .map(|s| capitalize(s))
-        .collect::<Vec<String>>()
-        .join("");
-    interface_name
+    id.split('-').map(capitalize).collect::<String>()
 }
 
 fn create_field_value(type_: &str, is_array: bool, required: bool) -> TokenStream {
@@ -70,17 +58,15 @@ fn create_field_value(type_: &str, is_array: bool, required: bool) -> TokenStrea
         quote! {#type_}
     };
 
-    let type_ = if required {
+    if required {
         quote! { #type_ }
     } else {
         quote! {Option<#type_>}
-    };
-
-    type_
+    }
 }
 
 /// If param is return and type is a resource, you can return resource directly from field.
-fn is_resource_return(parameters: &Vec<&OperationDefinitionParameter>) -> bool {
+fn is_resource_return(parameters: &[&OperationDefinitionParameter]) -> bool {
     // Need special handling for single "return" parameter of type Any or a Resource type
     if parameters.len() == 1
         && parameters[0].name.value.as_deref() == Some("return")
@@ -97,102 +83,135 @@ fn is_resource_return(parameters: &Vec<&OperationDefinitionParameter>) -> bool {
 fn generate_parameter_type(
     name: &str,
     parameters: &Vec<&OperationDefinitionParameter>,
-    direction: &Direction,
     is_base: bool,
 ) -> Vec<TokenStream> {
-    let mut types = vec![];
+    let mut generated_types = vec![];
     let mut fields = vec![];
 
-    for p in parameters.iter() {
-        let is_array = p.max.value != Some("1".to_string());
-        let required = p.min.value.unwrap_or(0) > 0;
+    for p in parameters {
+        let (field_ident, attribute_rename) = process_field_names(p);
         let description = p
             .documentation
             .as_ref()
             .and_then(|d| d.value.clone())
             .unwrap_or_default();
-        let initial_field_name = p.name.value.as_ref().expect("Parameter must have a name");
-        let formatted_field_name = initial_field_name.replace("-", "_");
-
-        let field_ident = if RUST_KEYWORDS.contains(&formatted_field_name.as_str()) {
-            format_ident!("{}_", formatted_field_name)
-        } else {
-            format_ident!("{}", formatted_field_name)
-        };
-
-        let attribute_rename = if RUST_KEYWORDS.contains(&formatted_field_name.as_str())
-            || formatted_field_name != *initial_field_name
-        {
-            quote! {  #[parameter_rename=#initial_field_name] }
-        } else {
-            quote! {}
-        };
+        let is_array = p.max.value != Some("1".to_string());
+        let required = p.min.value.unwrap_or(0) > 0;
 
         if let Some(type_) = p.type_.as_ref() {
-            let type_ = if type_ == &AllTypes::any() {
-                AllTypes::resource()
+            // Handle parameters with primitive or base types
+            let type_str = if type_ == &AllTypes::any() {
+                "Resource"
             } else {
-                type_.clone()
+                type_.as_str().unwrap_or_default()
             };
-            let field = create_field_value(type_.as_str().unwrap_or_default(), is_array, required);
+            let field_type = create_field_value(type_str, is_array, required);
 
             fields.push(quote! {
                 #[doc = #description]
                 #attribute_rename
-                pub #field_ident: #field
-            })
+                pub #field_ident: #field_type
+            });
         } else {
-            let name = name.to_string()
-                + formatted_field_name
-                    .split("_")
-                    .map(|s| capitalize(s))
-                    .collect::<String>()
-                    .as_str();
+            // Handle nested parameters (sub-properties)
+            let nested_struct_name = format_nested_name(name, p);
             let nested_types = generate_parameter_type(
-                &name,
+                &nested_struct_name,
                 &p.part
                     .as_ref()
                     .map(|v| v.iter().collect())
                     .unwrap_or(vec![]),
-                direction,
                 false,
             );
-            types.extend(nested_types);
+            generated_types.extend(nested_types);
 
-            let type_ = create_field_value(&name, is_array, required);
+            let field_type = create_field_value(&nested_struct_name, is_array, required);
             fields.push(quote! {
                 #[doc = #description]
                 #attribute_rename
                 #[parameter_nested]
-                pub #field_ident: #type_
-            })
+                pub #field_ident: #field_type
+            });
         }
     }
 
+    let base_type = build_struct_tokens(name, parameters, &fields, is_base);
+    generated_types.push(base_type);
+
+    generated_types
+}
+
+/// Formats the field name and generates rename attributes, handling reserved Rust keywords.
+fn process_field_names(p: &OperationDefinitionParameter) -> (proc_macro2::Ident, TokenStream) {
+    let initial_name = p.name.value.as_ref().expect("Parameter must have a name");
+    let formatted_name = initial_name.replace('-', "_");
+
+    let field_ident = if RUST_KEYWORDS.contains(&formatted_name.as_str()) {
+        format_ident!("{}_", formatted_name)
+    } else {
+        format_ident!("{}", formatted_name)
+    };
+
+    let attribute_rename =
+        if RUST_KEYWORDS.contains(&formatted_name.as_str()) || formatted_name != *initial_name {
+            quote! { #[parameter_rename=#initial_name] }
+        } else {
+            quote! {}
+        };
+
+    (field_ident, attribute_rename)
+}
+
+/// Generates a deterministic nested struct name by combining parent and child names.
+fn format_nested_name(parent_name: &str, p: &OperationDefinitionParameter) -> String {
+    let initial_name = p.name.value.as_ref().expect("Parameter must have a name");
+    let formatted_name = initial_name.replace('-', "_");
+
+    let capitalized_parts = formatted_name
+        .split('_')
+        .map(capitalize)
+        .collect::<String>();
+
+    format!("{parent_name}{capitalized_parts}")
+}
+
+/// Constructs the final [`TokenStream`]
+/// (Struct definition and From trait implementation)
+/// by differentiating between base resource returns and standard parameter wraps.
+fn build_struct_tokens(
+    name: &str,
+    parameters: &Vec<&OperationDefinitionParameter>,
+    fields: &[TokenStream],
+    is_base: bool,
+) -> TokenStream {
     let struct_name = format_ident!("{}", name);
 
-    let base_parameter_type = if is_base && is_resource_return(parameters) {
-        let required = parameters.get(0).and_then(|p| p.min.value).unwrap_or(0) > 0;
-        let type_ = parameters
-            .get(0)
-            .and_then(|p| p.type_.as_ref().and_then(|v| v.as_str()))
+    if is_base && is_resource_return(parameters) {
+        let required = parameters.first().and_then(|p| p.min.value).unwrap_or(0) > 0;
+        let type_str = parameters
+            .first()
+            .and_then(|p| {
+                p.type_
+                    .as_ref()
+                    .and_then(haste_fhir_model::r4::generated::terminology::BoundCode::as_str)
+            })
             .unwrap_or_default();
 
-        let return_type = if type_ == "Any" { "Resource" } else { type_ };
+        let return_type = if type_str == "Any" {
+            "Resource"
+        } else {
+            type_str
+        };
         let return_type_ident = format_ident!("{}", return_type);
 
         let return_v = if required {
-            quote! {
-                value.return_
-            }
+            quote! { value.return_ }
         } else {
-            quote! {
-               value.return_.unwrap_or_default()
-            }
+            quote! { value.return_.unwrap_or_default() }
         };
 
         let returned_value = if return_type == "Resource" {
-            quote! {#return_v}
+            quote! { #return_v }
         } else {
             quote! { Resource::#return_type_ident(#return_v) }
         };
@@ -227,40 +246,25 @@ fn generate_parameter_type(
                 }
             }
         }
-    };
-
-    types.push(base_parameter_type);
-
-    types
+    }
 }
 
-fn generate_output(parameters: &Cow<Vec<OperationDefinitionParameter>>) -> Vec<TokenStream> {
+fn generate_output(parameters: &[OperationDefinitionParameter]) -> Vec<TokenStream> {
     let input_parameters = parameters
         .iter()
-        .filter(|p| match &p.use_ {
-            use_ if use_ == &OperationParameterUse::out() => true,
-            _ => false,
-        })
+        .filter(|p| matches!(&p.use_, use_ if use_ == &OperationParameterUse::out()))
         .collect::<Vec<_>>();
 
-    generate_parameter_type("Output", &input_parameters, &Direction::Output, true)
+    generate_parameter_type("Output", &input_parameters, true)
 }
 
-fn generate_input(parameters: &Cow<Vec<OperationDefinitionParameter>>) -> Vec<TokenStream> {
+fn generate_input(parameters: &[OperationDefinitionParameter]) -> Vec<TokenStream> {
     let input_parameters = parameters
         .iter()
-        .filter(|p| match &p.use_ {
-            use_ if use_ == &OperationParameterUse::in_() => true,
-            _ => false,
-        })
+        .filter(|p| matches!(&p.use_, use_ if use_ == &OperationParameterUse::in_()))
         .collect::<Vec<_>>();
 
-    generate_parameter_type("Input", &input_parameters, &Direction::Input, true)
-}
-
-enum Direction {
-    Input,
-    Output,
+    generate_parameter_type("Input", &input_parameters, true)
 }
 
 fn generate_operation_definition(file_path: &Path) -> Result<TokenStream, String> {
@@ -275,20 +279,17 @@ fn generate_operation_definition(file_path: &Path) -> Result<TokenStream, String
             .value
             .as_ref()
             .expect("Operation must have a code.");
-        let parameters = op_def
-            .parameter
-            .as_ref()
-            .map(Cow::Borrowed)
-            .unwrap_or(Cow::Owned(vec![]));
+        let parameters: &[OperationDefinitionParameter] =
+            op_def.parameter.as_deref().unwrap_or_default();
 
         let operation_description = op_def
             .description
             .as_ref()
             .and_then(|d| d.value.clone())
-            .unwrap_or("".to_string());
+            .unwrap_or_default();
 
-        let generate_input = generate_input(&parameters);
-        let generate_output = generate_output(&parameters);
+        let generate_input = generate_input(parameters);
+        let generate_output = generate_output(parameters);
 
         generated.extend(quote! {
             #[doc = #operation_description]
@@ -305,9 +306,13 @@ fn generate_operation_definition(file_path: &Path) -> Result<TokenStream, String
     Ok(generated)
 }
 
-pub fn generate_operation_definitions_from_files(
-    file_paths: &Vec<String>,
-) -> Result<String, String> {
+/// Generates operation definitions from JSON files in the provided directories.
+///
+/// # Errors
+///
+/// Returns an error if an operation definition cannot be generated from one of
+/// the input files.
+pub fn generate_operation_definitions_from_files(file_paths: &[String]) -> Result<String, String> {
     let mut generated_code = quote! {
         #![allow(non_snake_case)]
         use haste_fhir_ops::derive::{FromParameters, ToParameters};
@@ -320,21 +325,16 @@ pub fn generate_operation_definitions_from_files(
         let walker = WalkDir::new(dir_path).sort_by_file_name().into_iter();
 
         for entry in walker
-            .filter_map(|e| e.ok())
-            .filter(|e| e.metadata().unwrap().is_file())
-            .filter(|e| {
-                e.path()
-                    .extension()
-                    .map(|ext| ext == "json")
-                    .unwrap_or(false)
-            })
+            .filter_map(std::result::Result::ok)
+            .filter(|e| e.metadata().is_ok_and(|metadata| metadata.is_file()))
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
         {
             let generated_types = generate_operation_definition(entry.path())?;
 
             generated_code = quote! {
                 #generated_code
                 #generated_types
-            }
+            };
         }
     }
 

--- a/backend/crates/codegen/src/type_gen/rust_types/mod.rs
+++ b/backend/crates/codegen/src/type_gen/rust_types/mod.rs
@@ -11,6 +11,13 @@ pub struct GeneratedTypes {
     pub types: TokenStream,
 }
 
+/// Generates the Rust types for the provided FHIR definition files.
+///
+/// # Errors
+///
+/// Returns an [`OperationOutcomeError`] if:
+/// - terminology generation fails; or
+/// - data type generation fails.
 pub async fn generate(
     file_paths: &Vec<String>,
     level: Option<&'static str>,


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.