### PR TITLE
Guarantee order for file loading in codegen

### DIFF
--- a/backend/crates/codegen/src/testscript_gen/mod.rs
+++ b/backend/crates/codegen/src/testscript_gen/mod.rs
@@ -234,7 +234,7 @@ fn generate_testscript_from_file(file_path: &Path) -> Result<TestScript, String>
 pub fn generate_testscripts(file_paths: &Vec<String>) -> Result<Vec<TestScript>, String> {
     let mut testscripts = vec![];
     for dir_path in file_paths {
-        let walker = WalkDir::new(dir_path).into_iter();
+        let walker = WalkDir::new(dir_path).sort_by_file_name().into_iter();
         for entry in walker
             .filter_map(|e| e.ok())
             .filter(|e| e.metadata().unwrap().is_file())

--- a/backend/crates/codegen/src/type_gen/operation_definitions.rs
+++ b/backend/crates/codegen/src/type_gen/operation_definitions.rs
@@ -317,7 +317,7 @@ pub fn generate_operation_definitions_from_files(
     };
 
     for dir_path in file_paths {
-        let walker = WalkDir::new(dir_path).into_iter();
+        let walker = WalkDir::new(dir_path).sort_by_file_name().into_iter();
 
         for entry in walker
             .filter_map(|e| e.ok())

--- a/backend/crates/codegen/src/type_gen/rust_types/data_types.rs
+++ b/backend/crates/codegen/src/type_gen/rust_types/data_types.rs
@@ -719,7 +719,7 @@ pub fn generate(
     let mut resource_types: Vec<ResourceTypeInfo> = vec![];
 
     for dir_path in file_paths {
-        let walker = WalkDir::new(dir_path).into_iter();
+        let walker = WalkDir::new(dir_path).sort_by_file_name().into_iter();
         for entry in walker
             .filter_map(|e| e.ok())
             .filter(|e| e.metadata().unwrap().is_file())

--- a/backend/crates/codegen/src/type_gen/rust_types/terminology.rs
+++ b/backend/crates/codegen/src/type_gen/rust_types/terminology.rs
@@ -211,7 +211,7 @@ fn load_terminologies(
     resolver_data.insert(ResourceType::CodeSystem, BTreeMap::new());
 
     for dir_path in file_paths {
-        let walker = WalkDir::new(dir_path).into_iter();
+        let walker = WalkDir::new(dir_path).sort_by_file_name().into_iter();
         for entry in walker
             .filter_map(|e| e.ok())
             .filter(|e| e.metadata().unwrap().is_file())

--- a/backend/crates/fhir-generated-ops/src/generated.rs
+++ b/backend/crates/fhir-generated-ops/src/generated.rs
@@ -3,16 +3,18 @@ use haste_fhir_model::r4::generated::resources::*;
 use haste_fhir_model::r4::generated::types::*;
 use haste_fhir_operation_error::*;
 use haste_fhir_ops::derive::{FromParameters, ToParameters};
-#[doc = "This operation is used to return the current status information about one or more topic-based Subscriptions in R4."]
-pub mod BackportSubscriptionStatus {
+#[doc = "This operation is used to search for and return notifications that have been previously triggered by a topic-based Subscription in R4."]
+pub mod BackportSubscriptionEvents {
     use super::*;
-    pub const CODE: &str = "status";
+    pub const CODE: &str = "events";
     #[derive(Debug, FromParameters, ToParameters)]
     pub struct Input {
-        #[doc = "At the Instance level, this parameter is ignored.  At the Resource level, one or more parameters containing a FHIR id for a Subscription to get status information for. In the absence of any specified ids, the server returns the status for all Subscriptions available to the caller. Multiple values are joined via OR (e.g., \"id1\" OR \"id2\")."]
-        pub id: Option<Vec<FHIRId>>,
-        #[doc = "At the Instance level, this parameter is ignored. At the Resource level, a Subscription status to filter by (e.g., \"active\"). In the absence of any specified status values, the server does not filter contents based on the status. Multiple values are joined via OR (e.g., \"error\" OR \"off\")."]
-        pub status: Option<Vec<FHIRCode>>,
+        #[doc = "The starting event number, inclusive of this event (lower bound)."]
+        pub eventsSinceNumber: Option<FHIRString>,
+        #[doc = "The ending event number, inclusive of this event (upper bound)."]
+        pub eventsUntilNumber: Option<FHIRString>,
+        #[doc = "Requested content style of returned data. Codes from backport-content-value-set (e.g., empty, id-only, full-resource). This is a hint to the server what a client would prefer, and MAY be ignored."]
+        pub content: Option<FHIRCode>,
     }
     impl From<Input> for Resource {
         fn from(value: Input) -> Self {
@@ -25,7 +27,7 @@ pub mod BackportSubscriptionStatus {
     }
     #[derive(Debug, FromParameters)]
     pub struct Output {
-        #[doc = "The operation returns a bundle containing one or more subscription status resources, one per Subscription being queried. The Bundle type is \"searchset\"."]
+        #[doc = "The operation returns a valid notification bundle, with the first entry being the subscription status information resource. The bundle type is \"history\"."]
         #[parameter_rename = "return"]
         pub return_: Bundle,
     }
@@ -111,18 +113,16 @@ pub mod BackportSubscriptionResend {
         }
     }
 }
-#[doc = "This operation is used to search for and return notifications that have been previously triggered by a topic-based Subscription in R4."]
-pub mod BackportSubscriptionEvents {
+#[doc = "This operation is used to return the current status information about one or more topic-based Subscriptions in R4."]
+pub mod BackportSubscriptionStatus {
     use super::*;
-    pub const CODE: &str = "events";
+    pub const CODE: &str = "status";
     #[derive(Debug, FromParameters, ToParameters)]
     pub struct Input {
-        #[doc = "The starting event number, inclusive of this event (lower bound)."]
-        pub eventsSinceNumber: Option<FHIRString>,
-        #[doc = "The ending event number, inclusive of this event (upper bound)."]
-        pub eventsUntilNumber: Option<FHIRString>,
-        #[doc = "Requested content style of returned data. Codes from backport-content-value-set (e.g., empty, id-only, full-resource). This is a hint to the server what a client would prefer, and MAY be ignored."]
-        pub content: Option<FHIRCode>,
+        #[doc = "At the Instance level, this parameter is ignored.  At the Resource level, one or more parameters containing a FHIR id for a Subscription to get status information for. In the absence of any specified ids, the server returns the status for all Subscriptions available to the caller. Multiple values are joined via OR (e.g., \"id1\" OR \"id2\")."]
+        pub id: Option<Vec<FHIRId>>,
+        #[doc = "At the Instance level, this parameter is ignored. At the Resource level, a Subscription status to filter by (e.g., \"active\"). In the absence of any specified status values, the server does not filter contents based on the status. Multiple values are joined via OR (e.g., \"error\" OR \"off\")."]
+        pub status: Option<Vec<FHIRCode>>,
     }
     impl From<Input> for Resource {
         fn from(value: Input) -> Self {
@@ -135,13 +135,236 @@ pub mod BackportSubscriptionEvents {
     }
     #[derive(Debug, FromParameters)]
     pub struct Output {
-        #[doc = "The operation returns a valid notification bundle, with the first entry being the subscription status information resource. The bundle type is \"history\"."]
+        #[doc = "The operation returns a bundle containing one or more subscription status resources, one per Subscription being queried. The Bundle type is \"searchset\"."]
         #[parameter_rename = "return"]
         pub return_: Bundle,
     }
     impl From<Output> for Resource {
         fn from(value: Output) -> Self {
             Resource::Bundle(value.return_)
+        }
+    }
+}
+#[doc = "Get Project resource for the current project."]
+pub mod ProjectInformation {
+    use super::*;
+    pub const CODE: &str = "current-project";
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct Input {}
+    impl From<Input> for Resource {
+        fn from(value: Input) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
+        }
+    }
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct Output {
+        #[doc = "Users current project."]
+        pub project: Project,
+    }
+    impl From<Output> for Resource {
+        fn from(value: Output) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
+        }
+    }
+}
+#[doc = "Get tenant information for the current tenant."]
+pub mod TenantInformation {
+    use super::*;
+    pub const CODE: &str = "current-tenant";
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct Input {}
+    impl From<Input> for Resource {
+        fn from(value: Input) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
+        }
+    }
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct Output {
+        #[doc = "tenant id"]
+        pub id: FHIRString,
+        #[doc = "tenant subscription level"]
+        pub subscription: FHIRCode,
+    }
+    impl From<Output> for Resource {
+        fn from(value: Output) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
+        }
+    }
+}
+#[doc = "Get tenant endpoint information for the current tenant."]
+pub mod TenantEndpointInformation {
+    use super::*;
+    pub const CODE: &str = "endpoints";
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct Input {}
+    impl From<Input> for Resource {
+        fn from(value: Input) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
+        }
+    }
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct Output {
+        #[doc = "FHIR R4 Endpoint URL."]
+        #[parameter_rename = "fhir-r4-base-url"]
+        pub fhir_r4_base_url: FHIRUri,
+        #[doc = "FHIR R4 Capabilities URL."]
+        #[parameter_rename = "fhir-r4-capabilities-url"]
+        pub fhir_r4_capabilities_url: FHIRUri,
+        #[doc = "OIDC Discovery URL."]
+        #[parameter_rename = "oidc-discovery-url"]
+        pub oidc_discovery_url: FHIRUri,
+        #[doc = "OIDC Token Endpoint."]
+        #[parameter_rename = "oidc-token-endpoint"]
+        pub oidc_token_endpoint: FHIRUri,
+        #[doc = "OIDC Authorize Endpoint."]
+        #[parameter_rename = "oidc-authorize-endpoint"]
+        pub oidc_authorize_endpoint: FHIRUri,
+        #[doc = "OIDC JWKS Endpoint."]
+        #[parameter_rename = "oidc-jwks-endpoint"]
+        pub oidc_jwks_endpoint: FHIRUri,
+        #[doc = "Model context protocol endpoint."]
+        #[parameter_rename = "mcp-endpoint"]
+        pub mcp_endpoint: FHIRUri,
+    }
+    impl From<Output> for Resource {
+        fn from(value: Output) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
+        }
+    }
+}
+#[doc = "Evaluate an Access Policy."]
+pub mod HasteHealthEvaluatePolicy {
+    use super::*;
+    pub const CODE: &str = "evaluate-policy";
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct Input {
+        #[doc = "The user to evaluate the policy against. Defaults to logged in user if not present."]
+        pub user: Option<Reference>,
+        #[doc = "The requests to evaluate against the policy."]
+        pub request: Bundle,
+    }
+    impl From<Input> for Resource {
+        fn from(value: Input) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
+        }
+    }
+    #[derive(Debug, FromParameters)]
+    pub struct Output {
+        #[doc = "The result of the policy evaluation."]
+        #[parameter_rename = "return"]
+        pub return_: OperationOutcome,
+    }
+    impl From<Output> for Resource {
+        fn from(value: Output) -> Self {
+            Resource::OperationOutcome(value.return_)
+        }
+    }
+}
+#[doc = "Parse HL7v2 messages."]
+pub mod Hl7v2Parse {
+    use super::*;
+    pub const CODE: &str = "hl7v2-parse";
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct Input {
+        #[doc = "HL7v2 message to be parsed."]
+        pub hl7v2: FHIRString,
+    }
+    impl From<Input> for Resource {
+        fn from(value: Input) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
+        }
+    }
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct Output {
+        #[doc = "Parsed HL7v2 message."]
+        pub hl7v2: HL7V2,
+    }
+    impl From<Output> for Resource {
+        fn from(value: Output) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
+        }
+    }
+}
+#[doc = "Get the registration information for an identity provider."]
+pub mod HasteHealthIdpRegistrationInfo {
+    use super::*;
+    pub const CODE: &str = "registration-info";
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct Input {}
+    impl From<Input> for Resource {
+        fn from(value: Input) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
+        }
+    }
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct OutputInformation {
+        #[doc = "The name of the property."]
+        pub name: FHIRString,
+        #[doc = "the value of the property."]
+        pub value: FHIRString,
+    }
+    impl From<OutputInformation> for Resource {
+        fn from(value: OutputInformation) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
+        }
+    }
+    #[derive(Debug, FromParameters, ToParameters)]
+    pub struct Output {
+        #[doc = "IdentityProviders registration information."]
+        #[parameter_nested]
+        pub information: Option<Vec<OutputInformation>>,
+    }
+    impl From<Output> for Resource {
+        fn from(value: Output) -> Self {
+            let parameters: Vec<ParametersParameter> = value.into();
+            Resource::Parameters(Parameters {
+                parameter: Some(parameters),
+                ..Default::default()
+            })
         }
     }
 }
@@ -227,167 +450,6 @@ pub mod HasteHealthListRefreshTokens {
         }
     }
 }
-#[doc = "Parse HL7v2 messages."]
-pub mod Hl7v2Parse {
-    use super::*;
-    pub const CODE: &str = "hl7v2-parse";
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct Input {
-        #[doc = "HL7v2 message to be parsed."]
-        pub hl7v2: FHIRString,
-    }
-    impl From<Input> for Resource {
-        fn from(value: Input) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct Output {
-        #[doc = "Parsed HL7v2 message."]
-        pub hl7v2: HL7V2,
-    }
-    impl From<Output> for Resource {
-        fn from(value: Output) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-}
-#[doc = "Get tenant endpoint information for the current tenant."]
-pub mod TenantEndpointInformation {
-    use super::*;
-    pub const CODE: &str = "endpoints";
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct Input {}
-    impl From<Input> for Resource {
-        fn from(value: Input) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct Output {
-        #[doc = "FHIR R4 Endpoint URL."]
-        #[parameter_rename = "fhir-r4-base-url"]
-        pub fhir_r4_base_url: FHIRUri,
-        #[doc = "FHIR R4 Capabilities URL."]
-        #[parameter_rename = "fhir-r4-capabilities-url"]
-        pub fhir_r4_capabilities_url: FHIRUri,
-        #[doc = "OIDC Discovery URL."]
-        #[parameter_rename = "oidc-discovery-url"]
-        pub oidc_discovery_url: FHIRUri,
-        #[doc = "OIDC Token Endpoint."]
-        #[parameter_rename = "oidc-token-endpoint"]
-        pub oidc_token_endpoint: FHIRUri,
-        #[doc = "OIDC Authorize Endpoint."]
-        #[parameter_rename = "oidc-authorize-endpoint"]
-        pub oidc_authorize_endpoint: FHIRUri,
-        #[doc = "OIDC JWKS Endpoint."]
-        #[parameter_rename = "oidc-jwks-endpoint"]
-        pub oidc_jwks_endpoint: FHIRUri,
-        #[doc = "Model context protocol endpoint."]
-        #[parameter_rename = "mcp-endpoint"]
-        pub mcp_endpoint: FHIRUri,
-    }
-    impl From<Output> for Resource {
-        fn from(value: Output) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-}
-#[doc = "Get the registration information for an identity provider."]
-pub mod HasteHealthIdpRegistrationInfo {
-    use super::*;
-    pub const CODE: &str = "registration-info";
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct Input {}
-    impl From<Input> for Resource {
-        fn from(value: Input) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct OutputInformation {
-        #[doc = "The name of the property."]
-        pub name: FHIRString,
-        #[doc = "the value of the property."]
-        pub value: FHIRString,
-    }
-    impl From<OutputInformation> for Resource {
-        fn from(value: OutputInformation) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct Output {
-        #[doc = "IdentityProviders registration information."]
-        #[parameter_nested]
-        pub information: Option<Vec<OutputInformation>>,
-    }
-    impl From<Output> for Resource {
-        fn from(value: Output) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-}
-#[doc = "Evaluate an Access Policy."]
-pub mod HasteHealthEvaluatePolicy {
-    use super::*;
-    pub const CODE: &str = "evaluate-policy";
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct Input {
-        #[doc = "The user to evaluate the policy against. Defaults to logged in user if not present."]
-        pub user: Option<Reference>,
-        #[doc = "The requests to evaluate against the policy."]
-        pub request: Bundle,
-    }
-    impl From<Input> for Resource {
-        fn from(value: Input) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-    #[derive(Debug, FromParameters)]
-    pub struct Output {
-        #[doc = "The result of the policy evaluation."]
-        #[parameter_rename = "return"]
-        pub return_: OperationOutcome,
-    }
-    impl From<Output> for Resource {
-        fn from(value: Output) -> Self {
-            Resource::OperationOutcome(value.return_)
-        }
-    }
-}
 #[doc = "Delete scope from user accepted scopes for the client."]
 pub mod HasteHealthDeleteScope {
     use super::*;
@@ -456,68 +518,6 @@ pub mod HasteHealthListScopes {
         #[doc = "The result of the operation."]
         #[parameter_nested]
         pub scopes: Option<Vec<OutputScopes>>,
-    }
-    impl From<Output> for Resource {
-        fn from(value: Output) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-}
-#[doc = "Get Project resource for the current project."]
-pub mod ProjectInformation {
-    use super::*;
-    pub const CODE: &str = "current-project";
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct Input {}
-    impl From<Input> for Resource {
-        fn from(value: Input) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct Output {
-        #[doc = "Users current project."]
-        pub project: Project,
-    }
-    impl From<Output> for Resource {
-        fn from(value: Output) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-}
-#[doc = "Get tenant information for the current tenant."]
-pub mod TenantInformation {
-    use super::*;
-    pub const CODE: &str = "current-tenant";
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct Input {}
-    impl From<Input> for Resource {
-        fn from(value: Input) -> Self {
-            let parameters: Vec<ParametersParameter> = value.into();
-            Resource::Parameters(Parameters {
-                parameter: Some(parameters),
-                ..Default::default()
-            })
-        }
-    }
-    #[derive(Debug, FromParameters, ToParameters)]
-    pub struct Output {
-        #[doc = "tenant id"]
-        pub id: FHIRString,
-        #[doc = "tenant subscription level"]
-        pub subscription: FHIRCode,
     }
     impl From<Output> for Resource {
         fn from(value: Output) -> Self {
@@ -631,7 +631,8 @@ pub mod CapabilityStatementConforms {
         #[doc = "Outcome of the CapabilityStatement test"]
         pub issues: OperationOutcome,
         #[doc = "The intersection of the functionality described by the CapabilityStatement resources"]
-        pub union: Option<CapabilityStatement>,
+        #[parameter_rename = "union"]
+        pub union_: Option<CapabilityStatement>,
         #[doc = "The union of the functionality described by the CapabilityStatement resources"]
         pub intersection: Option<CapabilityStatement>,
     }

--- a/backend/crates/fhir-model/src/r4/generated/resources.rs
+++ b/backend/crates/fhir-model/src/r4/generated/resources.rs
@@ -15,155 +15,6 @@ use thiserror::Error;
 )]
 #[fhir_type = "BackboneElement"]
 #[fhir_serialize_type = "complex"]
-#[doc = "Registered client for the OIDC provider."]
-pub struct IdentityProviderOidcClient {
-    #[primitive]
-    #[doc = "Registered clients id."]
-    pub clientId: Box<FHIRString>,
-    #[primitive]
-    #[doc = "Registered clients secret."]
-    pub secret: Option<Box<FHIRString>>,
-}
-#[derive(
-    Clone,
-    Reflect,
-    Debug,
-    Default,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
-)]
-#[fhir_type = "BackboneElement"]
-#[fhir_serialize_type = "complex"]
-#[doc = "PKCE Configuration"]
-pub struct IdentityProviderOidcPkce {
-    #[primitive]
-    #[doc = "PKCE code challenge method."]
-    pub code_challenge_method:
-        Option<terminology::BoundCode<terminology::IdentityProviderPkceChallengeMethod>>,
-    #[primitive]
-    #[doc = "PKCE enabled."]
-    pub enabled: Option<Box<FHIRBoolean>>,
-}
-#[derive(
-    Clone,
-    Reflect,
-    Debug,
-    Default,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
-)]
-#[fhir_type = "BackboneElement"]
-#[fhir_serialize_type = "complex"]
-#[doc = "OIDC connection configuration for the identity provider."]
-pub struct IdentityProviderOidc {
-    #[primitive]
-    #[doc = "OIDC authorization endpoint."]
-    pub authorization_endpoint: Box<FHIRString>,
-    #[primitive]
-    #[doc = "OIDC token endpoint."]
-    pub token_endpoint: Box<FHIRString>,
-    #[primitive]
-    #[doc = "The OIDC user info endpoint."]
-    pub userinfo_endpoint: Option<Box<FHIRString>>,
-    #[primitive]
-    #[doc = "If included will verify id token based on this jwks keys."]
-    pub jwks_uri: Option<Box<FHIRString>>,
-    #[primitive]
-    #[doc = "Scopes to send to the OIDC provider."]
-    pub scopes: Option<Vec<Box<FHIRString>>>,
-    #[doc = "Registered client for the OIDC provider."]
-    pub client: IdentityProviderOidcClient,
-    #[doc = "PKCE Configuration"]
-    pub pkce: Option<IdentityProviderOidcPkce>,
-}
-#[derive(
-    Clone,
-    Reflect,
-    Debug,
-    Default,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
-)]
-#[fhir_type = "IdentityProvider"]
-#[fhir_serialize_type = "resource"]
-#[doc = "External identity provider configuration."]
-pub struct IdentityProvider {
-    #[doc = "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes."]
-    pub id: Option<String>,
-    #[doc = "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource."]
-    pub meta: Option<Box<Meta>>,
-    #[primitive]
-    #[doc = "The name of the external identity provider."]
-    pub name: Box<FHIRString>,
-    #[primitive]
-    #[doc = "The status of the identity provider."]
-    pub status: terminology::BoundCode<terminology::IdentityProviderStatus>,
-    #[primitive]
-    #[doc = "Method for connecting to external identity provider."]
-    pub accessType: terminology::BoundCode<terminology::IdentityProviderAccessType>,
-    #[doc = "OIDC connection configuration for the identity provider."]
-    pub oidc: Option<IdentityProviderOidc>,
-}
-#[derive(
-    Clone,
-    Reflect,
-    Debug,
-    Default,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
-)]
-#[fhir_type = "Membership"]
-#[fhir_serialize_type = "resource"]
-#[doc = ""]
-pub struct Membership {
-    #[doc = "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes."]
-    pub id: Option<String>,
-    #[doc = "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource."]
-    pub meta: Option<Box<Meta>>,
-    # [reference (targets = ["Patient" , "Practitioner" , "RelatedPerson" , "Person"])]
-    #[doc = ""]
-    pub link: Option<Box<Reference>>,
-    # [reference (targets = ["User"])]
-    #[doc = ""]
-    pub user: Box<Reference>,
-}
-#[derive(
-    Clone,
-    Reflect,
-    Debug,
-    Default,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
-)]
-#[fhir_type = "Project"]
-#[fhir_serialize_type = "resource"]
-#[doc = ""]
-pub struct Project {
-    #[doc = "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes."]
-    pub id: Option<String>,
-    #[doc = "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource."]
-    pub meta: Option<Box<Meta>>,
-    #[primitive]
-    #[doc = ""]
-    pub name: Box<FHIRString>,
-    #[primitive]
-    #[doc = ""]
-    pub fhirVersion: terminology::BoundCode<terminology::SupportedFhirVersion>,
-    #[cardinality(max = 3usize)]
-    # [reference (targets = ["IdentityProvider"])]
-    #[doc = ""]
-    pub identityProvider: Option<Vec<Box<Reference>>>,
-}
-#[derive(
-    Clone,
-    Reflect,
-    Debug,
-    Default,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
-    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
-)]
-#[fhir_type = "BackboneElement"]
-#[fhir_serialize_type = "complex"]
 #[doc = "The operation to retrieve the attribute."]
 pub struct AccessPolicyV2AttributeOperation {
     #[rename_field = "type"]
@@ -311,6 +162,60 @@ pub struct AccessPolicyV2 {
     haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
     haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
 )]
+#[fhir_type = "ClientApplication"]
+#[fhir_serialize_type = "resource"]
+#[doc = ""]
+pub struct ClientApplication {
+    #[doc = "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes."]
+    pub id: Option<String>,
+    #[doc = "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource."]
+    pub meta: Option<Box<Meta>>,
+    #[primitive]
+    #[doc = ""]
+    pub name: Box<FHIRString>,
+    #[primitive]
+    #[doc = ""]
+    pub description: Option<Box<FHIRString>>,
+    #[primitive]
+    #[cardinality(min = 1usize)]
+    #[doc = "The grant type for this client application."]
+    pub grantType: Vec<terminology::BoundCode<terminology::ClientapplicationGrantType>>,
+    #[primitive]
+    #[doc = ""]
+    pub responseTypes: terminology::BoundCode<terminology::ClientapplicationResponseTypes>,
+    #[primitive]
+    #[doc = "For client credentials (or other confidential authentication methods), the client secret."]
+    pub secret: Option<Box<FHIRString>>,
+    #[primitive]
+    #[cardinality(max = 5usize)]
+    #[doc = "Array of redirection URI strings for use in redirect-based flows such as the authorization code and implicit flows.  As required by Section 2 of OAuth 2.0 [RFC6749], clients using flows with redirection MUST register their redirection URI values. Authorization servers that support dynamic registration for redirect-based flows MUST implement support for this metadata value."]
+    pub redirectUri: Option<Vec<Box<FHIRString>>>,
+    #[primitive]
+    #[doc = ""]
+    pub uri: Option<Box<FHIRUri>>,
+    #[primitive]
+    #[doc = ""]
+    pub logoUri: Option<Box<FHIRUri>>,
+    #[primitive]
+    #[doc = ""]
+    pub scope: Option<Box<FHIRString>>,
+    #[doc = ""]
+    pub contact: Option<Box<ContactPoint>>,
+    #[primitive]
+    #[doc = ""]
+    pub tosUri: Option<Box<FHIRUri>>,
+    #[primitive]
+    #[doc = ""]
+    pub policyUri: Option<Box<FHIRUri>>,
+}
+#[derive(
+    Clone,
+    Reflect,
+    Debug,
+    Default,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
+)]
 #[fhir_type = "BackboneElement"]
 #[fhir_serialize_type = "complex"]
 #[doc = "The component when no sub-components are present."]
@@ -404,10 +309,132 @@ pub struct HL7V2 {
     haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
     haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
 )]
-#[fhir_type = "ClientApplication"]
+#[fhir_type = "BackboneElement"]
+#[fhir_serialize_type = "complex"]
+#[doc = "Registered client for the OIDC provider."]
+pub struct IdentityProviderOidcClient {
+    #[primitive]
+    #[doc = "Registered clients id."]
+    pub clientId: Box<FHIRString>,
+    #[primitive]
+    #[doc = "Registered clients secret."]
+    pub secret: Option<Box<FHIRString>>,
+}
+#[derive(
+    Clone,
+    Reflect,
+    Debug,
+    Default,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
+)]
+#[fhir_type = "BackboneElement"]
+#[fhir_serialize_type = "complex"]
+#[doc = "PKCE Configuration"]
+pub struct IdentityProviderOidcPkce {
+    #[primitive]
+    #[doc = "PKCE code challenge method."]
+    pub code_challenge_method:
+        Option<terminology::BoundCode<terminology::IdentityProviderPkceChallengeMethod>>,
+    #[primitive]
+    #[doc = "PKCE enabled."]
+    pub enabled: Option<Box<FHIRBoolean>>,
+}
+#[derive(
+    Clone,
+    Reflect,
+    Debug,
+    Default,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
+)]
+#[fhir_type = "BackboneElement"]
+#[fhir_serialize_type = "complex"]
+#[doc = "OIDC connection configuration for the identity provider."]
+pub struct IdentityProviderOidc {
+    #[primitive]
+    #[doc = "OIDC authorization endpoint."]
+    pub authorization_endpoint: Box<FHIRString>,
+    #[primitive]
+    #[doc = "OIDC token endpoint."]
+    pub token_endpoint: Box<FHIRString>,
+    #[primitive]
+    #[doc = "The OIDC user info endpoint."]
+    pub userinfo_endpoint: Option<Box<FHIRString>>,
+    #[primitive]
+    #[doc = "If included will verify id token based on this jwks keys."]
+    pub jwks_uri: Option<Box<FHIRString>>,
+    #[primitive]
+    #[doc = "Scopes to send to the OIDC provider."]
+    pub scopes: Option<Vec<Box<FHIRString>>>,
+    #[doc = "Registered client for the OIDC provider."]
+    pub client: IdentityProviderOidcClient,
+    #[doc = "PKCE Configuration"]
+    pub pkce: Option<IdentityProviderOidcPkce>,
+}
+#[derive(
+    Clone,
+    Reflect,
+    Debug,
+    Default,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
+)]
+#[fhir_type = "IdentityProvider"]
+#[fhir_serialize_type = "resource"]
+#[doc = "External identity provider configuration."]
+pub struct IdentityProvider {
+    #[doc = "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes."]
+    pub id: Option<String>,
+    #[doc = "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource."]
+    pub meta: Option<Box<Meta>>,
+    #[primitive]
+    #[doc = "The name of the external identity provider."]
+    pub name: Box<FHIRString>,
+    #[primitive]
+    #[doc = "The status of the identity provider."]
+    pub status: terminology::BoundCode<terminology::IdentityProviderStatus>,
+    #[primitive]
+    #[doc = "Method for connecting to external identity provider."]
+    pub accessType: terminology::BoundCode<terminology::IdentityProviderAccessType>,
+    #[doc = "OIDC connection configuration for the identity provider."]
+    pub oidc: Option<IdentityProviderOidc>,
+}
+#[derive(
+    Clone,
+    Reflect,
+    Debug,
+    Default,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
+)]
+#[fhir_type = "Membership"]
 #[fhir_serialize_type = "resource"]
 #[doc = ""]
-pub struct ClientApplication {
+pub struct Membership {
+    #[doc = "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes."]
+    pub id: Option<String>,
+    #[doc = "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource."]
+    pub meta: Option<Box<Meta>>,
+    # [reference (targets = ["Patient" , "Practitioner" , "RelatedPerson" , "Person"])]
+    #[doc = ""]
+    pub link: Option<Box<Reference>>,
+    # [reference (targets = ["User"])]
+    #[doc = ""]
+    pub user: Box<Reference>,
+}
+#[derive(
+    Clone,
+    Reflect,
+    Debug,
+    Default,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeSerialize,
+    haste_fhir_serialization_json :: derive :: FHIRSerdeDeserialize,
+)]
+#[fhir_type = "Project"]
+#[fhir_serialize_type = "resource"]
+#[doc = ""]
+pub struct Project {
     #[doc = "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes."]
     pub id: Option<String>,
     #[doc = "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource."]
@@ -417,38 +444,11 @@ pub struct ClientApplication {
     pub name: Box<FHIRString>,
     #[primitive]
     #[doc = ""]
-    pub description: Option<Box<FHIRString>>,
-    #[primitive]
-    #[cardinality(min = 1usize)]
-    #[doc = "The grant type for this client application."]
-    pub grantType: Vec<terminology::BoundCode<terminology::ClientapplicationGrantType>>,
-    #[primitive]
+    pub fhirVersion: terminology::BoundCode<terminology::SupportedFhirVersion>,
+    #[cardinality(max = 3usize)]
+    # [reference (targets = ["IdentityProvider"])]
     #[doc = ""]
-    pub responseTypes: terminology::BoundCode<terminology::ClientapplicationResponseTypes>,
-    #[primitive]
-    #[doc = "For client credentials (or other confidential authentication methods), the client secret."]
-    pub secret: Option<Box<FHIRString>>,
-    #[primitive]
-    #[cardinality(max = 5usize)]
-    #[doc = "Array of redirection URI strings for use in redirect-based flows such as the authorization code and implicit flows.  As required by Section 2 of OAuth 2.0 [RFC6749], clients using flows with redirection MUST register their redirection URI values. Authorization servers that support dynamic registration for redirect-based flows MUST implement support for this metadata value."]
-    pub redirectUri: Option<Vec<Box<FHIRString>>>,
-    #[primitive]
-    #[doc = ""]
-    pub uri: Option<Box<FHIRUri>>,
-    #[primitive]
-    #[doc = ""]
-    pub logoUri: Option<Box<FHIRUri>>,
-    #[primitive]
-    #[doc = ""]
-    pub scope: Option<Box<FHIRString>>,
-    #[doc = ""]
-    pub contact: Option<Box<ContactPoint>>,
-    #[primitive]
-    #[doc = ""]
-    pub tosUri: Option<Box<FHIRUri>>,
-    #[primitive]
-    #[doc = ""]
-    pub policyUri: Option<Box<FHIRUri>>,
+    pub identityProvider: Option<Vec<Box<Reference>>>,
 }
 #[derive(
     Clone,
@@ -29584,12 +29584,12 @@ pub struct ViewDefinition {
 #[fhir_serialize_type = "enum-variant"]
 #[serde(tag = "resourceType")]
 pub enum Resource {
+    AccessPolicyV2(AccessPolicyV2),
+    ClientApplication(ClientApplication),
+    HL7V2(HL7V2),
     IdentityProvider(IdentityProvider),
     Membership(Membership),
     Project(Project),
-    AccessPolicyV2(AccessPolicyV2),
-    HL7V2(HL7V2),
-    ClientApplication(ClientApplication),
     User(User),
     Account(Account),
     ActivityDefinition(ActivityDefinition),
@@ -29746,12 +29746,12 @@ impl Resource {
     }
     pub fn resource_type(&self) -> ResourceType {
         match self {
+            Resource::AccessPolicyV2(_) => ResourceType::AccessPolicyV2,
+            Resource::ClientApplication(_) => ResourceType::ClientApplication,
+            Resource::HL7V2(_) => ResourceType::HL7V2,
             Resource::IdentityProvider(_) => ResourceType::IdentityProvider,
             Resource::Membership(_) => ResourceType::Membership,
             Resource::Project(_) => ResourceType::Project,
-            Resource::AccessPolicyV2(_) => ResourceType::AccessPolicyV2,
-            Resource::HL7V2(_) => ResourceType::HL7V2,
-            Resource::ClientApplication(_) => ResourceType::ClientApplication,
             Resource::User(_) => ResourceType::User,
             Resource::Account(_) => ResourceType::Account,
             Resource::ActivityDefinition(_) => ResourceType::ActivityDefinition,
@@ -29914,12 +29914,12 @@ impl Resource {
     }
     pub fn id<'a>(&'a self) -> &'a Option<String> {
         match self {
+            Resource::AccessPolicyV2(r) => &r.id,
+            Resource::ClientApplication(r) => &r.id,
+            Resource::HL7V2(r) => &r.id,
             Resource::IdentityProvider(r) => &r.id,
             Resource::Membership(r) => &r.id,
             Resource::Project(r) => &r.id,
-            Resource::AccessPolicyV2(r) => &r.id,
-            Resource::HL7V2(r) => &r.id,
-            Resource::ClientApplication(r) => &r.id,
             Resource::User(r) => &r.id,
             Resource::Account(r) => &r.id,
             Resource::ActivityDefinition(r) => &r.id,
@@ -30080,12 +30080,12 @@ pub enum ResourceTypeError {
     Debug, Clone, PartialEq, Eq, Hash, serde :: Deserialize, serde :: Serialize, PartialOrd, Ord,
 )]
 pub enum ResourceType {
+    AccessPolicyV2,
+    ClientApplication,
+    HL7V2,
     IdentityProvider,
     Membership,
     Project,
-    AccessPolicyV2,
-    HL7V2,
-    ClientApplication,
     User,
     Account,
     ActivityDefinition,
@@ -30241,6 +30241,15 @@ impl ResourceType {
         data: &str,
     ) -> Result<Resource, haste_fhir_serialization_json::errors::DeserializeError> {
         match self {
+            ResourceType::AccessPolicyV2 => Ok(Resource::AccessPolicyV2(serde_json::from_str::<
+                AccessPolicyV2,
+            >(data)?)),
+            ResourceType::ClientApplication => {
+                Ok(Resource::ClientApplication(serde_json::from_str::<
+                    ClientApplication,
+                >(data)?))
+            }
+            ResourceType::HL7V2 => Ok(Resource::HL7V2(serde_json::from_str::<HL7V2>(data)?)),
             ResourceType::IdentityProvider => {
                 Ok(Resource::IdentityProvider(serde_json::from_str::<
                     IdentityProvider,
@@ -30250,15 +30259,6 @@ impl ResourceType {
                 serde_json::from_str::<Membership>(data)?,
             )),
             ResourceType::Project => Ok(Resource::Project(serde_json::from_str::<Project>(data)?)),
-            ResourceType::AccessPolicyV2 => Ok(Resource::AccessPolicyV2(serde_json::from_str::<
-                AccessPolicyV2,
-            >(data)?)),
-            ResourceType::HL7V2 => Ok(Resource::HL7V2(serde_json::from_str::<HL7V2>(data)?)),
-            ResourceType::ClientApplication => {
-                Ok(Resource::ClientApplication(serde_json::from_str::<
-                    ClientApplication,
-                >(data)?))
-            }
             ResourceType::User => Ok(Resource::User(serde_json::from_str::<User>(data)?)),
             ResourceType::Account => Ok(Resource::Account(serde_json::from_str::<Account>(data)?)),
             ResourceType::ActivityDefinition => {
@@ -30783,12 +30783,12 @@ impl ResourceType {
 impl AsRef<str> for ResourceType {
     fn as_ref(&self) -> &str {
         match self {
+            ResourceType::AccessPolicyV2 => "AccessPolicyV2",
+            ResourceType::ClientApplication => "ClientApplication",
+            ResourceType::HL7V2 => "HL7V2",
             ResourceType::IdentityProvider => "IdentityProvider",
             ResourceType::Membership => "Membership",
             ResourceType::Project => "Project",
-            ResourceType::AccessPolicyV2 => "AccessPolicyV2",
-            ResourceType::HL7V2 => "HL7V2",
-            ResourceType::ClientApplication => "ClientApplication",
             ResourceType::User => "User",
             ResourceType::Account => "Account",
             ResourceType::ActivityDefinition => "ActivityDefinition",
@@ -30944,12 +30944,12 @@ impl TryFrom<String> for ResourceType {
     type Error = ResourceTypeError;
     fn try_from(s: String) -> Result<Self, Self::Error> {
         match s.as_str() {
+            "AccessPolicyV2" => Ok(ResourceType::AccessPolicyV2),
+            "ClientApplication" => Ok(ResourceType::ClientApplication),
+            "HL7V2" => Ok(ResourceType::HL7V2),
             "IdentityProvider" => Ok(ResourceType::IdentityProvider),
             "Membership" => Ok(ResourceType::Membership),
             "Project" => Ok(ResourceType::Project),
-            "AccessPolicyV2" => Ok(ResourceType::AccessPolicyV2),
-            "HL7V2" => Ok(ResourceType::HL7V2),
-            "ClientApplication" => Ok(ResourceType::ClientApplication),
             "User" => Ok(ResourceType::User),
             "Account" => Ok(ResourceType::Account),
             "ActivityDefinition" => Ok(ResourceType::ActivityDefinition),
@@ -31110,12 +31110,12 @@ impl TryFrom<&str> for ResourceType {
     type Error = ResourceTypeError;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
+            "AccessPolicyV2" => Ok(ResourceType::AccessPolicyV2),
+            "ClientApplication" => Ok(ResourceType::ClientApplication),
+            "HL7V2" => Ok(ResourceType::HL7V2),
             "IdentityProvider" => Ok(ResourceType::IdentityProvider),
             "Membership" => Ok(ResourceType::Membership),
             "Project" => Ok(ResourceType::Project),
-            "AccessPolicyV2" => Ok(ResourceType::AccessPolicyV2),
-            "HL7V2" => Ok(ResourceType::HL7V2),
-            "ClientApplication" => Ok(ResourceType::ClientApplication),
             "User" => Ok(ResourceType::User),
             "Account" => Ok(ResourceType::Account),
             "ActivityDefinition" => Ok(ResourceType::ActivityDefinition),


### PR DESCRIPTION
Platforms can load files in different order with walkdir. This can Guarantee determinism across platforms for codegen by sorting files according to name.