### PR TITLE
Resolve `clippy` lints for `config` crate

### DIFF
--- a/backend/crates/config/src/environment.rs
+++ b/backend/crates/config/src/environment.rs
@@ -1,7 +1,8 @@
-use crate::Config;
 use haste_fhir_operation_error::{OperationOutcomeError, derive::OperationOutcomeError};
 
-pub struct EnvironmentConfig();
+use crate::Config;
+
+pub struct EnvironmentConfig;
 
 #[derive(OperationOutcomeError, Debug)]
 pub enum EnvironmentConfigError {
@@ -15,12 +16,12 @@ pub enum EnvironmentConfigError {
 }
 
 impl EnvironmentConfig {
-    pub fn new(config_files: &[&str]) -> Result<Self, OperationOutcomeError> {
+    pub fn new(config_files: &[&str]) -> Self {
         for file in config_files {
             let _file_result = dotenvy::from_filename(file).map_err(EnvironmentConfigError::from);
         }
 
-        Ok(EnvironmentConfig())
+        EnvironmentConfig
     }
 }
 
@@ -31,6 +32,7 @@ impl<Key: Into<String>> Config<Key> for EnvironmentConfig {
             .map_err(|e| EnvironmentConfigError::EnvironmentVariableNotSet(e, key_string))?;
         Ok(k)
     }
+
     fn set(&self, key: Key, value: String) -> Result<(), OperationOutcomeError> {
         unsafe {
             std::env::set_var(key.into(), value);

--- a/backend/crates/config/src/lib.rs
+++ b/backend/crates/config/src/lib.rs
@@ -5,10 +5,22 @@ use std::sync::Arc;
 mod environment;
 
 pub trait Config<Key: Into<String>>: Send + Sync {
+    /// Gets the value of an environment configuration variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OperationOutcomeError`] if the environment variable is not set
+    /// or cannot be read.
     fn get(&self, name: Key) -> Result<String, OperationOutcomeError>;
+    /// Sets the value of an environment configuration variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OperationOutcomeError`] if setting the variable fails.
     fn set(&self, name: Key, value: String) -> Result<(), OperationOutcomeError>;
 }
 
+#[derive(Clone, Copy)]
 pub enum ConfigType {
     Environment,
 }
@@ -22,10 +34,9 @@ impl From<&str> for ConfigType {
     }
 }
 
+#[must_use]
 pub fn get_config<Key: Into<String>>(config_type: ConfigType) -> Arc<dyn Config<Key>> {
     match config_type {
-        ConfigType::Environment => {
-            Arc::new(EnvironmentConfig::new(&[".env", ".env.development"]).unwrap())
-        }
+        ConfigType::Environment => Arc::new(EnvironmentConfig::new(&[".env", ".env.development"])),
     }
 }


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.