### PR TITLE
Resolve `clippy` lints for `artifacts` crate

### DIFF
--- a/backend/crates/artifacts/src/lib.rs
+++ b/backend/crates/artifacts/src/lib.rs
@@ -2,19 +2,19 @@ use haste_fhir_model::r4::generated::resources::{Resource, SearchParameter};
 use rust_embed::Embed;
 use std::{collections::HashMap, sync::LazyLock};
 
-fn flatten_if_bundle(resource: Resource) -> Vec<Box<Resource>> {
+fn flatten_if_bundle(resource: Resource) -> Vec<Resource> {
     match resource {
         Resource::Bundle(bundle) => bundle
             .entry
-            .unwrap_or(vec![])
+            .unwrap_or_default()
             .into_iter()
-            .flat_map(|e| e.resource)
-            .collect::<Vec<_>>(),
-        _ => vec![Box::new(resource)],
+            .filter_map(|e| e.resource.map(|r| *r))
+            .collect(),
+        _ => vec![resource],
     }
 }
 
-fn load_resources() -> Vec<Box<Resource>> {
+fn load_resources() -> Vec<Resource> {
     let mut resources = HashMap::new();
 
     for path in EmbededResourceAssets::iter() {
@@ -22,7 +22,7 @@ fn load_resources() -> Vec<Box<Resource>> {
         let resource = serde_json::from_str::<Resource>(str::from_utf8(&data.data).unwrap())
             .expect("Failed to parse artifact parameters JSON");
 
-        flatten_if_bundle(resource).into_iter().for_each(|r| {
+        for r in flatten_if_bundle(resource) {
             let resource_type = r.resource_type();
             let id = r.id().clone().unwrap_or_else(|| {
                 panic!("Resource in '{}' does not have an ID", path.as_ref());
@@ -33,14 +33,14 @@ fn load_resources() -> Vec<Box<Resource>> {
             if resources.contains_key(&key) {
                 println!(
                     "Duplicate resource ID '{}' '{}' found in '{}'",
-                    &key.0.as_ref(),
-                    &key.1,
+                    key.0.as_ref(),
+                    key.1,
                     path.as_ref()
                 );
             }
 
             resources.insert(key, r);
-        });
+        }
     }
 
     resources.into_values().collect()
@@ -54,32 +54,32 @@ fn load_resources() -> Vec<Box<Resource>> {
 #[include = "r4/r4-to-r5-subscription-backport/**/*.json"]
 struct EmbededResourceAssets;
 
-pub static ARTIFACT_RESOURCES: LazyLock<Vec<Box<Resource>>> = LazyLock::new(|| load_resources());
+pub static ARTIFACT_RESOURCES: LazyLock<Vec<Resource>> = LazyLock::new(load_resources);
 
 #[derive(Embed)]
 #[folder = "./artifacts/r4"]
 #[include = "haste_health/search_parameter/*.json"]
 #[include = "hl7/minified/search-parameters.min.json"]
-
 struct EmbededSearchParameterAssets;
 
 /// System level Search Parameters. These are used for all tenants and projects and are loaded from embedded assets at startup.
-pub static R4_SEARCH_PARAMETERS: LazyLock<Vec<Box<SearchParameter>>> = LazyLock::new(|| {
-    let mut search_parameters = vec![];
+pub static R4_SEARCH_PARAMETERS: LazyLock<Vec<SearchParameter>> =
+    LazyLock::new(|| {
+        let mut search_parameters = Vec::new();
 
-    for path in EmbededSearchParameterAssets::iter() {
-        let data = EmbededSearchParameterAssets::get(path.as_ref()).unwrap();
-        let bundle = serde_json::from_str::<Resource>(std::str::from_utf8(&data.data).unwrap())
-            .expect("Failed to parse search parameters JSON");
+        for path in EmbededSearchParameterAssets::iter() {
+            let data = EmbededSearchParameterAssets::get(path.as_ref()).unwrap();
 
-        search_parameters.extend(flatten_if_bundle(bundle).into_iter().filter_map(|r| {
-            if let Resource::SearchParameter(param) = *r {
-                Some(Box::new(param))
-            } else {
-                None
-            }
-        }));
-    }
+            let bundle = serde_json::from_str::<Resource>(std::str::from_utf8(&data.data).unwrap())
+                .expect("Failed to parse search parameters JSON");
 
-    search_parameters
-});
+            search_parameters.extend(flatten_if_bundle(bundle).into_iter().filter_map(
+                |resource| match resource {
+                    Resource::SearchParameter(param) => Some(param),
+                    _ => None,
+                },
+            ));
+        }
+
+        search_parameters
+    });

--- a/backend/crates/fhir-search/src/memory/mod.rs
+++ b/backend/crates/fhir-search/src/memory/mod.rs
@@ -163,7 +163,7 @@ pub static R4_SEARCH_PARAMETERS_INDEX: LazyLock<Arc<SearchParametersIndex>> = La
         &ParameterLevel::System,
         R4_SEARCH_PARAMETERS
             .iter()
-            .map(|param| param.as_ref().clone())
+            .map(|param| param.clone())
             .collect(),
     ))
 });

--- a/backend/crates/server/src/fhir_client/compartment.rs
+++ b/backend/crates/server/src/fhir_client/compartment.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, LazyLock};
 static COMPARTMENTS: LazyLock<Vec<&'static CompartmentDefinition>> = LazyLock::new(|| {
     ARTIFACT_RESOURCES
         .iter()
-        .filter_map(|r| match r.as_ref() {
+        .filter_map(|r| match r {
             Resource::CompartmentDefinition(c) => Some(c),
             _ => None,
         })

--- a/backend/crates/server/src/load_artifacts.rs
+++ b/backend/crates/server/src/load_artifacts.rs
@@ -168,12 +168,12 @@ async fn _load_artifacts<Client: FHIRClient<Arc<ServerCTX<Client>>, OperationOut
         let sha_hash = generate_sha256_hash(*&resource);
         hashes.insert(sha_hash);
 
-        match &**resource {
+        match &resource {
             Resource::SearchParameter(_)
             | Resource::CodeSystem(_)
             | Resource::ValueSet(_)
             | Resource::StructureDefinition(_) => {
-                let mut resource = (**resource).clone();
+                let mut resource = resource.clone();
                 let resource_type = get_resource_type(&resource);
                 let id = get_id(&resource);
                 let sha_hash = generate_sha256_hash(&resource);


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.