### PR TITLE
Resolve more `clippy` lints for `fhir-client`

### DIFF
--- a/backend/crates/fhir-client/src/http.rs
+++ b/backend/crates/fhir-client/src/http.rs
@@ -8,10 +8,9 @@ use crate::{
         FHIRHistoryInstanceRequest, FHIRHistorySystemRequest, FHIRHistoryTypeRequest,
         FHIRInvokeInstanceRequest, FHIRInvokeSystemRequest, FHIRInvokeTypeRequest,
         FHIRPatchRequest, FHIRPatchResponse, FHIRReadRequest, FHIRReadResponse, FHIRRequest,
-        FHIRResponse, FHIRResponseRequest, FHIRSearchSystemRequest, FHIRSearchTypeRequest,
-        FHIRTransactionRequest, FHIRUpdateInstanceRequest, FHIRVersionReadRequest, HistoryRequest,
-        HistoryResponse, InvocationRequest, InvokeResponse, Operation, SearchRequest,
-        SearchResponse, UpdateRequest,
+        FHIRResponse, FHIRSearchSystemRequest, FHIRSearchTypeRequest, FHIRTransactionRequest,
+        FHIRUpdateInstanceRequest, FHIRVersionReadRequest, HistoryRequest, HistoryResponse,
+        InvocationRequest, InvokeResponse, Operation, SearchRequest, SearchResponse, UpdateRequest,
     },
     url::{ParsedParameter, ParsedParameters},
 };
@@ -174,29 +173,17 @@ fn fhir_request_to_http_request<'a>(
     Box::pin(async move {
         let request = match request {
             FHIRRequest::Read(request) => request_from_read(state, request),
-
             FHIRRequest::Compartment(request) => request_from_compartment(state, request).await,
-
             FHIRRequest::Create(request) => request_from_create(state, request),
-
             FHIRRequest::Patch(request) => request_from_patch(state, request),
-
             FHIRRequest::Transaction(request) => request_from_transaction(state, request),
-
             FHIRRequest::VersionRead(request) => request_from_version_read(state, request),
-
             FHIRRequest::Update(request) => request_from_update(state, request),
-
             FHIRRequest::Search(request) => request_from_search(state, request),
-
             FHIRRequest::Delete(request) => request_from_delete(state, request),
-
             FHIRRequest::Capabilities => request_from_capabilities(state),
-
             FHIRRequest::History(request) => request_from_history(state, request),
-
             FHIRRequest::Invocation(request) => request_from_invocation(state, request),
-
             FHIRRequest::Batch(request) => request_from_batch(state, request),
         };
 
@@ -591,12 +578,47 @@ fn request_from_invocation_system(
     build_post(state, request_url, body)
 }
 
+enum FHIRResponseRequest<'a> {
+    Read,
+    Create,
+    Patch,
+    Transaction,
+    VersionRead,
+    Update(&'a UpdateRequest),
+    Delete(&'a DeleteRequest),
+    Capabilities,
+    Search(&'a SearchRequest),
+    History(&'a HistoryRequest),
+    Invocation(&'a InvocationRequest),
+    Batch,
+}
+
+impl<'a> FHIRResponseRequest<'a> {
+    const fn response_request(request: &'a FHIRRequest) -> Self {
+        match request {
+            FHIRRequest::Compartment(request) => Self::response_request(&request.request),
+            FHIRRequest::Read(_) => Self::Read,
+            FHIRRequest::Create(_) => Self::Create,
+            FHIRRequest::Patch(_) => Self::Patch,
+            FHIRRequest::Transaction(_) => Self::Transaction,
+            FHIRRequest::VersionRead(_) => Self::VersionRead,
+            FHIRRequest::Update(request) => Self::Update(request),
+            FHIRRequest::Delete(request) => Self::Delete(request),
+            FHIRRequest::Capabilities => Self::Capabilities,
+            FHIRRequest::Search(request) => Self::Search(request),
+            FHIRRequest::History(request) => Self::History(request),
+            FHIRRequest::Invocation(request) => Self::Invocation(request),
+            FHIRRequest::Batch(_) => Self::Batch,
+        }
+    }
+}
+
 fn http_response_to_fhir_response<'a>(
     fhir_request: &'a FHIRRequest,
     response: reqwest::Response,
 ) -> Pin<Box<dyn Future<Output = Result<FHIRResponse, OperationOutcomeError>> + Send + 'a>> {
     Box::pin(async move {
-        let request = fhir_request.response_request();
+        let request = FHIRResponseRequest::response_request(fhir_request);
         let body = read_response(response).await?;
 
         build_response(request, &body)

--- a/backend/crates/fhir-client/src/request.rs
+++ b/backend/crates/fhir-client/src/request.rs
@@ -242,21 +242,6 @@ pub struct CompartmentRequest {
     pub request: Box<FHIRRequest>,
 }
 
-pub(crate) enum FHIRResponseRequest<'a> {
-    Read,
-    Create,
-    Patch,
-    Transaction,
-    VersionRead,
-    Update(&'a UpdateRequest),
-    Delete(&'a DeleteRequest),
-    Capabilities,
-    Search(&'a SearchRequest),
-    History(&'a HistoryRequest),
-    Invocation(&'a InvocationRequest),
-    Batch,
-}
-
 #[derive(Derivative, Clone)]
 #[derivative(Debug = "transparent")]
 pub enum FHIRRequest {
@@ -285,26 +270,6 @@ pub enum FHIRRequest {
     Transaction(FHIRTransactionRequest),
     #[derivative(Debug = "transparent")]
     Compartment(CompartmentRequest),
-}
-
-impl FHIRRequest {
-    pub(crate) const fn response_request(&self) -> FHIRResponseRequest<'_> {
-        match self {
-            FHIRRequest::Compartment(request) => request.request.response_request(),
-            FHIRRequest::Read(_) => FHIRResponseRequest::Read,
-            FHIRRequest::Create(_) => FHIRResponseRequest::Create,
-            FHIRRequest::Patch(_) => FHIRResponseRequest::Patch,
-            FHIRRequest::Transaction(_) => FHIRResponseRequest::Transaction,
-            FHIRRequest::VersionRead(_) => FHIRResponseRequest::VersionRead,
-            FHIRRequest::Update(request) => FHIRResponseRequest::Update(request),
-            FHIRRequest::Delete(request) => FHIRResponseRequest::Delete(request),
-            FHIRRequest::Capabilities => FHIRResponseRequest::Capabilities,
-            FHIRRequest::Search(request) => FHIRResponseRequest::Search(request),
-            FHIRRequest::History(request) => FHIRResponseRequest::History(request),
-            FHIRRequest::Invocation(request) => FHIRResponseRequest::Invocation(request),
-            FHIRRequest::Batch(_) => FHIRResponseRequest::Batch,
-        }
-    }
 }
 
 #[derive(Derivative, Clone)]


### PR DESCRIPTION
This PR resolves more `clippy` lints for `fhir-client` crate improving the crate maintainability.