### PR TITLE
Resolve `clippy` lints for `repository` crate

### DIFF
--- a/backend/crates/jwt/src/sqlx.rs
+++ b/backend/crates/jwt/src/sqlx.rs
@@ -14,12 +14,12 @@ where
     }
 }
 
-impl<'r> Encode<'r, Postgres> for TenantId {
+impl Encode<'_, Postgres> for TenantId {
     fn encode_by_ref(
         &self,
         buf: &mut PgArgumentBuffer,
     ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-        buf.write(self.as_ref().as_bytes())?;
+        buf.write_all(self.as_ref().as_bytes())?;
         Ok(sqlx::encode::IsNull::No)
     }
 }
@@ -41,12 +41,12 @@ where
         Ok(ProjectId::new(value.to_string()))
     }
 }
-impl<'r> Encode<'r, Postgres> for ProjectId {
+impl Encode<'_, Postgres> for ProjectId {
     fn encode_by_ref(
         &self,
         buf: &mut PgArgumentBuffer,
     ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-        buf.write(self.as_ref().as_bytes())?;
+        buf.write_all(self.as_ref().as_bytes())?;
         Ok(sqlx::encode::IsNull::No)
     }
 }
@@ -69,12 +69,12 @@ where
     }
 }
 
-impl<'r> Encode<'r, Postgres> for ResourceId {
+impl Encode<'_, Postgres> for ResourceId {
     fn encode_by_ref(
         &self,
         buf: &mut PgArgumentBuffer,
     ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-        buf.write(self.0.as_bytes())?;
+        buf.write_all(self.0.as_bytes())?;
         Ok(sqlx::encode::IsNull::No)
     }
 }
@@ -84,17 +84,17 @@ impl<'r> Encode<'r, Postgres> for VersionIdRef<'r> {
         &self,
         buf: &mut PgArgumentBuffer,
     ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-        buf.write(self.0.as_bytes())?;
+        buf.write_all(self.0.as_bytes())?;
         Ok(sqlx::encode::IsNull::No)
     }
 }
 
-impl<'r> Encode<'r, Postgres> for VersionId {
+impl Encode<'_, Postgres> for VersionId {
     fn encode_by_ref(
         &self,
         buf: &mut PgArgumentBuffer,
     ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-        buf.write(self.0.as_bytes())?;
+        buf.write_all(self.0.as_bytes())?;
         Ok(sqlx::encode::IsNull::No)
     }
 }
@@ -131,13 +131,13 @@ where
     }
 }
 
-impl<'r> Encode<'r, Postgres> for Scopes {
+impl Encode<'_, Postgres> for Scopes {
     fn encode_by_ref(
         &self,
         buf: &mut PgArgumentBuffer,
     ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
         let scope_string = String::from(self.clone());
-        buf.write(scope_string.as_bytes())?;
+        buf.write_all(scope_string.as_bytes())?;
         Ok(sqlx::encode::IsNull::No)
     }
 }

--- a/backend/crates/repository/src/fhir.rs
+++ b/backend/crates/repository/src/fhir.rs
@@ -67,8 +67,8 @@ pub trait FHIRRepository: Sized {
         project_id: &ProjectId,
         request: &HistoryRequest,
     ) -> impl Future<Output = Result<Vec<ResourceHistoryValue>, OperationOutcomeError>> + Send;
-    fn transaction<'a>(
-        &'a self,
+    fn transaction(
+        &self,
         register: bool,
     ) -> impl Future<Output = Result<Self, OperationOutcomeError>> + Send;
     fn in_transaction(&self) -> bool;

--- a/backend/crates/repository/src/pg/authorization_code.rs
+++ b/backend/crates/repository/src/pg/authorization_code.rs
@@ -2,84 +2,85 @@ use crate::{
     admin::{ProjectModelAdmin, TenantModelAdmin},
     pg::{PGConnection, StoreError},
     types::authorization_code::{
-        AuthorizationCode, AuthorizationCodeKind, AuthorizationCodeSearchClaims, CodeErrors,
-        CreateAuthorizationCode, PKCECodeChallengeMethod,
+        AuthorizationCode, AuthorizationCodeSearchClaims, CodeErrors, CreateAuthorizationCode,
     },
     utilities::generate_id,
 };
 use haste_fhir_model::r4::generated::terminology::IssueType;
 use haste_fhir_operation_error::OperationOutcomeError;
 use haste_jwt::{ProjectId, TenantId};
-use sqlx::{Acquire, Postgres, QueryBuilder, types::Json};
+use sqlx::{PgExecutor, QueryBuilder};
 use sqlx_postgres::types::PgInterval;
 
-fn create_code<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn create_code<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: Option<&'a ProjectId>,
     authorization_code: CreateAuthorizationCode,
-) -> impl Future<Output = Result<AuthorizationCode, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let expires_in: PgInterval = authorization_code
-            .expires_in
-            .try_into()
-            .map_err(|_e| CodeErrors::InvalidDuration)?;
+) -> Result<AuthorizationCode, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let expires_in: PgInterval = authorization_code
+        .expires_in
+        .try_into()
+        .map_err(|_e| CodeErrors::InvalidDuration)?;
 
-        let code = generate_id(Some(45));
+    let code = generate_id(Some(45));
 
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
+    let new_authorization_code = sqlx::query_as::<_, AuthorizationCode>(
+        r"
+            INSERT INTO authorization_code (
+                tenant, project, client_id, kind, code, expires_in,
+                user_id, pkce_code_challenge, pkce_code_challenge_method, redirect_uri, meta, membership
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+            RETURNING
+                tenant,
+                kind,
+                code,
+                user_id,
+                project,
+                client_id,
+                pkce_code_challenge,
+                pkce_code_challenge_method,
+                redirect_uri,
+                meta,
+                NOW() > (created_at + expires_in) as is_expired,
+                membership,
+                created_at
+        ",
+    )
+    .bind(tenant)
+    .bind(project)
+    .bind(authorization_code.client_id)
+    .bind(authorization_code.kind)
+    .bind(code)
+    .bind(expires_in)
+    .bind(authorization_code.user_id)
+    .bind(authorization_code.pkce_code_challenge)
+    .bind(authorization_code.pkce_code_challenge_method)
+    .bind(authorization_code.redirect_uri)
+    .bind(authorization_code.meta)
+    .bind(authorization_code.membership)
+    .fetch_one(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        let new_authorization_code = sqlx::query_as!(
-            AuthorizationCode,
-            r#"
-        INSERT INTO authorization_code (
-            tenant, project, client_id, kind, code, expires_in,
-            user_id, pkce_code_challenge, pkce_code_challenge_method, redirect_uri, meta, membership
-        )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-        RETURNING tenant as "tenant: TenantId",
-                  kind as "kind: AuthorizationCodeKind",
-                  code,
-                  user_id,
-                  project as "project: ProjectId",
-                  client_id,
-                  pkce_code_challenge,
-                  pkce_code_challenge_method as "pkce_code_challenge_method: PKCECodeChallengeMethod",
-                  redirect_uri,
-                  meta as "meta: Json<serde_json::Value>",
-                  NOW() > (created_at + expires_in) as is_expired,
-                  membership,
-                  created_at
-        "#,
-            tenant as &TenantId,
-            project as Option<&'a ProjectId>,
-            authorization_code.client_id,
-            authorization_code.kind as AuthorizationCodeKind,
-            code,
-            expires_in as PgInterval,
-            authorization_code.user_id,
-            authorization_code.pkce_code_challenge,
-            authorization_code.pkce_code_challenge_method as Option<PKCECodeChallengeMethod>,
-            authorization_code.redirect_uri,
-            authorization_code.meta as std::option::Option<Json<serde_json::Value>>,
-            authorization_code.membership as std::option::Option<String>,
-        ).fetch_one(&mut *conn).await.map_err(StoreError::SQLXError)?;
-
-        Ok(new_authorization_code)
-    }
+    Ok(new_authorization_code)
 }
 
-fn read_code<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn read_code<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: Option<&'a ProjectId>,
     code: &'a str,
-) -> impl Future<Output = Result<Option<AuthorizationCode>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-
-        let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
-            r#"
+) -> Result<Option<AuthorizationCode>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> = QueryBuilder::new(
+        r"
             SELECT tenant,
                kind,
                code,
@@ -94,94 +95,75 @@ fn read_code<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
                membership,
                created_at
             FROM authorization_code
-            WHERE 
-        "#,
-        );
+            WHERE
+        ",
+    );
 
-        query_builder.push("tenant = ").push_bind(tenant.as_ref());
-        query_builder.push(" AND code = ").push_bind(code);
+    query_builder.push("tenant = ").push_bind(tenant.as_ref());
+    query_builder.push(" AND code = ").push_bind(code);
 
-        if let Some(project) = project {
-            query_builder
-                .push(" AND project = ")
-                .push_bind(project.as_ref());
-        }
-
-        let query = query_builder.build_query_as();
-
-        let authorization_code: Option<AuthorizationCode> = query
-            .fetch_optional(&mut *conn)
-            .await
-            .map_err(StoreError::SQLXError)?;
-
-        Ok(authorization_code)
+    if let Some(project) = project {
+        query_builder
+            .push(" AND project = ")
+            .push_bind(project.as_ref());
     }
+
+    let query = query_builder.build_query_as::<AuthorizationCode>();
+
+    let authorization_code = query
+        .fetch_optional(executor)
+        .await
+        .map_err(StoreError::SQLXError)?;
+
+    Ok(authorization_code)
 }
 
-fn delete_code<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn delete_code<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: Option<&'a ProjectId>,
     code: &'a str,
-) -> impl Future<Output = Result<(), OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-
-        let mut query_builder = QueryBuilder::new(
-            r#"
+) -> Result<(), OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> = QueryBuilder::new(
+        r"
             DELETE FROM authorization_code
             WHERE
-            "#,
-        );
+        ",
+    );
 
-        query_builder.push(" tenant =  ").push_bind(tenant.as_ref());
-        query_builder.push(" AND code = ").push_bind(code);
+    query_builder.push(" tenant = ").push_bind(tenant.as_ref());
+    query_builder.push(" AND code = ").push_bind(code);
 
-        if let Some(project) = project {
-            query_builder
-                .push(" AND project = ")
-                .push_bind(project.as_ref());
-        }
-
-        query_builder.push(
-            r#" 
-             RETURNING tenant,
-                  kind,
-                  code,
-                  user_id,
-                  project,
-                  client_id,
-                  pkce_code_challenge,
-                  pkce_code_challenge_method,
-                  redirect_uri,
-                  meta,
-                  NOW() > (created_at + expires_in) as is_expired,
-                  membership,
-                  created_at
-        "#,
-        );
-
-        let query = query_builder.build_query_as();
-
-        let _authorization_code: Option<AuthorizationCode> = query
-            .fetch_optional(&mut *conn)
-            .await
-            .map_err(StoreError::SQLXError)?;
-
-        Ok(())
+    if let Some(project) = project {
+        query_builder
+            .push(" AND project = ")
+            .push_bind(project.as_ref());
     }
+
+    let query = query_builder.build();
+
+    query
+        .execute(executor)
+        .await
+        .map_err(StoreError::SQLXError)?;
+
+    Ok(())
 }
 
-fn search_codes<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn search_codes<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: Option<&'a ProjectId>,
     clauses: &'a AuthorizationCodeSearchClaims,
-) -> impl Future<Output = Result<Vec<AuthorizationCode>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
-            r#"
+) -> Result<Vec<AuthorizationCode>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> = QueryBuilder::new(
+        r"
             SELECT tenant,
                kind,
                code,
@@ -197,58 +179,53 @@ fn search_codes<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a
                created_at
             FROM authorization_code
             WHERE
-        "#,
-        );
+        ",
+    );
 
-        query_builder.push(" tenant =  ").push_bind(tenant.as_ref());
+    query_builder.push(" tenant = ").push_bind(tenant.as_ref());
 
-        if let Some(project) = project {
-            query_builder
-                .push(" AND project = ")
-                .push_bind(project.as_ref());
-        }
-
-        if let Some(client_id) = &clauses.client_id {
-            query_builder
-                .push(" AND client_id =  ")
-                .push_bind(client_id);
-        }
-
-        if let Some(code) = &clauses.code {
-            query_builder.push(" AND code =  ").push_bind(code);
-        }
-
-        if let Some(user_id) = &clauses.user_id {
-            query_builder.push(" AND user_id =  ").push_bind(user_id);
-        }
-
-        if let Some(kind) = &clauses.kind {
-            query_builder
-                .push(" AND kind =  ")
-                .push_bind(kind as &AuthorizationCodeKind);
-        }
-
-        if let Some(user_agent) = &clauses.user_agent {
-            query_builder
-                .push(" AND meta->>'user_agent' =  ")
-                .push_bind(user_agent);
-        }
-
-        if let Some(is_expired) = &clauses.is_expired {
-            query_builder
-                .push(" AND (NOW() > (created_at + expires_in)) =  ")
-                .push_bind(is_expired);
-        }
-
-        let query = query_builder.build_query_as();
-
-        let authorization_codes: Vec<AuthorizationCode> = query
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(StoreError::SQLXError)?;
-
-        Ok(authorization_codes)
+    if let Some(project) = project {
+        query_builder
+            .push(" AND project = ")
+            .push_bind(project.as_ref());
     }
+
+    if let Some(client_id) = &clauses.client_id {
+        query_builder.push(" AND client_id = ").push_bind(client_id);
+    }
+
+    if let Some(code) = &clauses.code {
+        query_builder.push(" AND code = ").push_bind(code);
+    }
+
+    if let Some(user_id) = &clauses.user_id {
+        query_builder.push(" AND user_id = ").push_bind(user_id);
+    }
+
+    if let Some(kind) = &clauses.kind {
+        query_builder.push(" AND kind = ").push_bind(kind);
+    }
+
+    if let Some(user_agent) = &clauses.user_agent {
+        query_builder
+            .push(" AND meta->>'user_agent' = ")
+            .push_bind(user_agent);
+    }
+
+    if let Some(is_expired) = &clauses.is_expired {
+        query_builder
+            .push(" AND (NOW() > (created_at + expires_in)) = ")
+            .push_bind(is_expired);
+    }
+
+    let query = query_builder.build_query_as::<AuthorizationCode>();
+
+    let authorization_codes = query
+        .fetch_all(executor)
+        .await
+        .map_err(StoreError::SQLXError)?;
+
+    Ok(authorization_codes)
 }
 
 impl<Key: AsRef<str> + Send + Sync>
@@ -267,14 +244,11 @@ impl<Key: AsRef<str> + Send + Sync>
     ) -> Result<AuthorizationCode, OperationOutcomeError> {
         match &self {
             PGConnection::Pool(pool, _) => {
-                let res = create_code(pool, tenant, None, authorization_code).await?;
-                Ok(res)
+                create_code(pool, tenant, None, authorization_code).await
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-
-                let res = create_code(&mut *tx, tenant, None, authorization_code).await?;
-                Ok(res)
+                create_code(&mut **tx, tenant, None, authorization_code).await
             }
         }
     }
@@ -285,15 +259,10 @@ impl<Key: AsRef<str> + Send + Sync>
         code: &Key,
     ) -> Result<Option<AuthorizationCode>, OperationOutcomeError> {
         match &self {
-            PGConnection::Pool(pool, _) => {
-                let res = read_code(pool, tenant, None, code.as_ref()).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => read_code(pool, tenant, None, code.as_ref()).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-
-                let res = read_code(&mut *tx, tenant, None, code.as_ref()).await?;
-                Ok(res)
+                read_code(&mut **tx, tenant, None, code.as_ref()).await
             }
         }
     }
@@ -311,15 +280,10 @@ impl<Key: AsRef<str> + Send + Sync>
 
     async fn delete(&self, tenant: &TenantId, code: &Key) -> Result<(), OperationOutcomeError> {
         match &self {
-            PGConnection::Pool(pool, _) => {
-                let res = delete_code(pool, tenant, None, code.as_ref()).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => delete_code(pool, tenant, None, code.as_ref()).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-
-                let res = delete_code(&mut *tx, tenant, None, code.as_ref()).await?;
-                Ok(res)
+                delete_code(&mut **tx, tenant, None, code.as_ref()).await
             }
         }
     }
@@ -330,15 +294,10 @@ impl<Key: AsRef<str> + Send + Sync>
         clauses: &AuthorizationCodeSearchClaims,
     ) -> Result<Vec<AuthorizationCode>, OperationOutcomeError> {
         match &self {
-            PGConnection::Pool(pool, _) => {
-                let res = search_codes(pool, tenant, None, clauses).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => search_codes(pool, tenant, None, clauses).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-
-                let res = search_codes(&mut *tx, tenant, None, clauses).await?;
-                Ok(res)
+                search_codes(&mut **tx, tenant, None, clauses).await
             }
         }
     }
@@ -361,14 +320,11 @@ impl<Key: AsRef<str> + Send + Sync>
     ) -> Result<AuthorizationCode, OperationOutcomeError> {
         match &self {
             PGConnection::Pool(pool, _) => {
-                let res = create_code(pool, tenant, Some(project), authorization_code).await?;
-                Ok(res)
+                create_code(pool, tenant, Some(project), authorization_code).await
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-
-                let res = create_code(&mut *tx, tenant, Some(project), authorization_code).await?;
-                Ok(res)
+                create_code(&mut **tx, tenant, Some(project), authorization_code).await
             }
         }
     }
@@ -381,14 +337,11 @@ impl<Key: AsRef<str> + Send + Sync>
     ) -> Result<Option<AuthorizationCode>, OperationOutcomeError> {
         match &self {
             PGConnection::Pool(pool, _) => {
-                let res = read_code(pool, tenant, Some(project), code.as_ref()).await?;
-                Ok(res)
+                read_code(pool, tenant, Some(project), code.as_ref()).await
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-
-                let res = read_code(&mut *tx, tenant, Some(project), code.as_ref()).await?;
-                Ok(res)
+                read_code(&mut **tx, tenant, Some(project), code.as_ref()).await
             }
         }
     }
@@ -413,14 +366,11 @@ impl<Key: AsRef<str> + Send + Sync>
     ) -> Result<(), OperationOutcomeError> {
         match &self {
             PGConnection::Pool(pool, _) => {
-                let res = delete_code(pool, tenant, Some(project), code.as_ref()).await?;
-                Ok(res)
+                delete_code(pool, tenant, Some(project), code.as_ref()).await
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-
-                let res = delete_code(&mut *tx, tenant, Some(project), code.as_ref()).await?;
-                Ok(res)
+                delete_code(&mut **tx, tenant, Some(project), code.as_ref()).await
             }
         }
     }
@@ -432,15 +382,10 @@ impl<Key: AsRef<str> + Send + Sync>
         clauses: &AuthorizationCodeSearchClaims,
     ) -> Result<Vec<AuthorizationCode>, OperationOutcomeError> {
         match &self {
-            PGConnection::Pool(pool, _) => {
-                let res = search_codes(pool, tenant, Some(project), clauses).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => search_codes(pool, tenant, Some(project), clauses).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-
-                let res = search_codes(&mut *tx, tenant, Some(project), clauses).await?;
-                Ok(res)
+                search_codes(&mut **tx, tenant, Some(project), clauses).await
             }
         }
     }

--- a/backend/crates/repository/src/pg/fhir.rs
+++ b/backend/crates/repository/src/pg/fhir.rs
@@ -487,10 +487,10 @@ where
     .await
     .map_err(StoreError::from)?;
 
-    if let Some((_, true)) = response {
-        Ok(None)
-    } else {
-        Ok(response.map(|(json, _)| json.0))
+    match response {
+        Some((_, true)) => Ok(None),
+        Some((json, _)) => Ok(Some(json.0)),
+        None => Ok(None),
     }
 }
 
@@ -502,7 +502,7 @@ fn process_history_parameters<'a>(
         match parameter {
             ParsedParameter::Result(result_param) => {
                 if result_param.name.as_str() == "_since" {
-                    if let Some(value) = &result_param.value.first() {
+                    if let Some(value) = result_param.value.first() {
                         let date_time = parse_datetime(value.as_str()).map_err(|e| {
                             OperationOutcomeError::fatal(
                                 IssueType::invalid(),

--- a/backend/crates/repository/src/pg/fhir.rs
+++ b/backend/crates/repository/src/pg/fhir.rs
@@ -581,23 +581,19 @@ where
         HistoryRequest::System(_request) => {}
     }
 
-    let count = if let Some(ParsedParameter::Result(count_param)) = history_parameters.get("_count")
+    let limit = if let Some(ParsedParameter::Result(count_param)) = history_parameters.get("_count")
     {
         std::cmp::min(
             1000,
             count_param
                 .value
                 .first()
-                .and_then(|v| v.parse::<usize>().ok())
+                .and_then(|v| v.parse::<i64>().ok())
                 .unwrap_or(100),
         )
     } else {
         1000
     };
-
-    let limit = i64::try_from(count).map_err(|_| {
-        OperationOutcomeError::error(IssueType::invalid(), "count exceeds i64::MAX".into())
-    })?;
 
     query_builder
         .push(" ORDER BY sequence DESC LIMIT ")
@@ -608,14 +604,10 @@ where
             offset_param
                 .value
                 .first()
-                .and_then(|v| v.parse::<usize>().ok())
+                .and_then(|v| v.parse::<i64>().ok())
                 .unwrap_or(0),
             0,
         );
-
-        let offset = i64::try_from(offset).map_err(|_| {
-            OperationOutcomeError::error(IssueType::invalid(), "offset exceeds i64::MAX".into())
-        })?;
 
         query_builder.push(" OFFSET ").push_bind(offset);
     }

--- a/backend/crates/repository/src/pg/fhir.rs
+++ b/backend/crates/repository/src/pg/fhir.rs
@@ -22,14 +22,9 @@ use haste_fhir_model::r4::{
 use haste_fhir_operation_error::OperationOutcomeError;
 use haste_jwt::{ProjectId, ResourceId, TenantId, VersionId, claims::UserTokenClaims};
 use moka::future::Cache;
-use sqlx::{Acquire, Postgres, QueryBuilder, query_builder::Separated};
+use sqlx::{PgExecutor, Postgres, QueryBuilder, query_builder::Separated};
 use std::sync::Arc;
 use tokio::sync::Mutex;
-
-#[derive(sqlx::FromRow, Debug)]
-struct ReturnSingularResource {
-    resource: FHIRJson<Resource>,
-}
 
 #[derive(sqlx::FromRow, Debug)]
 struct ReturnVersionedResource {
@@ -49,9 +44,9 @@ async fn read_version_ids_from_cache<'a>(
 ) -> (Vec<Resource>, Vec<&'a VersionId>) {
     let mut remaining_version_ids = vec![];
     let mut cached_resources = vec![];
-    for version_id in version_ids.iter() {
+    for version_id in version_ids {
         if let Some(resource) = cache.get(*version_id).await {
-            cached_resources.push(resource)
+            cached_resources.push(resource);
         } else {
             remaining_version_ids.push(*version_id);
         }
@@ -74,17 +69,14 @@ impl FHIRRepository for PGConnection {
                 let tx = create_transaction(self, true).await?;
                 let res = {
                     let mut conn = tx.lock().await;
-                    let res =
-                        create(&mut *conn, tenant, project, author, fhir_version, resource).await?;
-                    res
+                    create(&mut **conn, tenant, project, author, fhir_version, resource).await?
                 };
                 commit_transaction(tx).await?;
                 Ok(res)
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = create(&mut *tx, tenant, project, author, fhir_version, resource).await?;
-                Ok(res)
+                create(&mut **tx, tenant, project, author, fhir_version, resource).await
             }
         }
     }
@@ -103,8 +95,8 @@ impl FHIRRepository for PGConnection {
                 let tx = create_transaction(self, true).await?;
                 let res = {
                     let mut conn = tx.lock().await;
-                    let res = delete(
-                        &mut *conn,
+                    delete(
+                        &mut **conn,
                         tenant,
                         project,
                         author,
@@ -112,8 +104,7 @@ impl FHIRRepository for PGConnection {
                         resource,
                         id,
                     )
-                    .await?;
-                    res
+                    .await?
                 };
                 commit_transaction(tx).await?;
                 Ok(res)
@@ -121,8 +112,8 @@ impl FHIRRepository for PGConnection {
             PGConnection::Transaction(tx, _) => {
                 let mut conn = tx.lock().await;
                 // Handle PgConnection connection
-                let res = delete(
-                    &mut *conn,
+                delete(
+                    &mut **conn,
                     tenant,
                     project,
                     author,
@@ -130,8 +121,7 @@ impl FHIRRepository for PGConnection {
                     resource,
                     id,
                 )
-                .await?;
-                Ok(res)
+                .await
             }
         }
     }
@@ -150,8 +140,8 @@ impl FHIRRepository for PGConnection {
                 let tx = create_transaction(self, true).await?;
                 let res = {
                     let mut conn = tx.lock().await;
-                    let res = update(
-                        &mut *conn,
+                    update(
+                        &mut **conn,
                         tenant,
                         project,
                         author,
@@ -159,8 +149,7 @@ impl FHIRRepository for PGConnection {
                         resource,
                         id,
                     )
-                    .await?;
-                    res
+                    .await?
                 };
 
                 commit_transaction(tx).await?;
@@ -169,8 +158,8 @@ impl FHIRRepository for PGConnection {
             PGConnection::Transaction(tx, _) => {
                 let mut conn = tx.lock().await;
                 // Handle PgConnection connection
-                let res = update(
-                    &mut *conn,
+                update(
+                    &mut **conn,
                     tenant,
                     project,
                     author,
@@ -178,8 +167,7 @@ impl FHIRRepository for PGConnection {
                     resource,
                     id,
                 )
-                .await?;
-                Ok(res)
+                .await
             }
         }
     }
@@ -192,11 +180,11 @@ impl FHIRRepository for PGConnection {
         cache_policy: CachePolicy,
     ) -> Result<Vec<Resource>, OperationOutcomeError> {
         if version_ids.is_empty() {
-            return Ok(vec![]);
+            return Ok(Vec::new());
         }
 
         let (cached_result, remaining_version_ids) =
-            read_version_ids_from_cache(self.cache(), &version_ids).await;
+            read_version_ids_from_cache(self.cache(), version_ids).await;
 
         if remaining_version_ids.is_empty() {
             return Ok(cached_result);
@@ -208,7 +196,7 @@ impl FHIRRepository for PGConnection {
                     .await?;
 
                 if cache_policy == CachePolicy::Cache {
-                    for v in res.iter() {
+                    for v in &res {
                         cache
                             .insert(v.version_id.clone(), v.resource.0.clone())
                             .await;
@@ -224,11 +212,11 @@ impl FHIRRepository for PGConnection {
                 let mut conn = tx.lock().await;
                 // Handle PgConnection connection
                 let res =
-                    read_by_version_ids(&mut *conn, tenant_id, project_id, &remaining_version_ids)
+                    read_by_version_ids(&mut **conn, tenant_id, project_id, &remaining_version_ids)
                         .await?;
 
                 if cache_policy == CachePolicy::Cache {
-                    for v in res.iter() {
+                    for v in &res {
                         cache
                             .insert(v.version_id.clone(), v.resource.0.clone())
                             .await;
@@ -259,15 +247,14 @@ impl FHIRRepository for PGConnection {
             PGConnection::Transaction(tx, _) => {
                 let mut conn = tx.lock().await;
                 // Handle PgConnection connection
-                let res = read_latest(
-                    &mut *conn,
+                read_latest(
+                    &mut **conn,
                     tenant_id,
                     project_id,
                     resource_type,
                     resource_id,
                 )
-                .await?;
-                Ok(res)
+                .await
             }
         }
     }
@@ -279,30 +266,20 @@ impl FHIRRepository for PGConnection {
         request: &HistoryRequest,
     ) -> Result<Vec<ResourceHistoryValue>, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = history(pool, tenant_id, project_id, request).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => history(pool, tenant_id, project_id, request).await,
             PGConnection::Transaction(tx, _) => {
                 let mut conn = tx.lock().await;
                 // Handle PgConnection connection
-                let res = history(&mut *conn, tenant_id, project_id, request).await?;
-                Ok(res)
+                history(&mut **conn, tenant_id, project_id, request).await
             }
         }
     }
 
     fn in_transaction(&self) -> bool {
-        match self {
-            PGConnection::Transaction(_tx, _) => true,
-            _ => false,
-        }
+        matches!(self, PGConnection::Transaction(_tx, _))
     }
 
-    async fn transaction<'a>(
-        &'a self,
-        is_updating_sequence: bool,
-    ) -> Result<Self, OperationOutcomeError> {
+    async fn transaction(&self, is_updating_sequence: bool) -> Result<Self, OperationOutcomeError> {
         let tx = create_transaction(self, is_updating_sequence).await?;
         Ok(PGConnection::Transaction(tx, self.cache().clone()))
     }
@@ -323,190 +300,197 @@ impl FHIRRepository for PGConnection {
                 );
 
                 // Handle PgConnection connection
-                let res = conn.rollback().await.map_err(StoreError::from)?;
-                Ok(res)
+                conn.rollback().await.map_err(StoreError::from)?;
+                Ok(())
             }
         }
     }
 }
 
-fn create<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn create<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: &'a ProjectId,
     author: &'a UserTokenClaims,
     fhir_version: &'a SupportedFHIRVersions,
     resource: &'a mut Resource,
-) -> impl Future<Output = Result<Resource, OperationOutcomeError>> + Send + 'a {
-    async move {
-        utilities::set_resource_id(resource, None)?;
-        utilities::set_version_id(resource)?;
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let result = sqlx::query_as!(
-                ReturnSingularResource,
-                r#"INSERT INTO resources (tenant, project, author_id, fhir_version, resource, deleted, request_method, author_type, fhir_method) 
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) 
-                RETURNING resource as "resource: FHIRJson<Resource>""#,
-                tenant.as_ref() as &str,
-                project.as_ref() as &str,
-                author.sub.as_ref() as &str,
-                // Useless cast so that macro has access to the type information.
-                // Otherwise it will not compile on type check.
-                fhir_version as &SupportedFHIRVersions,
-                &FHIRJsonRef(resource) as &FHIRJsonRef<'_ , Resource>,
-                false, // deleted
-                "POST",
-                author.resource_type.as_ref() as &str,
-                &FHIRMethod::Create as &FHIRMethod,
-            ).fetch_one(&mut *conn).await.map_err(StoreError::from)?;
-        Ok(result.resource.0)
-    }
+) -> Result<Resource, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    utilities::set_resource_id(resource, None)?;
+    utilities::set_version_id(resource)?;
+
+    let result = sqlx::query_as::<_, (FHIRJson<Resource>,)>(
+        r"
+            INSERT INTO resources (tenant, project, author_id, fhir_version, resource, deleted, request_method, author_type, fhir_method)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            RETURNING resource
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(project.as_ref())
+    .bind(author.sub.as_ref())
+    .bind(fhir_version)
+    .bind(FHIRJsonRef(resource))
+    .bind(false)
+    .bind("POST")
+    .bind(author.resource_type.as_ref())
+    .bind(FHIRMethod::Create)
+    .fetch_one(executor)
+    .await
+    .map_err(StoreError::from)?;
+
+    Ok(result.0.0)
 }
 
-fn delete<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
-    tenant: &'a TenantId,
-    project: &'a ProjectId,
-    author: &'a UserTokenClaims,
-    fhir_version: &'a SupportedFHIRVersions,
-    resource: &'a mut Resource,
-    id: &'a str,
-) -> impl Future<Output = Result<Resource, OperationOutcomeError>> + Send + 'a {
-    async move {
-        utilities::set_resource_id(resource, Some(id.to_string()))?;
-        utilities::set_version_id(resource)?;
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let result = sqlx::query_as!(
-                ReturnSingularResource,
-                r#"INSERT INTO resources (tenant, project, author_id, fhir_version, resource, deleted, request_method, author_type, fhir_method) 
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) 
-                RETURNING resource as "resource: FHIRJson<Resource>""#,
-                tenant.as_ref() as &str,
-                project.as_ref() as &str,
-                author.sub.as_ref() as &str,
-                // Useless cast so that macro has access to the type information.
-                // Otherwise it will not compile on type check.
-                fhir_version as &SupportedFHIRVersions,
-                &FHIRJsonRef(resource) as &FHIRJsonRef<'_ , Resource>,
-                true, // deleted
-                "DELETE",
-                author.resource_type.as_ref() as &str,
-                &FHIRMethod::Delete as &FHIRMethod,
-            ).fetch_one(&mut *conn).await.map_err(StoreError::from)?;
-
-        Ok(result.resource.0)
-    }
-}
-
-fn update<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn delete<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: &'a ProjectId,
     author: &'a UserTokenClaims,
     fhir_version: &'a SupportedFHIRVersions,
     resource: &'a mut Resource,
     id: &'a str,
-) -> impl Future<Output = Result<Resource, OperationOutcomeError>> + Send + 'a {
-    async move {
-        utilities::set_resource_id(resource, Some(id.to_string()))?;
-        utilities::set_version_id(resource)?;
+) -> Result<Resource, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    utilities::set_resource_id(resource, Some(id.to_string()))?;
+    utilities::set_version_id(resource)?;
 
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
+    let result = sqlx::query_as::<_, (FHIRJson<Resource>,)>(
+        r"
+            INSERT INTO resources (tenant, project, author_id, fhir_version, resource, deleted, request_method, author_type, fhir_method)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            RETURNING resource
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(project.as_ref())
+    .bind(author.sub.as_ref())
+    .bind(fhir_version)
+    .bind(FHIRJsonRef(resource))
+    .bind(true)
+    .bind("DELETE")
+    .bind(author.resource_type.as_ref())
+    .bind(FHIRMethod::Delete)
+    .fetch_one(executor)
+    .await
+    .map_err(StoreError::from)?;
 
-        let query = sqlx::query_as!(
-            ReturnSingularResource,
-            r#"INSERT INTO resources (tenant, project, author_id, fhir_version, resource, deleted, request_method, author_type, fhir_method) 
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) 
-                RETURNING resource as "resource: FHIRJson<Resource>""#,
-            tenant.as_ref() as &str,
-            project.as_ref() as &str,
-            author.sub.as_ref() as &str,
-            // Useless cast so that macro has access to the type information.
-            // Otherwise it will not compile on type check.
-            fhir_version as &SupportedFHIRVersions,
-            &FHIRJsonRef(resource) as &FHIRJsonRef<'_, Resource>,
-            false, // deleted
-            "PUT",
-            author.resource_type.as_ref() as &str,
-            &FHIRMethod::Update as &FHIRMethod,
-        );
-
-        let result = query
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(StoreError::from)?;
-
-        Ok(result.resource.0)
-    }
+    Ok(result.0.0)
 }
 
-fn read_by_version_ids<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn update<'a, 'e, E>(
+    executor: E,
+    tenant: &'a TenantId,
+    project: &'a ProjectId,
+    author: &'a UserTokenClaims,
+    fhir_version: &'a SupportedFHIRVersions,
+    resource: &'a mut Resource,
+    id: &'a str,
+) -> Result<Resource, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    utilities::set_resource_id(resource, Some(id.to_string()))?;
+    utilities::set_version_id(resource)?;
+
+    let result = sqlx::query_as::<_, (FHIRJson<Resource>,)>(
+        r"
+            INSERT INTO resources (tenant, project, author_id, fhir_version, resource, deleted, request_method, author_type, fhir_method)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            RETURNING resource
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(project.as_ref())
+    .bind(author.sub.as_ref())
+    .bind(fhir_version)
+    .bind(FHIRJsonRef(resource))
+    .bind(false)
+    .bind("PUT")
+    .bind(author.resource_type.as_ref())
+    .bind(FHIRMethod::Update)
+    .fetch_one(executor)
+    .await
+    .map_err(StoreError::from)?;
+
+    Ok(result.0.0)
+}
+
+async fn read_by_version_ids<'a, 'e, E>(
+    executor: E,
     tenant_id: &'a TenantId,
     project_id: &'a ProjectId,
     version_ids: &'a Vec<&'a VersionId>,
-) -> impl Future<Output = Result<Vec<ReturnVersionedResource>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
+) -> Result<Vec<ReturnVersionedResource>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> =
+        QueryBuilder::new("SELECT resource, version_id FROM resources WHERE tenant = ");
 
-        let mut query_builder: QueryBuilder<Postgres> =
-            QueryBuilder::new(r#"SELECT resource, version_id FROM resources WHERE tenant = "#);
+    query_builder
+        .push_bind(tenant_id.as_ref())
+        .push(" AND project =")
+        .push_bind(project_id.as_ref());
 
-        query_builder
-            .push_bind(tenant_id.as_ref())
-            .push(" AND project =")
-            .push_bind(project_id.as_ref());
+    query_builder.push(" AND version_id in (");
 
-        query_builder.push(" AND version_id in (");
-
-        let mut separated = query_builder.separated(", ");
-        for version_id in version_ids.iter() {
-            separated.push_bind(version_id.as_ref());
-        }
-        separated.push_unseparated(")");
-
-        // To preserve sort order.
-        query_builder.push(" ORDER BY  array_position(array[");
-        let mut order_separator = query_builder.separated(", ");
-        for version_id in version_ids.iter() {
-            order_separator.push_bind(version_id.as_ref());
-        }
-        query_builder.push("], version_id)");
-
-        let query = query_builder.build_query_as();
-        let response: Vec<ReturnVersionedResource> = query
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(StoreError::from)?;
-
-        Ok(response)
+    let mut separated = query_builder.separated(", ");
+    for version_id in version_ids {
+        separated.push_bind(version_id.as_ref());
     }
+    separated.push_unseparated(")");
+
+    query_builder.push(" ORDER BY array_position(array[");
+    let mut order_separator = query_builder.separated(", ");
+    for version_id in version_ids {
+        order_separator.push_bind(version_id.as_ref());
+    }
+    query_builder.push("], version_id)");
+
+    let query = query_builder.build_query_as::<ReturnVersionedResource>();
+
+    let response: Vec<ReturnVersionedResource> =
+        query.fetch_all(executor).await.map_err(StoreError::from)?;
+
+    Ok(response)
 }
 
-fn read_latest<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn read_latest<'a, 'e, E>(
+    executor: E,
     tenant_id: &'a TenantId,
     project_id: &'a ProjectId,
     resource_type: &'a ResourceType,
     resource_id: &'a ResourceId,
-) -> impl Future<Output = Result<Option<Resource>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let response = sqlx::query!(
-            r#"SELECT resource as "resource: FHIRJson<Resource>", deleted FROM resources WHERE tenant = $1 AND project = $2 AND id = $3 AND resource_type = $4 ORDER BY sequence DESC LIMIT 1"#,
-            tenant_id.as_ref(),
-            project_id.as_ref(),
-            resource_id.as_ref(),
-            resource_type.as_ref(),
-        ).fetch_optional(&mut *conn).await.map_err(StoreError::from)?;
+) -> Result<Option<Resource>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let response = sqlx::query_as::<_, (FHIRJson<Resource>, bool)>(
+        r"
+            SELECT resource, deleted
+            FROM resources
+            WHERE tenant = $1 AND project = $2 AND id = $3 AND resource_type = $4
+            ORDER BY sequence DESC
+            LIMIT 1
+        ",
+    )
+    .bind(tenant_id.as_ref())
+    .bind(project_id.as_ref())
+    .bind(resource_id.as_ref())
+    .bind(resource_type.as_ref())
+    .fetch_optional(executor)
+    .await
+    .map_err(StoreError::from)?;
 
-        // For deletes entry will contain deleted = true.
-        // In that case return None.
-        if let Some(true) = response.as_ref().map(|r| r.deleted) {
-            Ok(None)
-        } else {
-            Ok(response.map(|r| r.resource.0))
-        }
+    if let Some((_, true)) = response {
+        Ok(None)
+    } else {
+        Ok(response.map(|(json, _)| json.0))
     }
 }
 
@@ -516,13 +500,13 @@ fn process_history_parameters<'a>(
 ) -> Result<(), OperationOutcomeError> {
     for parameter in parameters.parameters() {
         match parameter {
-            ParsedParameter::Result(result_param) => match result_param.name.as_str() {
-                "_since" => {
-                    if let Some(value) = &result_param.value.get(0) {
+            ParsedParameter::Result(result_param) => {
+                if result_param.name.as_str() == "_since" {
+                    if let Some(value) = &result_param.value.first() {
                         let date_time = parse_datetime(value.as_str()).map_err(|e| {
                             OperationOutcomeError::fatal(
                                 IssueType::invalid(),
-                                format!("Invalid _since parameter datetime: {:?}", e),
+                                format!("Invalid _since parameter datetime: {e:?}"),
                             )
                         })?;
 
@@ -530,18 +514,16 @@ fn process_history_parameters<'a>(
                             chrono::DateTime::try_from(date_time).map_err(|e| {
                                 OperationOutcomeError::fatal(
                                     IssueType::invalid(),
-                                    format!("Invalid _since parameter datetime: {:?}", e),
+                                    format!("Invalid _since parameter datetime: {e:?}"),
                                 )
                             })?,
                         );
                     }
-                }
-                "_count" | "_offset" => {
+                } else {
                     // Ignore offset and count parameter as these parameters are held separately and not used in the where clause.
                 }
-                _ => {}
-            },
-            _ => {
+            }
+            ParsedParameter::Resource(_) => {
                 return Err(OperationOutcomeError::fatal(
                     IssueType::not_supported(),
                     format!(
@@ -556,96 +538,97 @@ fn process_history_parameters<'a>(
     Ok(())
 }
 
-fn history<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn history<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: &'a ProjectId,
     history_request: &'a HistoryRequest,
-) -> impl Future<Output = Result<Vec<ResourceHistoryValue>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::from)?;
+) -> Result<Vec<ResourceHistoryValue>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> =
+        QueryBuilder::new(r"SELECT resource, request_method FROM resources WHERE ");
 
-        let mut query_builder: QueryBuilder<Postgres> =
-            QueryBuilder::new(r#"SELECT resource, request_method FROM resources WHERE  "#);
+    let mut clauses = query_builder.separated(" AND ");
+    clauses
+        .push(" tenant = ")
+        .push_bind_unseparated(tenant.as_ref())
+        .push(" project = ")
+        .push_bind_unseparated(project.as_ref());
 
-        let mut clauses = query_builder.separated(" AND ");
-        clauses
-            .push(" tenant = ")
-            .push_bind_unseparated(tenant.as_ref())
-            .push(" project = ")
-            .push_bind_unseparated(project.as_ref());
+    let history_parameters = match history_request {
+        HistoryRequest::Instance(history_instance_request) => &history_instance_request.parameters,
+        HistoryRequest::Type(history_type_request) => &history_type_request.parameters,
+        HistoryRequest::System(system_request) => &system_request.parameters,
+    };
 
-        let history_parameters = match history_request {
-            HistoryRequest::Instance(history_instance_request) => {
-                &history_instance_request.parameters
-            }
-            HistoryRequest::Type(history_type_request) => &history_type_request.parameters,
-            HistoryRequest::System(system_request) => &system_request.parameters,
-        };
+    process_history_parameters(history_parameters, &mut clauses)?;
 
-        process_history_parameters(&history_parameters, &mut clauses)?;
-
-        match history_request {
-            HistoryRequest::Instance(history_instance_request) => {
-                clauses
-                    .push(" resource_type = ")
-                    .push_bind_unseparated(history_instance_request.resource_type.as_ref())
-                    .push(" id = ")
-                    .push_bind_unseparated(&history_instance_request.id);
-            }
-            HistoryRequest::Type(history_type_request) => {
-                clauses
-                    .push(" resource_type = ")
-                    .push_bind_unseparated(history_type_request.resource_type.as_ref());
-            }
-            HistoryRequest::System(_request) => {}
-        };
-
-        let count =
-            if let Some(ParsedParameter::Result(count_param)) = history_parameters.get("_count") {
-                // Enforce a maximum count of 1000 to prevent abuse and performance issues.
-                std::cmp::min(
-                    1000,
-                    count_param
-                        .value
-                        .get(0)
-                        .and_then(|v| v.parse::<usize>().ok())
-                        .unwrap_or(100),
-                )
-            } else {
-                1000
-            };
-
-        query_builder
-            .push(" ORDER BY sequence DESC LIMIT ")
-            .push_bind(count as i64);
-
-        if let Some(ParsedParameter::Result(offset_param)) = history_parameters.get("_offset") {
-            let offset = std::cmp::max(
-                offset_param
-                    .value
-                    .get(0)
-                    .and_then(|v| v.parse::<usize>().ok())
-                    .unwrap_or(0),
-                0,
-            );
-
-            query_builder.push(" OFFSET ").push_bind(offset as i64);
+    match history_request {
+        HistoryRequest::Instance(history_instance_request) => {
+            clauses
+                .push(" resource_type = ")
+                .push_bind_unseparated(history_instance_request.resource_type.as_ref())
+                .push(" id = ")
+                .push_bind_unseparated(&history_instance_request.id);
         }
-
-        let query = query_builder.build_query_as();
-
-        let result: Vec<HistoryValue> = query
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(StoreError::from)?;
-
-        Ok(result
-            .into_iter()
-            .map(|r| ResourceHistoryValue {
-                resource: r.resource.0,
-                request_method: r.request_method,
-            })
-            .collect::<Vec<_>>())
+        HistoryRequest::Type(history_type_request) => {
+            clauses
+                .push(" resource_type = ")
+                .push_bind_unseparated(history_type_request.resource_type.as_ref());
+        }
+        HistoryRequest::System(_request) => {}
     }
+
+    let count = if let Some(ParsedParameter::Result(count_param)) = history_parameters.get("_count")
+    {
+        std::cmp::min(
+            1000,
+            count_param
+                .value
+                .first()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(100),
+        )
+    } else {
+        1000
+    };
+
+    let limit = i64::try_from(count).map_err(|_| {
+        OperationOutcomeError::error(IssueType::invalid(), "count exceeds i64::MAX".into())
+    })?;
+
+    query_builder
+        .push(" ORDER BY sequence DESC LIMIT ")
+        .push_bind(limit);
+
+    if let Some(ParsedParameter::Result(offset_param)) = history_parameters.get("_offset") {
+        let offset = std::cmp::max(
+            offset_param
+                .value
+                .first()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(0),
+            0,
+        );
+
+        let offset = i64::try_from(offset).map_err(|_| {
+            OperationOutcomeError::error(IssueType::invalid(), "offset exceeds i64::MAX".into())
+        })?;
+
+        query_builder.push(" OFFSET ").push_bind(offset);
+    }
+
+    let query = query_builder.build_query_as::<HistoryValue>();
+
+    let result: Vec<HistoryValue> = query.fetch_all(executor).await.map_err(StoreError::from)?;
+
+    Ok(result
+        .into_iter()
+        .map(|r| ResourceHistoryValue {
+            resource: r.resource.0,
+            request_method: r.request_method,
+        })
+        .collect::<Vec<_>>())
 }

--- a/backend/crates/repository/src/pg/membership.rs
+++ b/backend/crates/repository/src/pg/membership.rs
@@ -1,189 +1,182 @@
 use crate::{
     admin::ProjectModelAdmin,
     pg::{PGConnection, StoreError},
-    types::membership::{CreateMembership, Membership, MembershipRole, MembershipSearchClaims},
+    types::membership::{CreateMembership, Membership, MembershipSearchClaims},
 };
 use haste_fhir_operation_error::OperationOutcomeError;
 use haste_jwt::{ProjectId, TenantId};
-use sqlx::{Acquire, Postgres, QueryBuilder};
+use sqlx::{PgExecutor, QueryBuilder};
 
-fn create_membership<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn create_membership<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: &'a ProjectId,
     membership: CreateMembership,
-) -> impl Future<Output = Result<Membership, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let mut query_builder = QueryBuilder::new(
-            r#"
-                INSERT INTO memberships(tenant, project, user_id, role, resource_id) VALUES (
-            "#,
-        );
+) -> Result<Membership, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder = QueryBuilder::new(
+        r"
+            INSERT INTO memberships(tenant, project, user_id, role, resource_id) VALUES (
+        ",
+    );
 
-        let mut seperator = query_builder.separated(", ");
+    let mut seperator = query_builder.separated(", ");
 
-        seperator
-            .push_bind(tenant.as_ref())
-            .push_bind(project.as_ref())
-            .push_bind(&membership.user_id)
-            .push_bind(membership.role as MembershipRole)
-            .push_bind(&membership.resource_id);
+    seperator
+        .push_bind(tenant.as_ref())
+        .push_bind(project.as_ref())
+        .push_bind(&membership.user_id)
+        .push_bind(membership.role)
+        .push_bind(&membership.resource_id);
 
-        query_builder.push(r#") RETURNING tenant, project, user_id, role, resource_id"#);
+    query_builder.push(r") RETURNING tenant, project, user_id, role, resource_id");
 
-        let query = query_builder.build_query_as();
+    let query = query_builder.build_query_as::<Membership>();
 
-        let membership = query
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(StoreError::SQLXError)?;
-
-        Ok(membership)
-    }
-}
-
-fn read_membership<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
-    tenant: &'a TenantId,
-    project: &'a ProjectId,
-    user_id: &'a str,
-) -> impl Future<Output = Result<Option<Membership>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let membership = sqlx::query_as!(
-            Membership,
-            r#"
-                SELECT tenant as "tenant: TenantId", project as "project: ProjectId", user_id, role as "role: MembershipRole", resource_id
-                FROM memberships
-                WHERE tenant = $1 AND project = $2 AND user_id = $3
-            "#,
-            tenant.as_ref(),
-            project.as_ref(),
-            user_id
-        )
-        .fetch_optional(&mut *conn)
+    let membership = query
+        .fetch_one(executor)
         .await
         .map_err(StoreError::SQLXError)?;
 
-        Ok(membership)
-    }
+    Ok(membership)
 }
 
-fn update_membership<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn read_membership<'a, 'e, E>(
+    executor: E,
+    tenant: &'a TenantId,
+    project: &'a ProjectId,
+    user_id: &'a str,
+) -> Result<Option<Membership>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let membership = sqlx::query_as::<_, Membership>(
+        r"
+            SELECT tenant, project, user_id, role, resource_id
+            FROM memberships
+            WHERE tenant = $1 AND project = $2 AND user_id = $3
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(project.as_ref())
+    .bind(user_id)
+    .fetch_optional(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
+
+    Ok(membership)
+}
+
+async fn update_membership<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: &'a ProjectId,
     model: Membership,
-) -> impl Future<Output = Result<Membership, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let mut query_builder = QueryBuilder::new(
-            r#"
-                INSERT INTO memberships(tenant, project, user_id, role, resource_id) VALUES (
-            "#,
-        );
+) -> Result<Membership, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder = QueryBuilder::new(
+        r"
+            INSERT INTO memberships(tenant, project, user_id, role, resource_id) VALUES (
+        ",
+    );
 
-        let mut seperator = query_builder.separated(", ");
+    let mut seperator = query_builder.separated(", ");
 
-        seperator
-            .push_bind(tenant.as_ref())
-            .push_bind(project.as_ref())
-            .push_bind(&model.user_id)
-            .push_bind(model.role.clone() as MembershipRole)
-            .push_bind(&model.resource_id);
+    seperator
+        .push_bind(tenant.as_ref())
+        .push_bind(project.as_ref())
+        .push_bind(&model.user_id)
+        .push_bind(model.role.clone())
+        .push_bind(&model.resource_id);
 
-        query_builder.push(r#") ON CONFLICT (tenant, project, user_id) DO UPDATE SET "#);
+    query_builder.push(r") ON CONFLICT (tenant, project, user_id) DO UPDATE SET ");
 
-        let mut set_statements = query_builder.separated(", ");
+    let mut set_statements = query_builder.separated(", ");
 
-        set_statements
-            .push(" role = ")
-            .push_bind_unseparated(model.role);
+    set_statements
+        .push(" role = ")
+        .push_bind_unseparated(model.role);
 
-        set_statements
-            .push(" resource_id = ")
-            .push_bind_unseparated(&model.resource_id);
+    set_statements
+        .push(" resource_id = ")
+        .push_bind_unseparated(&model.resource_id);
 
-        query_builder.push(r#" RETURNING tenant, project, user_id, role, resource_id"#);
+    query_builder.push(r" RETURNING tenant, project, user_id, role, resource_id");
 
-        let query = query_builder.build_query_as();
+    let query = query_builder.build_query_as::<Membership>();
 
-        let membership = query
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(StoreError::SQLXError)?;
-
-        Ok(membership)
-    }
-}
-
-fn delete_membership<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
-    tenant: &'a TenantId,
-    project: &'a ProjectId,
-    user_id: &'a str,
-) -> impl Future<Output = Result<(), OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let _membership = sqlx::query_as!(
-            Membership,
-            r#"
-                DELETE FROM memberships
-                WHERE tenant = $1 AND project = $2 AND user_id = $3
-                RETURNING user_id, tenant as "tenant: TenantId", project as "project: ProjectId", role as "role: MembershipRole", resource_id
-            "#,
-            tenant.as_ref(),
-            project.as_ref(),
-            user_id
-        )
-        .fetch_optional(&mut *conn)
+    let membership = query
+        .fetch_one(executor)
         .await
         .map_err(StoreError::SQLXError)?;
 
-        Ok(())
-    }
+    Ok(membership)
 }
 
-fn search_memberships<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn delete_membership<'a, 'e, E>(
+    executor: E,
+    tenant: &'a TenantId,
+    project: &'a ProjectId,
+    user_id: &'a str,
+) -> Result<(), OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    sqlx::query(
+        r"
+            DELETE FROM memberships
+            WHERE tenant = $1 AND project = $2 AND user_id = $3
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(project.as_ref())
+    .bind(user_id)
+    .execute(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
+
+    Ok(())
+}
+
+async fn search_memberships<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: &'a ProjectId,
     clauses: &'a MembershipSearchClaims,
-) -> impl Future<Output = Result<Vec<Membership>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
+) -> Result<Vec<Membership>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> = QueryBuilder::new(
+        r"SELECT user_id, tenant, project, role, resource_id FROM memberships WHERE ",
+    );
 
-        let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
-            r#"SELECT user_id, tenant, project, role, resource_id FROM memberships WHERE  "#,
-        );
+    let mut seperator = query_builder.separated(" AND ");
+    seperator
+        .push(" tenant = ")
+        .push_bind_unseparated(tenant.as_ref())
+        .push(" project = ")
+        .push_bind_unseparated(project.as_ref());
 
-        let mut seperator = query_builder.separated(" AND ");
+    if let Some(user_id) = clauses.user_id.as_ref() {
         seperator
-            .push(" tenant = ")
-            .push_bind_unseparated(tenant.as_ref())
-            .push(" project = ")
-            .push_bind_unseparated(project.as_ref());
-
-        if let Some(user_id) = clauses.user_id.as_ref() {
-            seperator
-                .push(" user_id = ")
-                .push_bind_unseparated(user_id.as_ref());
-        }
-
-        if let Some(role) = clauses.role.as_ref() {
-            seperator.push(" role = ").push_bind_unseparated(role);
-        }
-
-        let query = query_builder.build_query_as();
-
-        let memberships: Vec<Membership> = query
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(StoreError::from)?;
-
-        Ok(memberships)
+            .push(" user_id = ")
+            .push_bind_unseparated(user_id.as_ref());
     }
+
+    if let Some(role) = clauses.role.as_ref() {
+        seperator.push(" role = ").push_bind_unseparated(role);
+    }
+
+    let query = query_builder.build_query_as::<Membership>();
+
+    let memberships: Vec<Membership> = query.fetch_all(executor).await.map_err(StoreError::from)?;
+
+    Ok(memberships)
 }
 
 impl<Key: AsRef<str> + Send + Sync>
@@ -198,13 +191,11 @@ impl<Key: AsRef<str> + Send + Sync>
     ) -> Result<Membership, OperationOutcomeError> {
         match self {
             PGConnection::Pool(pool, _) => {
-                let res = create_membership(pool, tenant, project, new_membership).await?;
-                Ok(res)
+                create_membership(pool, tenant, project, new_membership).await
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = create_membership(&mut *tx, tenant, project, new_membership).await?;
-                Ok(res)
+                create_membership(&mut **tx, tenant, project, new_membership).await
             }
         }
     }
@@ -217,13 +208,11 @@ impl<Key: AsRef<str> + Send + Sync>
     ) -> Result<Option<Membership>, OperationOutcomeError> {
         match self {
             PGConnection::Pool(pool, _) => {
-                let res = read_membership(pool, tenant, project, id.as_ref()).await?;
-                Ok(res)
+                read_membership(pool, tenant, project, id.as_ref()).await
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = read_membership(&mut *tx, tenant, project, id.as_ref()).await?;
-                Ok(res)
+                read_membership(&mut **tx, tenant, project, id.as_ref()).await
             }
         }
     }
@@ -235,14 +224,10 @@ impl<Key: AsRef<str> + Send + Sync>
         model: Membership,
     ) -> Result<Membership, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = update_membership(pool, tenant, project, model).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => update_membership(pool, tenant, project, model).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = update_membership(&mut *tx, tenant, project, model).await?;
-                Ok(res)
+                update_membership(&mut **tx, tenant, project, model).await
             }
         }
     }
@@ -255,13 +240,11 @@ impl<Key: AsRef<str> + Send + Sync>
     ) -> Result<(), OperationOutcomeError> {
         match self {
             PGConnection::Pool(pool, _) => {
-                let res = delete_membership(pool, tenant, project, id.as_ref()).await?;
-                Ok(res)
+                delete_membership(pool, tenant, project, id.as_ref()).await
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = delete_membership(&mut *tx, tenant, project, id.as_ref()).await?;
-                Ok(res)
+                delete_membership(&mut **tx, tenant, project, id.as_ref()).await
             }
         }
     }
@@ -273,14 +256,10 @@ impl<Key: AsRef<str> + Send + Sync>
         clauses: &MembershipSearchClaims,
     ) -> Result<Vec<Membership>, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = search_memberships(pool, tenant, project, clauses).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => search_memberships(pool, tenant, project, clauses).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = search_memberships(&mut *tx, tenant, project, clauses).await?;
-                Ok(res)
+                search_memberships(&mut **tx, tenant, project, clauses).await
             }
         }
     }

--- a/backend/crates/repository/src/pg/mfa.rs
+++ b/backend/crates/repository/src/pg/mfa.rs
@@ -9,28 +9,28 @@ use crate::{
 use haste_fhir_model::r4::generated::terminology::IssueType;
 use haste_fhir_operation_error::OperationOutcomeError;
 use haste_jwt::TenantId;
-use sqlx::{Acquire, Postgres, QueryBuilder};
+use sqlx::{PgExecutor, QueryBuilder};
 
-fn create_user_mfa_credential<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn create_user_mfa_credential<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     new_mfa_credentials: UserMFACredentialCreate,
-) -> impl Future<Output = Result<UserMFACredential, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
+) -> Result<UserMFACredential, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let type_: &str = new_mfa_credentials.credential_type.into();
+    let totp_algorithm = new_mfa_credentials
+        .totp_algorithm
+        .unwrap_or_else(|| "SHA1".to_string());
 
-        let type_: &str = new_mfa_credentials.credential_type.into();
-        let totp_algorithm = new_mfa_credentials
-            .totp_algorithm
-            .unwrap_or("SHA1".to_string());
-
-        let user_mfa_credential = sqlx::query_as!(
-            UserMFACredential,
-            r#"INSERT INTO user_mfa_credential (tenant, user_id, credential_type, secret_ciphertext, secret_nonce, key_id, totp_algorithm, totp_digits, totp_period, totp_skew) 
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) 
-            RETURNING 
+    let user_mfa_credential = sqlx::query_as::<_, UserMFACredential>(
+        r"
+            INSERT INTO user_mfa_credential (tenant, user_id, credential_type, secret_ciphertext, secret_nonce, key_id, totp_algorithm, totp_digits, totp_period, totp_skew)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            RETURNING
                 id::TEXT,
-                tenant as "tenant: TenantId",
+                tenant,
                 user_id,
                 credential_type,
                 secret_ciphertext,
@@ -42,38 +42,38 @@ fn create_user_mfa_credential<'a, 'c, Connection: Acquire<'c, Database = Postgre
                 totp_skew,
                 created_at,
                 is_active
-            "#,
-            tenant.as_ref(),
-            new_mfa_credentials.user_id.as_ref(),
-            type_,
-            new_mfa_credentials.secret_ciphertext,
-            new_mfa_credentials.secret_nonce,
-            new_mfa_credentials.key_id,
-            totp_algorithm,
-            new_mfa_credentials.totp_digits.unwrap_or(6),
-            new_mfa_credentials.totp_period.unwrap_or(30),
-            new_mfa_credentials.totp_skew.unwrap_or(1),
-        )
-        .fetch_one(&mut *conn)
-        .await
-        .map_err(StoreError::SQLXError)?;
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(new_mfa_credentials.user_id.as_ref())
+    .bind(type_)
+    .bind(new_mfa_credentials.secret_ciphertext)
+    .bind(new_mfa_credentials.secret_nonce)
+    .bind(new_mfa_credentials.key_id)
+    .bind(totp_algorithm)
+    .bind(new_mfa_credentials.totp_digits.unwrap_or(6))
+    .bind(new_mfa_credentials.totp_period.unwrap_or(30))
+    .bind(new_mfa_credentials.totp_skew.unwrap_or(1))
+    .fetch_one(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        Ok(user_mfa_credential)
-    }
+    Ok(user_mfa_credential)
 }
 
-fn read_user_mfa<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn read_user_mfa<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     key: &'a MFAKey,
-) -> impl Future<Output = Result<Option<UserMFACredential>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let user_mfa = sqlx::query_as!(
-            UserMFACredential,
-            r#"SELECT 
+) -> Result<Option<UserMFACredential>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let user_mfa = sqlx::query_as::<_, UserMFACredential>(
+        r"
+            SELECT
                 id::TEXT,
-                tenant as "tenant: TenantId",
+                tenant,
                 user_id,
                 credential_type,
                 secret_ciphertext,
@@ -85,182 +85,168 @@ fn read_user_mfa<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + '
                 totp_skew,
                 created_at,
                 is_active
-            FROM user_mfa_credential where tenant = $1 AND id::text = $2 AND user_id = $3"#,
-            tenant.as_ref(),
-            key.mfa_id().0,
-            key.user_id().as_ref()
-        )
-        .fetch_optional(&mut *conn)
-        .await
-        .map_err(StoreError::SQLXError)?;
-
-        Ok(user_mfa)
-    }
-}
-
-fn delete_user_mfa<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
-    tenant: &'a TenantId,
-    key: &'a MFAKey,
-) -> impl Future<Output = Result<(), OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let _delted_user_mfa = sqlx::query_as!(
-            UserMFACredential,
-            r#"DELETE FROM user_mfa_credential 
+            FROM user_mfa_credential
             WHERE tenant = $1 AND id::text = $2 AND user_id = $3
-            RETURNING 
-                id::TEXT,
-                tenant as "tenant: TenantId",
-                user_id,
-                credential_type,
-                secret_ciphertext,
-                secret_nonce,
-                key_id,
-                totp_algorithm,
-                totp_digits,
-                totp_period,
-                totp_skew,
-                created_at,
-                is_active"#,
-            tenant.as_ref(),
-            key.mfa_id().0,
-            key.user_id().as_ref()
-        )
-        .fetch_optional(&mut *conn)
-        .await
-        .map_err(|_e| {
-            OperationOutcomeError::error(
-                IssueType::not_found(),
-                format!(
-                    "User MFA credential '{}' not found or is system created and cannot be deleted.",
-                    key.mfa_id().0
-                ),
-            )
-        })?;
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(&key.mfa_id().0)
+    .bind(key.user_id().as_ref())
+    .fetch_optional(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        if !_delted_user_mfa.is_some() {
-            return Err(OperationOutcomeError::error(
-                IssueType::not_found(),
-                format!(
-                    "User MFA credential '{}' not found or is system created and cannot be deleted.",
-                    key.mfa_id().0
-                ),
-            ));
-        }
-
-        Ok(())
-    }
+    Ok(user_mfa)
 }
 
-fn search_user_mfa<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn delete_user_mfa<'a, 'e, E>(
+    executor: E,
+    tenant: &'a TenantId,
+    key: &'a MFAKey,
+) -> Result<(), OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let rows_affected = sqlx::query(
+        r"
+            DELETE FROM user_mfa_credential
+            WHERE tenant = $1 AND id::text = $2 AND user_id = $3
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(&key.mfa_id().0)
+    .bind(key.user_id().as_ref())
+    .execute(executor)
+    .await
+    .map_err(|_e| {
+        OperationOutcomeError::error(
+            IssueType::not_found(),
+            format!(
+                "User MFA credential '{}' not found or is system created and cannot be deleted.",
+                key.mfa_id().0
+            ),
+        )
+    })?
+    .rows_affected();
+
+    if rows_affected == 0 {
+        return Err(OperationOutcomeError::error(
+            IssueType::not_found(),
+            format!(
+                "User MFA credential '{}' not found or is system created and cannot be deleted.",
+                key.mfa_id().0
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+async fn search_user_mfa<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     clauses: &'a UserMFASearchClaims,
-) -> impl Future<Output = Result<Vec<UserMFACredential>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
-            r#"SELECT 
-                id::TEXT,
-                tenant,
-                user_id,
-                credential_type,
-                secret_ciphertext,
-                secret_nonce,
-                key_id,
-                totp_algorithm,
-                totp_digits,
-                totp_period,
-                totp_skew,
-                created_at,
-                is_active FROM user_mfa_credential WHERE "#,
-        );
+) -> Result<Vec<UserMFACredential>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> = QueryBuilder::new(
+        r"SELECT
+            id::TEXT,
+            tenant,
+            user_id,
+            credential_type,
+            secret_ciphertext,
+            secret_nonce,
+            key_id,
+            totp_algorithm,
+            totp_digits,
+            totp_period,
+            totp_skew,
+            created_at,
+            is_active FROM user_mfa_credential WHERE ",
+    );
 
-        let mut and_clauses = query_builder.separated(" AND ");
+    let mut and_clauses = query_builder.separated(" AND ");
 
+    and_clauses
+        .push(" tenant = ")
+        .push_bind_unseparated(tenant.as_ref());
+
+    and_clauses
+        .push(" user_id = ")
+        .push_bind_unseparated(clauses.user_id.as_ref());
+
+    if let Some(is_active) = clauses.is_active {
         and_clauses
-            .push(" tenant = ")
-            .push_bind_unseparated(tenant.as_ref());
-
-        and_clauses
-            .push(" user_id = ")
-            .push_bind_unseparated(clauses.user_id.as_ref());
-
-        if let Some(is_active) = clauses.is_active {
-            and_clauses
-                .push(" is_active = ")
-                .push_bind_unseparated(is_active);
-        }
-
-        let query = query_builder.build_query_as();
-
-        let user_mfas: Vec<UserMFACredential> = query
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(StoreError::from)?;
-
-        Ok(user_mfas)
+            .push(" is_active = ")
+            .push_bind_unseparated(is_active);
     }
+
+    let query = query_builder.build_query_as::<UserMFACredential>();
+
+    let user_mfas: Vec<UserMFACredential> =
+        query.fetch_all(executor).await.map_err(StoreError::from)?;
+
+    Ok(user_mfas)
 }
 
-/// Not allowing updates on internal row just reading to confirm it's existance.
-fn update_user_mfa<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn update_user_mfa<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     model: UserMFACredentialUpdate,
-) -> impl Future<Output = Result<UserMFACredential, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let mut query_builder = QueryBuilder::new(
-            r#"
-                UPDATE user_mfa_credential SET 
-            "#,
-        );
+) -> Result<UserMFACredential, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder = QueryBuilder::new(
+        r"
+            UPDATE user_mfa_credential SET
+        ",
+    );
 
-        let mut set_statements = query_builder.separated(", ");
+    let mut set_statements = query_builder.separated(", ");
 
-        set_statements
-            .push(" is_active = ")
-            .push_bind_unseparated(model.is_active);
+    set_statements
+        .push(" is_active = ")
+        .push_bind_unseparated(model.is_active);
 
-        query_builder.push(" WHERE ");
+    query_builder.push(" WHERE ");
 
-        let mut where_statements = query_builder.separated(" AND ");
-        where_statements
-            .push(" tenant = ")
-            .push_bind_unseparated(tenant.as_ref())
-            .push(" id::text = ")
-            .push_bind_unseparated(model.id)
-            .push(" user_id = ")
-            .push_bind_unseparated(model.user_id.as_ref());
+    let mut where_statements = query_builder.separated(" AND ");
+    where_statements
+        .push(" tenant = ")
+        .push_bind_unseparated(tenant.as_ref())
+        .push(" id::text = ")
+        .push_bind_unseparated(model.id)
+        .push(" user_id = ")
+        .push_bind_unseparated(model.user_id.as_ref());
 
-        query_builder.push(
-            r#" RETURNING 
-                id::TEXT,
-                tenant,
-                user_id,
-                credential_type,
-                secret_ciphertext,
-                secret_nonce,
-                key_id,
-                totp_algorithm,
-                totp_digits,
-                totp_period,
-                totp_skew,
-                created_at,
-                is_active"#,
-        );
+    query_builder.push(
+        r" RETURNING
+            id::TEXT,
+            tenant,
+            user_id,
+            credential_type,
+            secret_ciphertext,
+            secret_nonce,
+            key_id,
+            totp_algorithm,
+            totp_digits,
+            totp_period,
+            totp_skew,
+            created_at,
+            is_active",
+    );
 
-        let query = query_builder.build_query_as();
+    let query = query_builder.build_query_as::<UserMFACredential>();
 
-        let user_mfa_credentials = query
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(StoreError::SQLXError)?;
+    let user_mfa_credentials = query
+        .fetch_one(executor)
+        .await
+        .map_err(StoreError::SQLXError)?;
 
-        Ok(user_mfa_credentials)
-    }
+    Ok(user_mfa_credentials)
 }
 
 impl
@@ -279,14 +265,12 @@ impl
     ) -> Result<UserMFACredential, OperationOutcomeError> {
         match self {
             PGConnection::Pool(pool, _) => {
-                let res = create_user_mfa_credential(pool, tenant, new_user_mfa_credential).await?;
-                Ok(res)
+                create_user_mfa_credential(pool, tenant, new_user_mfa_credential).await
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res =
-                    create_user_mfa_credential(&mut *tx, tenant, new_user_mfa_credential).await?;
-                Ok(res)
+
+                create_user_mfa_credential(&mut **tx, tenant, new_user_mfa_credential).await
             }
         }
     }
@@ -297,14 +281,10 @@ impl
         id: &MFAKey,
     ) -> Result<Option<UserMFACredential>, haste_fhir_operation_error::OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = read_user_mfa(pool, tenant, id).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => read_user_mfa(pool, tenant, id).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = read_user_mfa(&mut *tx, tenant, id).await?;
-                Ok(res)
+                read_user_mfa(&mut **tx, tenant, id).await
             }
         }
     }
@@ -315,14 +295,10 @@ impl
         model: UserMFACredentialUpdate,
     ) -> Result<UserMFACredential, haste_fhir_operation_error::OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = update_user_mfa(pool, tenant, model).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => update_user_mfa(pool, tenant, model).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = update_user_mfa(&mut *tx, tenant, model).await?;
-                Ok(res)
+                update_user_mfa(&mut **tx, tenant, model).await
             }
         }
     }
@@ -333,14 +309,10 @@ impl
         id: &MFAKey,
     ) -> Result<(), haste_fhir_operation_error::OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = delete_user_mfa(pool, tenant, id).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => delete_user_mfa(pool, tenant, id).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = delete_user_mfa(&mut *tx, tenant, id).await?;
-                Ok(res)
+                delete_user_mfa(&mut **tx, tenant, id).await
             }
         }
     }
@@ -351,14 +323,10 @@ impl
         claims: &UserMFASearchClaims,
     ) -> Result<Vec<UserMFACredential>, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = search_user_mfa(pool, tenant, claims).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => search_user_mfa(pool, tenant, claims).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = search_user_mfa(&mut *tx, tenant, claims).await?;
-                Ok(res)
+                search_user_mfa(&mut **tx, tenant, claims).await
             }
         }
     }

--- a/backend/crates/repository/src/pg/migrate.rs
+++ b/backend/crates/repository/src/pg/migrate.rs
@@ -7,24 +7,19 @@ use crate::admin::Migrate;
 impl Migrate for super::PGConnection {
     async fn migrate(&self) -> Result<(), OperationOutcomeError> {
         match self {
-            super::PGConnection::Pool(pool, _) => {
-                sqlx::migrate!("./pg-migrations")
-                    .run(pool)
-                    .await
-                    .map_err(|e| {
-                        OperationOutcomeError::fatal(
-                            IssueType::exception(),
-                            format!("Failed to migrate repository schema: {}", e),
-                        )
-                    })?;
-                Ok(())
-            }
-            super::PGConnection::Transaction(_, _) => {
-                return Err(OperationOutcomeError::fatal(
-                    IssueType::exception(),
-                    "Cannot run migrations in a transaction.".to_string(),
-                ));
-            }
+            super::PGConnection::Pool(pool, _) => sqlx::migrate!("./pg-migrations")
+                .run(pool)
+                .await
+                .map_err(|e| {
+                    OperationOutcomeError::fatal(
+                        IssueType::exception(),
+                        format!("Failed to migrate repository schema: {e}"),
+                    )
+                }),
+            super::PGConnection::Transaction(_, _) => Err(OperationOutcomeError::fatal(
+                IssueType::exception(),
+                "Cannot run migrations in a transaction.".to_string(),
+            )),
         }
     }
 }

--- a/backend/crates/repository/src/pg/mod.rs
+++ b/backend/crates/repository/src/pg/mod.rs
@@ -53,14 +53,15 @@ pub enum PGConnection {
 static TOTAL_CACHE_SIZE: u64 = 1000 * 10;
 
 impl PGConnection {
+    #[must_use]
     pub fn pool(pool: sqlx::Pool<Postgres>) -> Self {
         PGConnection::Pool(pool, Cache::new(TOTAL_CACHE_SIZE))
     }
 
+    #[must_use]
     pub fn cache(&self) -> &Cache<VersionId, Resource> {
         match self {
-            PGConnection::Pool(_, cache) => cache,
-            PGConnection::Transaction(_, cache) => cache,
+            PGConnection::Pool(_, cache) | PGConnection::Transaction(_, cache) => cache,
         }
     }
 }

--- a/backend/crates/repository/src/pg/project.rs
+++ b/backend/crates/repository/src/pg/project.rs
@@ -1,162 +1,163 @@
 use crate::{
     admin::TenantModelAdmin,
     pg::{PGConnection, StoreError},
-    types::{
-        SupportedFHIRVersions,
-        project::{CreateProject, Project, ProjectSearchClaims},
-    },
+    types::project::{CreateProject, Project, ProjectSearchClaims},
     utilities::{generate_id, validate_id},
 };
 use haste_fhir_model::r4::generated::terminology::IssueType;
 use haste_fhir_operation_error::OperationOutcomeError;
 use haste_jwt::{ProjectId, TenantId};
-use sqlx::{Acquire, Postgres, QueryBuilder};
+use sqlx::{PgExecutor, QueryBuilder};
 
-fn create_project<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn create_project<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: CreateProject,
-) -> impl Future<Output = Result<Project, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let id = project.id.unwrap_or(ProjectId::new(generate_id(None)));
+) -> Result<Project, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let id = project.id.unwrap_or(ProjectId::new(generate_id(None)));
 
-        validate_id(id.as_ref())?;
+    validate_id(id.as_ref())?;
 
-        let project = sqlx::query_as!(
-            Project,
-            r#"INSERT INTO projects (tenant, id, fhir_version, system_created) VALUES ($1, $2, $3, $4) RETURNING tenant as "tenant: TenantId", system_created, id as "id: ProjectId", fhir_version as "fhir_version: SupportedFHIRVersions""#,
-            tenant.as_ref(),
-            id.as_ref(),
-            project.fhir_version as SupportedFHIRVersions,
-            project.system_created
-        )
-        .fetch_one(&mut *conn)
-        .await
-        .map_err(StoreError::SQLXError)?;
+    let project = sqlx::query_as::<_, Project>(
+        r"
+            INSERT INTO projects (tenant, id, fhir_version, system_created)
+            VALUES ($1, $2, $3, $4)
+            RETURNING tenant, system_created, id, fhir_version
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(id.as_ref())
+    .bind(project.fhir_version)
+    .bind(project.system_created)
+    .fetch_one(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        Ok(project)
-    }
+    Ok(project)
 }
 
-fn read_project<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn read_project<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     id: &'a str,
-) -> impl Future<Output = Result<Option<Project>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let project = sqlx::query_as!(
-            Project,
-            r#"SELECT id as "id: ProjectId", tenant as "tenant: TenantId", system_created, fhir_version as "fhir_version: SupportedFHIRVersions" FROM projects where tenant = $1 AND id = $2"#,
-            tenant.as_ref(),
-            id
-        )
-        .fetch_optional(&mut *conn)
-        .await
-        .map_err(StoreError::SQLXError)?;
+) -> Result<Option<Project>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let project = sqlx::query_as::<_, Project>(
+        r"
+            SELECT id, tenant, system_created, fhir_version
+            FROM projects
+            WHERE tenant = $1 AND id = $2
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(id)
+    .fetch_optional(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        Ok(project)
-    }
+    Ok(project)
 }
 
-fn delete_project<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn delete_project<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     id: &'a str,
-) -> impl Future<Output = Result<(), OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let _deleted_project = sqlx::query_as!(
-            Project,
-            r#"DELETE FROM projects WHERE tenant = $1 AND id = $2 and system_created = false RETURNING id as "id: ProjectId", tenant as "tenant: TenantId", system_created, fhir_version as "fhir_version: SupportedFHIRVersions""#,
-            tenant.as_ref(),
-            id
+) -> Result<(), OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let rows_affected = sqlx::query(
+        r"
+            DELETE FROM projects
+            WHERE tenant = $1 AND id = $2 AND system_created = false
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(id)
+    .execute(executor)
+    .await
+    .map_err(|_e| {
+        OperationOutcomeError::error(
+            IssueType::not_found(),
+            format!("Project '{id}' not found or is system created and cannot be deleted."),
         )
-        .fetch_optional(&mut *conn)
-        .await
-        .map_err(|_e| {
-            OperationOutcomeError::error(
-                IssueType::not_found(),
-                format!("Project '{}' not found or is system created and cannot be deleted.", id),
-            )
-        })?;
+    })?
+    .rows_affected();
 
-        if !_deleted_project.is_some() {
-            return Err(OperationOutcomeError::error(
-                IssueType::not_found(),
-                format!(
-                    "Project '{}' not found or is system created and cannot be deleted.",
-                    id
-                ),
-            ));
-        }
-
-        Ok(())
+    if rows_affected == 0 {
+        return Err(OperationOutcomeError::error(
+            IssueType::not_found(),
+            format!("Project '{id}' not found or is system created and cannot be deleted."),
+        ));
     }
+
+    Ok(())
 }
 
-fn search_project<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn search_project<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     clauses: &'a ProjectSearchClaims,
-) -> impl Future<Output = Result<Vec<Project>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let mut query_builder: QueryBuilder<Postgres> =
-            QueryBuilder::new(r#"SELECT tenant, id, fhir_version FROM projects WHERE "#);
+) -> Result<Vec<Project>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> =
+        QueryBuilder::new(r"SELECT tenant, id, fhir_version, system_created FROM projects WHERE ");
 
-        let mut and_clauses = query_builder.separated(" AND ");
+    let mut and_clauses = query_builder.separated(" AND ");
 
+    and_clauses
+        .push(" tenant = ")
+        .push_bind_unseparated(tenant.as_ref());
+
+    if let Some(id) = clauses.id.as_ref() {
         and_clauses
-            .push(" tenant = ")
-            .push_bind_unseparated(tenant.as_ref());
-
-        if let Some(id) = clauses.id.as_ref() {
-            and_clauses
-                .push(" id = ")
-                .push_bind_unseparated(id.as_ref());
-        }
-
-        if let Some(fhir_version) = clauses.fhir_version.as_ref() {
-            and_clauses
-                .push(" fhir_version = ")
-                .push_bind_unseparated(fhir_version);
-        }
-
-        if let Some(system_created) = clauses.system_created.as_ref() {
-            and_clauses
-                .push(" system_created = ")
-                .push_bind_unseparated(system_created);
-        }
-
-        let query = query_builder.build_query_as();
-
-        let projects: Vec<Project> = query
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(StoreError::from)?;
-
-        Ok(projects)
+            .push(" id = ")
+            .push_bind_unseparated(id.as_ref());
     }
+
+    if let Some(fhir_version) = clauses.fhir_version.as_ref() {
+        and_clauses
+            .push(" fhir_version = ")
+            .push_bind_unseparated(fhir_version);
+    }
+
+    if let Some(system_created) = clauses.system_created.as_ref() {
+        and_clauses
+            .push(" system_created = ")
+            .push_bind_unseparated(system_created);
+    }
+
+    let query = query_builder.build_query_as::<Project>();
+
+    let projects: Vec<Project> = query.fetch_all(executor).await.map_err(StoreError::from)?;
+
+    Ok(projects)
 }
 
 /// Not allowing updates on internal row just reading to confirm it's existance.
-fn update_project<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn update_project<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     model: Project,
-) -> impl Future<Output = Result<Project, OperationOutcomeError>> + Send + 'a {
-    async move {
-        read_project(connection, tenant, model.id.as_ref())
-            .await?
-            .ok_or_else(|| {
-                OperationOutcomeError::error(
-                    IssueType::not_found(),
-                    format!("Project '{}' not found.", model.id.as_ref()),
-                )
-            })
-    }
+) -> Result<Project, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    read_project(executor, tenant, model.id.as_ref())
+        .await?
+        .ok_or_else(|| {
+            OperationOutcomeError::error(
+                IssueType::not_found(),
+                format!("Project '{}' not found.", model.id.as_ref()),
+            )
+        })
 }
 
 impl<Key: AsRef<str> + Send + Sync>
@@ -168,14 +169,10 @@ impl<Key: AsRef<str> + Send + Sync>
         new_project: CreateProject,
     ) -> Result<Project, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = create_project(pool, tenant, new_project).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => create_project(pool, tenant, new_project).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = create_project(&mut *tx, tenant, new_project).await?;
-                Ok(res)
+                create_project(&mut **tx, tenant, new_project).await
             }
         }
     }
@@ -186,14 +183,10 @@ impl<Key: AsRef<str> + Send + Sync>
         id: &Key,
     ) -> Result<Option<Project>, haste_fhir_operation_error::OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = read_project(pool, tenant, id.as_ref()).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => read_project(pool, tenant, id.as_ref()).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = read_project(&mut *tx, tenant, id.as_ref()).await?;
-                Ok(res)
+                read_project(&mut **tx, tenant, id.as_ref()).await
             }
         }
     }
@@ -204,14 +197,10 @@ impl<Key: AsRef<str> + Send + Sync>
         model: Project,
     ) -> Result<Project, haste_fhir_operation_error::OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = update_project(pool, tenant, model).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => update_project(pool, tenant, model).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = update_project(&mut *tx, tenant, model).await?;
-                Ok(res)
+                update_project(&mut **tx, tenant, model).await
             }
         }
     }
@@ -222,14 +211,10 @@ impl<Key: AsRef<str> + Send + Sync>
         id: &Key,
     ) -> Result<(), haste_fhir_operation_error::OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = delete_project(pool, tenant, id.as_ref()).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => delete_project(pool, tenant, id.as_ref()).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = delete_project(&mut *tx, tenant, id.as_ref()).await?;
-                Ok(res)
+                delete_project(&mut **tx, tenant, id.as_ref()).await
             }
         }
     }
@@ -240,14 +225,10 @@ impl<Key: AsRef<str> + Send + Sync>
         claims: &ProjectSearchClaims,
     ) -> Result<Vec<Project>, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = search_project(pool, tenant, claims).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => search_project(pool, tenant, claims).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = search_project(&mut *tx, tenant, claims).await?;
-                Ok(res)
+                search_project(&mut **tx, tenant, claims).await
             }
         }
     }

--- a/backend/crates/repository/src/pg/rate_limit.rs
+++ b/backend/crates/repository/src/pg/rate_limit.rs
@@ -6,9 +6,9 @@ use crate::pg::{
 };
 use haste_rate_limit::{RateLimit, RateLimitError};
 use moka::future::{Cache, CacheBuilder};
-use sqlx::{Acquire, Postgres};
+use sqlx::PgExecutor;
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 enum RateLimitState {
     Count(i32),
     Max,
@@ -23,39 +23,32 @@ static MEMORY: LazyLock<Cache<String, RateLimitState>> = LazyLock::new(
     },
 );
 
-fn _check_rate_limit_remote<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn check_rate_limit_remote_with_executor<'a, 'e, E>(
+    executor: E,
     rate_key: &'a str,
     max: i32,
     points: i32,
     window_in_seconds: i32,
-) -> impl Future<Output = Result<i32, haste_rate_limit::RateLimitError>> + Send + 'a {
-    async move {
-        let mut conn = connection
-            .acquire()
+) -> Result<i32, haste_rate_limit::RateLimitError>
+where
+    E: PgExecutor<'e>,
+{
+    let result =
+        sqlx::query_as::<_, (i32,)>("SELECT check_rate_limit($1, $2, $3, $4) as current_limit")
+            .bind(rate_key)
+            .bind(max)
+            .bind(points)
+            .bind(window_in_seconds)
+            .fetch_one(executor)
             .await
-            .map_err(|_e| RateLimitError::Error("could not acquire connection".to_string()))?;
+            .map_err(|_e| RateLimitError::Exceeded)?;
 
-        let result: i32 = sqlx::query!(
-            "SELECT check_rate_limit($1, $2, $3, $4) as current_limit",
-            rate_key as &str,
-            max as i32,
-            points as i32,
-            window_in_seconds as i32,
-        )
-        .fetch_one(&mut *conn)
-        .await
-        .map_err(|_e| RateLimitError::Exceeded)?
-        .current_limit
-        .unwrap_or(0);
-
-        Ok(result)
-    }
+    Ok(result.0)
 }
 
-async fn check_rate_limit_remote<'a>(
+async fn check_rate_limit_remote(
     pg: PGConnection,
-    rate_key: &'a str,
+    rate_key: &str,
     max: i32,
     points: i32,
     window_in_seconds: i32,
@@ -67,10 +60,14 @@ async fn check_rate_limit_remote<'a>(
                 .map_err(|e| RateLimitError::Error(e.to_string()))?;
             let res = {
                 let mut conn = tx.lock().await;
-                let res =
-                    _check_rate_limit_remote(&mut *conn, rate_key, max, points, window_in_seconds)
-                        .await?;
-                res
+                check_rate_limit_remote_with_executor(
+                    &mut **conn,
+                    rate_key,
+                    max,
+                    points,
+                    window_in_seconds,
+                )
+                .await?
             };
             commit_transaction(tx)
                 .await
@@ -79,79 +76,79 @@ async fn check_rate_limit_remote<'a>(
         }
         PGConnection::Transaction(tx, _) => {
             let mut tx = tx.lock().await;
-            let res = _check_rate_limit_remote(&mut *tx, rate_key, max, points, window_in_seconds)
-                .await?;
-            Ok(res)
+            check_rate_limit_remote_with_executor(
+                &mut **tx,
+                rate_key,
+                max,
+                points,
+                window_in_seconds,
+            )
+            .await
         }
     }
 }
 
-fn check_rate_limit<'a>(
+async fn check_rate_limit(
     connection: PGConnection,
-    rate_key: &'a str,
+    rate_key: &str,
     max: i32,
     points: i32,
     window_in_seconds: i32,
-) -> impl Future<Output = Result<i32, haste_rate_limit::RateLimitError>> + Send + 'a {
-    async move {
-        // First check in-memory cache
-        if let Some(current) = MEMORY.get(rate_key).await {
-            let cloned_key = rate_key.to_string();
-            // Run background task to update the cache asynchronously without blocking the main request flow.
-            // This allows us to have a fast response time while still keeping the cache reasonably up to date.
-            tokio::spawn(async move {
-                let result = check_rate_limit_remote(
-                    connection,
-                    &cloned_key,
-                    max,
-                    points,
-                    window_in_seconds,
-                )
-                .await;
+) -> Result<i32, haste_rate_limit::RateLimitError> {
+    if let Some(current) = MEMORY.get(rate_key).await {
+        let cloned_key = rate_key.to_string();
+        let connection_clone = connection.clone();
 
-                if let Ok(points) = result {
-                    MEMORY
-                        .insert(cloned_key, RateLimitState::Count(points))
-                        .await;
-                } else if let Err(e) = result {
-                    match e {
-                        RateLimitError::Exceeded => {
-                            // If the rate limit is exceeded, we can set the in-memory cache to max to prevent further requests from hitting the database until the cache expires.
-                            MEMORY.insert(cloned_key, RateLimitState::Max).await;
-                        }
-                        RateLimitError::Error(e) => {
-                            println!("Error checking rate limit: {:?}", e);
-                        }
+        tokio::spawn(async move {
+            let result = check_rate_limit_remote(
+                connection_clone,
+                &cloned_key,
+                max,
+                points,
+                window_in_seconds,
+            )
+            .await;
+
+            if let Ok(points) = result {
+                MEMORY
+                    .insert(cloned_key, RateLimitState::Count(points))
+                    .await;
+            } else if let Err(e) = result {
+                match e {
+                    RateLimitError::Exceeded => {
+                        MEMORY.insert(cloned_key, RateLimitState::Max).await;
+                    }
+                    RateLimitError::Error(e) => {
+                        println!("Error checking rate limit: {e:?}");
                     }
                 }
-            });
-
-            match current {
-                RateLimitState::Count(current) => {
-                    let current_score = current + points;
-
-                    if current_score > max {
-                        Err(RateLimitError::Exceeded)
-                    } else {
-                        MEMORY
-                            .insert(rate_key.to_string(), RateLimitState::Count(current_score))
-                            .await;
-                        Ok(current_score)
-                    }
-                }
-                RateLimitState::Max => Err(RateLimitError::Exceeded),
             }
-        } else {
-            let result =
-                check_rate_limit_remote(connection, rate_key, max, points, window_in_seconds)
-                    .await?;
+        });
 
-            MEMORY
-                .insert(rate_key.to_string(), RateLimitState::Count(result))
-                .await;
+        match current {
+            RateLimitState::Count(current) => {
+                let current_score = current + points;
 
-            Ok(result)
+                if current_score > max {
+                    Err(RateLimitError::Exceeded)
+                } else {
+                    MEMORY
+                        .insert(rate_key.to_string(), RateLimitState::Count(current_score))
+                        .await;
+                    Ok(current_score)
+                }
+            }
+            RateLimitState::Max => Err(RateLimitError::Exceeded),
         }
+    } else {
+        let result =
+            check_rate_limit_remote(connection, rate_key, max, points, window_in_seconds).await?;
+
+        MEMORY
+            .insert(rate_key.to_string(), RateLimitState::Count(result))
+            .await;
+
+        Ok(result)
     }
 }
 

--- a/backend/crates/repository/src/pg/rate_limit.rs
+++ b/backend/crates/repository/src/pg/rate_limit.rs
@@ -41,7 +41,7 @@ where
             .bind(window_in_seconds)
             .fetch_one(executor)
             .await
-            .map_err(|_e| RateLimitError::Exceeded)?;
+            .map_err(|e| RateLimitError::Error(e.to_string()))?;
 
     Ok(result.0)
 }

--- a/backend/crates/repository/src/pg/scope.rs
+++ b/backend/crates/repository/src/pg/scope.rs
@@ -4,174 +4,175 @@ use crate::{
     types::scope::{CreateScope, Scope, ScopeKey, ScopeSearchClaims, UpdateScope},
 };
 use haste_fhir_operation_error::OperationOutcomeError;
-use haste_jwt::{ProjectId, TenantId, scopes::Scopes};
-use sqlx::{Acquire, Postgres, QueryBuilder};
+use haste_jwt::{ProjectId, TenantId};
+use sqlx::{PgExecutor, QueryBuilder};
 
-fn create_scope<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn create_scope<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: &'a ProjectId,
     scope: CreateScope,
-) -> impl Future<Output = Result<Scope, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let scope = sqlx::query_as!(
-            Scope,
-            r#"INSERT INTO authorization_scopes(tenant, project, client, user_, scope) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (tenant, project, client, user_) DO UPDATE set scope = $5  RETURNING  client, user_, scope, created_at"#,
-            tenant.as_ref(),
-            project.as_ref(),
-            &scope.client.as_ref(),
-            &scope.user_.as_ref(),
-            &scope.scope as &Scopes,
-        ).fetch_one(&mut *conn).await.map_err(StoreError::SQLXError)?;
+) -> Result<Scope, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let scope = sqlx::query_as::<_, Scope>(
+        r"
+            INSERT INTO authorization_scopes(tenant, project, client, user_, scope)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (tenant, project, client, user_)
+            DO UPDATE SET scope = $5
+            RETURNING client, user_, scope, created_at
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(project.as_ref())
+    .bind(scope.client.as_ref())
+    .bind(scope.user_.as_ref())
+    .bind(scope.scope)
+    .fetch_one(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        Ok(scope)
-    }
+    Ok(scope)
 }
 
-fn update_scope<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn update_scope<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: &'a ProjectId,
     model: UpdateScope,
-) -> impl Future<Output = Result<Scope, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let mut query_builder = QueryBuilder::new(
-            r#"
-                UPDATE authorization_scopes SET 
-            "#,
-        );
+) -> Result<Scope, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder = QueryBuilder::new(
+        r"
+            UPDATE authorization_scopes SET
+        ",
+    );
 
-        let mut set_statements = query_builder.separated(", ");
+    let mut set_statements = query_builder.separated(", ");
 
-        set_statements
-            .push(" scope = ")
-            .push_bind_unseparated(model.scope);
+    set_statements
+        .push(" scope = ")
+        .push_bind_unseparated(model.scope);
 
-        query_builder.push(" WHERE ");
+    query_builder.push(" WHERE ");
 
-        let mut where_statements = query_builder.separated(" AND ");
-        where_statements
-            .push(" tenant = ")
-            .push_bind_unseparated(tenant.as_ref())
-            .push(" project = ")
-            .push_bind_unseparated(project.as_ref())
-            .push(" client = ")
-            .push_bind_unseparated(model.client.as_ref())
-            .push(" user = ")
-            .push_bind_unseparated(model.user_.as_ref());
+    let mut where_statements = query_builder.separated(" AND ");
+    where_statements
+        .push(" tenant = ")
+        .push_bind_unseparated(tenant.as_ref())
+        .push(" project = ")
+        .push_bind_unseparated(project.as_ref())
+        .push(" client = ")
+        .push_bind_unseparated(model.client.as_ref())
+        .push(" user = ")
+        .push_bind_unseparated(model.user_.as_ref());
 
-        query_builder.push(r#" RETURNING client, user_ , scope, created_at"#);
+    query_builder.push(r" RETURNING client, user_, scope, created_at");
 
-        let query = query_builder.build_query_as();
+    let query = query_builder.build_query_as::<Scope>();
 
-        let scope = query
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(StoreError::SQLXError)?;
+    let scope = query
+        .fetch_one(executor)
+        .await
+        .map_err(StoreError::SQLXError)?;
 
-        Ok(scope)
-    }
+    Ok(scope)
 }
 
-fn read_scope<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn read_scope<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: &'a ProjectId,
     id: &'a ScopeKey,
-) -> impl Future<Output = Result<Option<Scope>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let scope = sqlx::query_as!(
-            Scope,
-            r#"
-                SELECT user_, client, scope, created_at
-                FROM authorization_scopes
-                WHERE tenant = $1 AND project = $2 AND client = $3 and user_ = $4
-            "#,
-            tenant.as_ref(),
-            project.as_ref(),
-            String::from(id.0.clone()),
-            String::from(id.1.clone()),
-        )
-        .fetch_optional(&mut *conn)
-        .await
-        .map_err(StoreError::SQLXError)?;
+) -> Result<Option<Scope>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let scope = sqlx::query_as::<_, Scope>(
+        r"
+            SELECT user_, client, scope, created_at
+            FROM authorization_scopes
+            WHERE tenant = $1 AND project = $2 AND client = $3 AND user_ = $4
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(project.as_ref())
+    .bind(String::from(id.0.clone()))
+    .bind(String::from(id.1.clone()))
+    .fetch_optional(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        Ok(scope)
-    }
+    Ok(scope)
 }
 
-fn delete_scope<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn delete_scope<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: &'a ProjectId,
     key: &'a ScopeKey,
-) -> impl Future<Output = Result<(), OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let _scope = sqlx::query_as!(
-            Scope,
-            r#"
-                DELETE FROM authorization_scopes
-                WHERE tenant = $1 AND project = $2 AND client = $3 AND user_ = $4
-                RETURNING user_, client, scope, created_at
-            "#,
-            tenant.as_ref(),
-            project.as_ref(),
-            key.0.as_ref(),
-            key.1.as_ref(),
-        )
-        .fetch_optional(&mut *conn)
-        .await
-        .map_err(StoreError::SQLXError)?;
+) -> Result<(), OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    sqlx::query(
+        r"
+            DELETE FROM authorization_scopes
+            WHERE tenant = $1 AND project = $2 AND client = $3 AND user_ = $4
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(project.as_ref())
+    .bind(key.0.as_ref())
+    .bind(key.1.as_ref())
+    .execute(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        Ok(())
-    }
+    Ok(())
 }
 
-fn search_scopes<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn search_scopes<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     project: &'a ProjectId,
     clauses: &'a ScopeSearchClaims,
-) -> impl Future<Output = Result<Vec<Scope>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
+) -> Result<Vec<Scope>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> = QueryBuilder::new(
+        r"SELECT user_, client, scope, created_at FROM authorization_scopes WHERE ",
+    );
 
-        let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
-            r#"SELECT user_, client, scope, created_at FROM authorization_scopes WHERE  "#,
-        );
+    let mut seperator = query_builder.separated(" AND ");
+    seperator
+        .push(" tenant = ")
+        .push_bind_unseparated(tenant.as_ref())
+        .push(" project = ")
+        .push_bind_unseparated(project.as_ref());
 
-        let mut seperator = query_builder.separated(" AND ");
+    if let Some(user_id) = clauses.user_.as_ref() {
         seperator
-            .push(" tenant = ")
-            .push_bind_unseparated(tenant.as_ref())
-            .push(" project = ")
-            .push_bind_unseparated(project.as_ref());
-
-        if let Some(user_id) = clauses.user_.as_ref() {
-            seperator
-                .push(" user_ = ")
-                .push_bind_unseparated(user_id.as_ref());
-        }
-
-        if let Some(client) = clauses.client.as_ref() {
-            seperator
-                .push(" client = ")
-                .push_bind_unseparated(client.as_ref());
-        }
-
-        let query = query_builder.build_query_as();
-
-        let scopes: Vec<Scope> = query
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(StoreError::from)?;
-
-        Ok(scopes)
+            .push(" user_ = ")
+            .push_bind_unseparated(user_id.as_ref());
     }
+
+    if let Some(client) = clauses.client.as_ref() {
+        seperator
+            .push(" client = ")
+            .push_bind_unseparated(client.as_ref());
+    }
+
+    let query = query_builder.build_query_as::<Scope>();
+
+    let scopes: Vec<Scope> = query.fetch_all(executor).await.map_err(StoreError::from)?;
+
+    Ok(scopes)
 }
 
 impl ProjectModelAdmin<CreateScope, Scope, ScopeSearchClaims, UpdateScope, ScopeKey>
@@ -184,14 +185,10 @@ impl ProjectModelAdmin<CreateScope, Scope, ScopeSearchClaims, UpdateScope, Scope
         new_scope: CreateScope,
     ) -> Result<Scope, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = create_scope(pool, tenant, project, new_scope).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => create_scope(pool, tenant, project, new_scope).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = create_scope(&mut *tx, tenant, project, new_scope).await?;
-                Ok(res)
+                create_scope(&mut **tx, tenant, project, new_scope).await
             }
         }
     }
@@ -203,14 +200,10 @@ impl ProjectModelAdmin<CreateScope, Scope, ScopeSearchClaims, UpdateScope, Scope
         key: &ScopeKey,
     ) -> Result<Option<Scope>, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = read_scope(pool, tenant, project, key).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => read_scope(pool, tenant, project, key).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = read_scope(&mut *tx, tenant, project, key).await?;
-                Ok(res)
+                read_scope(&mut **tx, tenant, project, key).await
             }
         }
     }
@@ -222,14 +215,10 @@ impl ProjectModelAdmin<CreateScope, Scope, ScopeSearchClaims, UpdateScope, Scope
         model: UpdateScope,
     ) -> Result<Scope, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = update_scope(pool, tenant, project, model).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => update_scope(pool, tenant, project, model).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = update_scope(&mut *tx, tenant, project, model).await?;
-                Ok(res)
+                update_scope(&mut **tx, tenant, project, model).await
             }
         }
     }
@@ -241,14 +230,10 @@ impl ProjectModelAdmin<CreateScope, Scope, ScopeSearchClaims, UpdateScope, Scope
         key: &ScopeKey,
     ) -> Result<(), OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = delete_scope(pool, tenant, project, key).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => delete_scope(pool, tenant, project, key).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = delete_scope(&mut *tx, tenant, project, key).await?;
-                Ok(res)
+                delete_scope(&mut **tx, tenant, project, key).await
             }
         }
     }
@@ -260,14 +245,10 @@ impl ProjectModelAdmin<CreateScope, Scope, ScopeSearchClaims, UpdateScope, Scope
         clauses: &ScopeSearchClaims,
     ) -> Result<Vec<Scope>, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = search_scopes(pool, tenant, project, clauses).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => search_scopes(pool, tenant, project, clauses).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = search_scopes(&mut *tx, tenant, project, clauses).await?;
-                Ok(res)
+                search_scopes(&mut **tx, tenant, project, clauses).await
             }
         }
     }

--- a/backend/crates/repository/src/pg/scope.rs
+++ b/backend/crates/repository/src/pg/scope.rs
@@ -68,7 +68,7 @@ where
         .push_bind_unseparated(project.as_ref())
         .push(" client = ")
         .push_bind_unseparated(model.client.as_ref())
-        .push(" user = ")
+        .push(" user_ = ")
         .push_bind_unseparated(model.user_.as_ref());
 
     query_builder.push(r" RETURNING client, user_, scope, created_at");

--- a/backend/crates/repository/src/pg/sequence.rs
+++ b/backend/crates/repository/src/pg/sequence.rs
@@ -58,7 +58,7 @@ async fn get_sequence_helper(
     .await
     .map_err(StoreError::from)?;
 
-    let polling_values: Result<Vec<ResourcePollingValue>, OperationOutcomeError> = result
+    result
         .into_iter()
         .map(
             |(
@@ -90,9 +90,7 @@ async fn get_sequence_helper(
                 })
             },
         )
-        .collect();
-
-    polling_values
+        .collect()
 }
 
 // 2. Trait implementation matching your PGConnection enum
@@ -105,16 +103,15 @@ impl ResourceSequential for PGConnection {
     ) -> Result<Vec<ResourcePollingValue>, OperationOutcomeError> {
         match self {
             PGConnection::Pool(pool, _) => {
-                // Acquire an explicit connection from the pool to run multiple queries sequentially
+                // Acquire a dedicated connection from the pool so both queries execute
+                // sequentially on the same PgConnection, matching the transaction path.
                 let mut conn = pool.acquire().await.map_err(StoreError::from)?;
-                let res = get_sequence_helper(&mut conn, tenant_id, sequence_id, count).await?;
-                Ok(res)
+                get_sequence_helper(&mut conn, tenant_id, sequence_id, count).await
             }
             PGConnection::Transaction(tx, _) => {
                 let mut conn = tx.lock().await;
                 // Pass the mutable reference to the underlying PgConnection handle
-                let res = get_sequence_helper(&mut conn, tenant_id, sequence_id, count).await?;
-                Ok(res)
+                get_sequence_helper(&mut conn, tenant_id, sequence_id, count).await
             }
         }
     }

--- a/backend/crates/repository/src/pg/sequence.rs
+++ b/backend/crates/repository/src/pg/sequence.rs
@@ -85,7 +85,7 @@ async fn get_sequence_helper(
                     version_id,
                     resource_type,
                     fhir_method,
-                    sequence, // Fixed: Left as i64 as expected by your model struct definition
+                    sequence,
                     resource,
                 })
             },

--- a/backend/crates/repository/src/pg/sequence.rs
+++ b/backend/crates/repository/src/pg/sequence.rs
@@ -1,10 +1,11 @@
 use haste_fhir_model::r4::{
     generated::resources::{Resource, ResourceType},
+    generated::terminology::IssueType,
     sqlx::FHIRJson,
 };
 use haste_fhir_operation_error::OperationOutcomeError;
 use haste_jwt::{ProjectId, ResourceId, TenantId};
-use sqlx::{Acquire, Postgres};
+use sqlx::PgConnection;
 
 use crate::{
     pg::{PGConnection, StoreError},
@@ -12,54 +13,89 @@ use crate::{
     types::FHIRMethod,
 };
 
-fn get_sequence<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
-    tenant_id: &'a TenantId,
+// 1. Concrete helper function accepting an explicit reference to remove HRTB issues entirely
+async fn get_sequence_helper(
+    executor: &mut PgConnection,
+    tenant_id: &TenantId,
     cur_sequence: u64,
     count: Option<u64>,
-) -> impl Future<Output = Result<Vec<ResourcePollingValue>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::from)?;
-        // Run as a transaction to ensure safe sequence retrieval.
-        // Run as seperate query.
-        // Isolation level must be set to allowe dirty reads from pg_locks.
-        // This is to ensure that we can read the safe sequence even if other transactions are in progress.
-        let safe_sequence =
-            sqlx::query!("SELECT max_safe_seq('resources_sequence_seq') as max_safe_seq")
-                .fetch_one(&mut *conn)
-                .await
-                .map_err(StoreError::from)?
-                .max_safe_seq
-                .unwrap_or(0);
+) -> Result<Vec<ResourcePollingValue>, OperationOutcomeError> {
+    let safe_sequence_row = sqlx::query_as::<_, (Option<i64>,)>(
+        "SELECT max_safe_seq('resources_sequence_seq') as max_safe_seq",
+    )
+    .fetch_one(&mut *executor)
+    .await
+    .map_err(StoreError::from)?;
 
-        let result = sqlx::query_as!(
-            ResourcePollingValue,
-            r#"SELECT  id as "id: ResourceId", 
-                       tenant as "tenant: TenantId", 
-                       project as "project: ProjectId", 
-                       version_id, 
-                       resource_type as "resource_type: ResourceType", 
-                       fhir_method as "fhir_method: FHIRMethod", 
-                       sequence, 
-                       resource as "resource: FHIRJson<Resource>"
-            FROM resources WHERE tenant = $1 AND sequence > $2 AND sequence <= $3 ORDER BY sequence LIMIT $4 "#,
-            tenant_id.as_ref() as &str,
-            cur_sequence as i64,
-            safe_sequence,
-            count.unwrap_or(100) as i64
+    let safe_sequence = safe_sequence_row.0.unwrap_or(0);
+
+    let result = sqlx::query_as::<
+        _,
+        (
+            String,
+            TenantId,
+            ProjectId,
+            String,
+            String,
+            FHIRMethod,
+            i64,
+            FHIRJson<Resource>,
+        ),
+    >(
+        r"
+            SELECT id, tenant, project, version_id, resource_type, fhir_method, sequence, resource
+            FROM resources
+            WHERE tenant = $1 AND sequence > $2 AND sequence <= $3
+            ORDER BY sequence
+            LIMIT $4
+        ",
+    )
+    .bind(tenant_id.as_ref())
+    .bind(cur_sequence.cast_signed())
+    .bind(safe_sequence)
+    .bind(count.unwrap_or(100).cast_signed())
+    .fetch_all(executor)
+    .await
+    .map_err(StoreError::from)?;
+
+    let polling_values: Result<Vec<ResourcePollingValue>, OperationOutcomeError> = result
+        .into_iter()
+        .map(
+            |(
+                id,
+                tenant,
+                project,
+                version_id,
+                resource_type_str,
+                fhir_method,
+                sequence,
+                resource,
+            )| {
+                let resource_type = ResourceType::try_from(resource_type_str).map_err(|_| {
+                    OperationOutcomeError::error(
+                        IssueType::structure(),
+                        "Invalid resource type encountered during sequence polling.".to_string(),
+                    )
+                })?;
+
+                Ok::<ResourcePollingValue, OperationOutcomeError>(ResourcePollingValue {
+                    id: ResourceId::new(id),
+                    tenant,
+                    project,
+                    version_id,
+                    resource_type,
+                    fhir_method,
+                    sequence, // Fixed: Left as i64 as expected by your model struct definition
+                    resource,
+                })
+            },
         )
-        .fetch_all(&mut *conn)
-        .await
-        .map_err(StoreError::from)?;
+        .collect();
 
-        // if !result.is_empty() {
-        //     println!("safe_sequence: {:?}", safe_sequence);
-        // }
-
-        Ok(result)
-    }
+    polling_values
 }
 
+// 2. Trait implementation matching your PGConnection enum
 impl ResourceSequential for PGConnection {
     async fn get_sequence(
         &self,
@@ -69,14 +105,15 @@ impl ResourceSequential for PGConnection {
     ) -> Result<Vec<ResourcePollingValue>, OperationOutcomeError> {
         match self {
             PGConnection::Pool(pool, _) => {
-                let res = get_sequence(pool, tenant_id, sequence_id, count).await?;
+                // Acquire an explicit connection from the pool to run multiple queries sequentially
+                let mut conn = pool.acquire().await.map_err(StoreError::from)?;
+                let res = get_sequence_helper(&mut conn, tenant_id, sequence_id, count).await?;
                 Ok(res)
             }
             PGConnection::Transaction(tx, _) => {
                 let mut conn = tx.lock().await;
-
-                // Handle PgConnection connection
-                let res = get_sequence(&mut *conn, tenant_id, sequence_id, count).await?;
+                // Pass the mutable reference to the underlying PgConnection handle
+                let res = get_sequence_helper(&mut conn, tenant_id, sequence_id, count).await?;
                 Ok(res)
             }
         }

--- a/backend/crates/repository/src/pg/system.rs
+++ b/backend/crates/repository/src/pg/system.rs
@@ -4,41 +4,37 @@ use crate::{
     types::user::{User, UserSearchClauses},
 };
 use haste_fhir_operation_error::OperationOutcomeError;
-use sqlx::{Acquire, Postgres, QueryBuilder};
+use sqlx::{PgExecutor, QueryBuilder};
 
-fn search_system_user<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn search_system_user<'a, 'e, E>(
+    executor: E,
     clauses: &'a UserSearchClauses,
-) -> impl Future<Output = Result<Vec<User>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
-            r#"SELECT id, tenant, email, role, method, provider_id FROM users WHERE  "#,
-        );
+) -> Result<Vec<User>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> =
+        QueryBuilder::new(r"SELECT id, tenant, email, role, method, provider_id FROM users WHERE ");
 
-        let mut seperator = query_builder.separated(" AND ");
+    let mut seperator = query_builder.separated(" AND ");
 
-        if let Some(email) = clauses.email.as_ref() {
-            seperator.push(" email = ").push_bind_unseparated(email);
-        }
-
-        if let Some(role) = clauses.role.as_ref() {
-            seperator.push(" role = ").push_bind_unseparated(role);
-        }
-
-        if let Some(method) = clauses.method.as_ref() {
-            seperator.push(" method = ").push_bind_unseparated(method);
-        }
-
-        let query = query_builder.build_query_as();
-
-        let users: Vec<User> = query
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(StoreError::from)?;
-
-        Ok(users)
+    if let Some(email) = clauses.email.as_ref() {
+        seperator.push(" email = ").push_bind_unseparated(email);
     }
+
+    if let Some(role) = clauses.role.as_ref() {
+        seperator.push(" role = ").push_bind_unseparated(role);
+    }
+
+    if let Some(method) = clauses.method.as_ref() {
+        seperator.push(" method = ").push_bind_unseparated(method);
+    }
+
+    let query = query_builder.build_query_as::<User>();
+
+    let users: Vec<User> = query.fetch_all(executor).await.map_err(StoreError::from)?;
+
+    Ok(users)
 }
 
 impl SystemAdmin<User, UserSearchClauses> for PGConnection {
@@ -53,7 +49,7 @@ impl SystemAdmin<User, UserSearchClauses> for PGConnection {
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = search_system_user(&mut *tx, clauses).await?;
+                let res = search_system_user(&mut **tx, clauses).await?;
                 Ok(res)
             }
         }

--- a/backend/crates/repository/src/pg/tenant.rs
+++ b/backend/crates/repository/src/pg/tenant.rs
@@ -6,120 +6,132 @@ use crate::{
 };
 use haste_fhir_operation_error::OperationOutcomeError;
 use haste_jwt::TenantId;
-use sqlx::{Acquire, Postgres, QueryBuilder};
+use sqlx::{PgExecutor, QueryBuilder};
 
-fn create_tenant<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn create_tenant<'a, 'e, E>(
+    executor: E,
     tenant: CreateTenant,
-) -> impl Future<Output = Result<Tenant, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let id = tenant.id.unwrap_or(TenantId::new(generate_id(None)));
-        validate_id(id.as_ref())?;
+) -> Result<Tenant, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let id = tenant
+        .id
+        .unwrap_or_else(|| TenantId::new(generate_id(None)));
+    validate_id(id.as_ref())?;
 
-        let result = sqlx::query_as!(
-            Tenant,
-            r#"INSERT INTO tenants (id, subscription_tier) VALUES ($1, $2) RETURNING id as "id: TenantId", subscription_tier"#,
-            id as TenantId,
-            tenant.subscription_tier.unwrap_or("free".to_string())
-        )
-        .fetch_one(&mut *conn)
-        .await;
+    let result = sqlx::query_as::<_, Tenant>(
+        r"
+            INSERT INTO tenants (id, subscription_tier)
+            VALUES ($1, $2)
+            RETURNING id, subscription_tier
+        ",
+    )
+    .bind(id)
+    .bind(
+        tenant
+            .subscription_tier
+            .unwrap_or_else(|| "free".to_string()),
+    )
+    .fetch_one(executor)
+    .await;
 
-        if let Err(res) = result.as_ref()
-            && let sqlx::Error::Database(db_error) = res
-            && db_error.code().as_deref() == Some("23505")
-        {
-            println!("Duplicate tenant ID detected");
-            Err(StoreError::Duplicate.into())
-        } else {
-            Ok(result.map_err(StoreError::SQLXError)?)
-        }
+    if let Err(ref res) = result
+        && let sqlx::Error::Database(db_error) = res
+        && db_error.code().as_deref() == Some("23505")
+    {
+        println!("Duplicate tenant ID detected");
+        Err(StoreError::Duplicate.into())
+    } else {
+        Ok(result.map_err(StoreError::SQLXError)?)
     }
 }
 
-fn read_tenant<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn read_tenant<'a, 'e, E>(
+    executor: E,
     id: &'a str,
-) -> impl Future<Output = Result<Option<Tenant>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let tenant = sqlx::query_as!(
-            Tenant,
-            r#"SELECT id as "id: TenantId", subscription_tier FROM tenants where id = $1"#,
-            id
-        )
-        .fetch_optional(&mut *conn)
-        .await
-        .map_err(StoreError::SQLXError)?;
+) -> Result<Option<Tenant>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let tenant = sqlx::query_as::<_, Tenant>(
+        r"
+            SELECT id, subscription_tier
+            FROM tenants
+            WHERE id = $1
+        ",
+    )
+    .bind(id)
+    .fetch_optional(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        Ok(tenant)
-    }
+    Ok(tenant)
 }
 
-fn update_tenant<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn update_tenant<'a, 'e, E>(
+    executor: E,
     tenant: Tenant,
-) -> impl Future<Output = Result<Tenant, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let updated_tenant = sqlx::query_as!(
-            Tenant,
-            r#"UPDATE tenants SET subscription_tier = $1 WHERE id = $2 RETURNING id as "id: TenantId", subscription_tier"#,
-            tenant.subscription_tier,
-            tenant.id as TenantId,
-        )
-        .fetch_one(&mut *conn)
-        .await
-        .map_err(StoreError::SQLXError)?;
+) -> Result<Tenant, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let updated_tenant = sqlx::query_as::<_, Tenant>(
+        r"
+            UPDATE tenants
+            SET subscription_tier = $1
+            WHERE id = $2
+            RETURNING id, subscription_tier
+        ",
+    )
+    .bind(tenant.subscription_tier)
+    .bind(tenant.id)
+    .fetch_one(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        Ok(updated_tenant)
-    }
+    Ok(updated_tenant)
 }
 
-fn delete_tenant<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
-    id: &'a str,
-) -> impl Future<Output = Result<(), OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let _deleted_tenant = sqlx::query_as!(
-            Tenant,
-            r#"DELETE FROM tenants WHERE id = $1 RETURNING id as "id: TenantId", subscription_tier"#,
-            id
-        )
-        .fetch_optional(&mut *conn)
-        .await
-        .map_err(StoreError::SQLXError)?;
+async fn delete_tenant<'a, 'e, E>(executor: E, id: &'a str) -> Result<(), OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    sqlx::query(
+        r"
+            DELETE FROM tenants
+            WHERE id = $1
+        ",
+    )
+    .bind(id)
+    .execute(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        Ok(())
-    }
+    Ok(())
 }
 
-fn search_tenant<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn search_tenant<'a, 'e, E>(
+    executor: E,
     clauses: &'a TenantSearchClaims,
-) -> impl Future<Output = Result<Vec<Tenant>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let mut query_builder: QueryBuilder<Postgres> =
-            QueryBuilder::new(r#"SELECT id, subscription_tier FROM tenants WHERE "#);
+) -> Result<Vec<Tenant>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> =
+        QueryBuilder::new(r"SELECT id, subscription_tier FROM tenants WHERE ");
 
-        if let Some(subscription_tier) = clauses.subscription_tier.as_ref() {
-            query_builder
-                .push(" subscription_tier = ")
-                .push_bind(subscription_tier);
-        }
-
-        let query = query_builder.build_query_as();
-
-        let tenants: Vec<Tenant> = query
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(StoreError::from)?;
-
-        Ok(tenants)
+    if let Some(subscription_tier) = clauses.subscription_tier.as_ref() {
+        query_builder
+            .push(" subscription_tier = ")
+            .push_bind(subscription_tier);
     }
+
+    let query = query_builder.build_query_as::<Tenant>();
+
+    let tenants: Vec<Tenant> = query.fetch_all(executor).await.map_err(StoreError::from)?;
+
+    Ok(tenants)
 }
 
 impl<Key: AsRef<str> + Send + Sync>
@@ -131,14 +143,10 @@ impl<Key: AsRef<str> + Send + Sync>
         new_tenant: CreateTenant,
     ) -> Result<Tenant, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = create_tenant(pool, new_tenant).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => create_tenant(pool, new_tenant).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = create_tenant(&mut *tx, new_tenant).await?;
-                Ok(res)
+                create_tenant(&mut **tx, new_tenant).await
             }
         }
     }
@@ -149,14 +157,10 @@ impl<Key: AsRef<str> + Send + Sync>
         id: &Key,
     ) -> Result<Option<Tenant>, haste_fhir_operation_error::OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = read_tenant(pool, id.as_ref()).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => read_tenant(pool, id.as_ref()).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = read_tenant(&mut *tx, id.as_ref()).await?;
-                Ok(res)
+                read_tenant(&mut **tx, id.as_ref()).await
             }
         }
     }
@@ -167,14 +171,10 @@ impl<Key: AsRef<str> + Send + Sync>
         model: Tenant,
     ) -> Result<Tenant, haste_fhir_operation_error::OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = update_tenant(pool, model).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => update_tenant(pool, model).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = update_tenant(&mut *tx, model).await?;
-                Ok(res)
+                update_tenant(&mut **tx, model).await
             }
         }
     }
@@ -185,14 +185,10 @@ impl<Key: AsRef<str> + Send + Sync>
         id: &Key,
     ) -> Result<(), haste_fhir_operation_error::OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = delete_tenant(pool, id.as_ref()).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => delete_tenant(pool, id.as_ref()).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = delete_tenant(&mut *tx, id.as_ref()).await?;
-                Ok(res)
+                delete_tenant(&mut **tx, id.as_ref()).await
             }
         }
     }
@@ -203,14 +199,10 @@ impl<Key: AsRef<str> + Send + Sync>
         claims: &TenantSearchClaims,
     ) -> Result<Vec<Tenant>, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = search_tenant(pool, claims).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => search_tenant(pool, claims).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = search_tenant(&mut *tx, claims).await?;
-                Ok(res)
+                search_tenant(&mut **tx, claims).await
             }
         }
     }

--- a/backend/crates/repository/src/pg/tenant.rs
+++ b/backend/crates/repository/src/pg/tenant.rs
@@ -36,14 +36,18 @@ where
     .fetch_one(executor)
     .await;
 
-    if let Err(ref res) = result
-        && let sqlx::Error::Database(db_error) = res
-        && db_error.code().as_deref() == Some("23505")
-    {
-        println!("Duplicate tenant ID detected");
-        Err(StoreError::Duplicate.into())
-    } else {
-        Ok(result.map_err(StoreError::SQLXError)?)
+    match result {
+        Ok(tenant) => Ok(tenant),
+        Err(e) => {
+            if let sqlx::Error::Database(db_error) = &e
+                && db_error.code().as_deref() == Some("23505")
+            {
+                println!("Duplicate tenant ID detected");
+                Err(StoreError::Duplicate.into())
+            } else {
+                Err(StoreError::SQLXError(e).into())
+            }
+        }
     }
 }
 

--- a/backend/crates/repository/src/pg/user.rs
+++ b/backend/crates/repository/src/pg/user.rs
@@ -12,70 +12,87 @@ use argon2::{
 };
 use haste_fhir_operation_error::OperationOutcomeError;
 use haste_jwt::TenantId;
-use sqlx::{Acquire, Postgres, QueryBuilder};
+use sqlx::{PgExecutor, QueryBuilder};
 
 fn hash_password(password: &str) -> Result<String, StoreError> {
     let salt = SaltString::generate(&mut OsRng);
     let hash = Argon2::default()
         .hash_password(password.as_bytes(), &salt)
-        .map_err(|e| StoreError::PasswordHashError(e))?
+        .map_err(StoreError::PasswordHashError)?
         .to_string();
 
     Ok(hash)
 }
 
-fn login<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn login<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     method: &'a LoginMethod,
-) -> impl Future<Output = Result<LoginResult, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        match method {
-            LoginMethod::EmailPassword { email, password } => {
-                let row = sqlx::query!(
-                    r#"
-                  SELECT id, tenant as "tenant: TenantId", email, role as "role: UserRole", method as "method: AuthMethod", provider_id, password FROM users WHERE tenant = $1 AND method = $2 AND email = $3
-                "#,
-                    tenant.as_ref(),
-                    AuthMethod::EmailPassword as AuthMethod,
-                    email
-                ).fetch_optional(&mut *conn).await.map_err(StoreError::from)?;
+) -> Result<LoginResult, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    match method {
+        LoginMethod::EmailPassword { email, password } => {
+            let row = sqlx::query_as::<
+                _,
+                (
+                    String,
+                    TenantId,
+                    Option<String>,
+                    UserRole,
+                    AuthMethod,
+                    Option<String>,
+                    Option<String>,
+                ),
+            >(
+                r"
+                    SELECT id, tenant, email, role, method, provider_id, password
+                    FROM users
+                    WHERE tenant = $1 AND method = $2 AND email = $3
+                ",
+            )
+            .bind(tenant.as_ref())
+            .bind(AuthMethod::EmailPassword)
+            .bind(email)
+            .fetch_optional(executor)
+            .await
+            .map_err(StoreError::from)?;
 
-                let Some(row) = row else {
-                    return Ok(LoginResult::Failure);
-                };
+            let Some((id, tenant_id, email_val, role, method_val, provider_id, password_hash)) =
+                row
+            else {
+                return Ok(LoginResult::Failure);
+            };
 
-                let verified = row
-                    .password
-                    .as_deref()
-                    .and_then(|hash| PasswordHash::new(hash).ok())
-                    .is_some_and(|parsed_hash| {
-                        Argon2::default()
-                            .verify_password(password.as_bytes(), &parsed_hash)
-                            .is_ok()
-                    });
+            let verified = password_hash
+                .as_deref()
+                .and_then(|hash| PasswordHash::new(hash).ok())
+                .is_some_and(|parsed_hash| {
+                    Argon2::default()
+                        .verify_password(password.as_bytes(), &parsed_hash)
+                        .is_ok()
+                });
 
-                if !verified {
-                    return Ok(LoginResult::Failure);
-                }
-
-                Ok(LoginResult::Success {
-                    user: User {
-                        id: row.id,
-                        tenant: row.tenant,
-                        email: row.email,
-                        role: row.role,
-                        method: row.method,
-                        provider_id: row.provider_id,
-                    },
-                })
+            if !verified {
+                return Ok(LoginResult::Failure);
             }
-            LoginMethod::OIDC {
-                email: _,
-                provider_id: _,
-            } => Ok(LoginResult::Failure),
+
+            Ok(LoginResult::Success {
+                user: User {
+                    id,
+                    tenant: tenant_id,
+                    email: email_val,
+                    role,
+                    method: method_val,
+                    provider_id,
+                },
+            })
         }
+        LoginMethod::OIDC {
+            email: _,
+            provider_id: _,
+        } => Ok(LoginResult::Failure),
     }
 }
 
@@ -93,209 +110,207 @@ impl Login for PGConnection {
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
 
-                let res = login(&mut *tx, tenant, method).await?;
+                let res = login(&mut **tx, tenant, method).await?;
                 Ok(res)
             }
         }
     }
 }
 
-fn create_user<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn create_user<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     new_user: CreateUser,
-) -> impl Future<Output = Result<User, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
+) -> Result<User, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder = QueryBuilder::new(
+        r"
+            INSERT INTO users(tenant, id, email, role, method, provider_id, password)
+        ",
+    );
 
-        let mut query_builder = QueryBuilder::new(
-            r#"
-                INSERT INTO users(tenant, id, email, role, method, provider_id, password)
-            "#,
-        );
+    query_builder.push(" VALUES (");
 
-        query_builder.push(" VALUES (");
+    let mut seperator = query_builder.separated(", ");
 
-        let mut seperator = query_builder.separated(", ");
+    seperator
+        .push_bind(tenant.as_ref())
+        .push_bind(new_user.id)
+        .push_bind(new_user.email)
+        .push_bind(new_user.role)
+        .push_bind(new_user.method);
 
-        seperator
-            .push_bind(tenant.as_ref())
-            .push_bind(new_user.id)
-            .push_bind(new_user.email)
-            .push_bind(new_user.role as UserRole)
-            .push_bind(new_user.method as AuthMethod);
-
-        if let Some(provider_id) = new_user.provider_id {
-            seperator.push_bind(provider_id);
-        } else {
-            seperator.push_bind(None::<String>);
-        }
-
-        if let Some(password) = new_user.password {
-            let hashed_password = hash_password(&password)?;
-            seperator.push_bind(hashed_password);
-        } else {
-            seperator.push_bind(None::<String>);
-        }
-
-        query_builder.push(r#") RETURNING id, tenant, provider_id, email, role , method"#);
-
-        let query = query_builder.build_query_as();
-
-        let user = query
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(StoreError::SQLXError)?;
-
-        Ok(user)
+    if let Some(provider_id) = new_user.provider_id {
+        seperator.push_bind(provider_id);
+    } else {
+        seperator.push_bind(None::<String>);
     }
+
+    if let Some(password) = new_user.password {
+        let hashed_password = hash_password(&password)?;
+        seperator.push_bind(hashed_password);
+    } else {
+        seperator.push_bind(None::<String>);
+    }
+
+    query_builder.push(r") RETURNING id, tenant, provider_id, email, role, method");
+
+    let query = query_builder.build_query_as::<User>();
+
+    let user = query
+        .fetch_one(executor)
+        .await
+        .map_err(StoreError::SQLXError)?;
+
+    Ok(user)
 }
 
-fn read_user<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn read_user<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     id: &'a str,
-) -> impl Future<Output = Result<Option<User>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let user = sqlx::query_as!(
-            User,
-            r#"
-                SELECT id, tenant as "tenant: TenantId", provider_id, email, role as "role: UserRole", method as "method: AuthMethod"
-                FROM users
-                WHERE tenant = $1 AND id = $2
-            "#,
-            tenant.as_ref(),
-            id
-        ).fetch_optional(&mut *conn).await.map_err(StoreError::SQLXError)?;
+) -> Result<Option<User>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let user = sqlx::query_as::<_, User>(
+        r"
+            SELECT id, tenant, provider_id, email, role, method
+            FROM users
+            WHERE tenant = $1 AND id = $2
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(id)
+    .fetch_optional(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        Ok(user)
-    }
+    Ok(user)
 }
 
-fn update_user<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn update_user<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     model: UpdateUser,
-) -> impl Future<Output = Result<User, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let mut query_builder = QueryBuilder::new(
-            r#"
-                UPDATE users SET 
-            "#,
-        );
+) -> Result<User, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder = QueryBuilder::new(
+        r"
+            UPDATE users SET
+        ",
+    );
 
-        let mut update_clauses = query_builder.separated(", ");
+    let mut update_clauses = query_builder.separated(", ");
 
-        if let Some(provider_id) = model.provider_id {
-            update_clauses
-                .push(" provider_id = ")
-                .push_bind_unseparated(provider_id);
-        }
-
-        if let Some(email) = model.email.as_ref() {
-            update_clauses
-                .push(" email = ")
-                .push_bind_unseparated(email);
-        }
-
-        if let Some(role) = model.role.as_ref() {
-            update_clauses.push(" role = ").push_bind_unseparated(role);
-        }
-
-        if let Some(method) = model.method.as_ref() {
-            update_clauses
-                .push(" method = ")
-                .push_bind_unseparated(method);
-        }
-
-        if let Some(password) = model.password {
-            let hashed_password = hash_password(&password)?;
-            update_clauses
-                .push(" password = ")
-                .push_bind_unseparated(hashed_password);
-        }
-
+    if let Some(provider_id) = model.provider_id {
         update_clauses
-            .push(" tenant = ")
-            .push_bind_unseparated(tenant.as_ref());
-
-        query_builder.push(" WHERE id = ");
-        query_builder.push_bind(model.id);
-
-        query_builder.push(r#" RETURNING id, tenant, provider_id, email, role, method"#);
-
-        let query = query_builder.build_query_as();
-
-        let user = query
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(StoreError::SQLXError)?;
-
-        Ok(user)
+            .push(" provider_id = ")
+            .push_bind_unseparated(provider_id);
     }
+
+    if let Some(email) = model.email.as_ref() {
+        update_clauses
+            .push(" email = ")
+            .push_bind_unseparated(email);
+    }
+
+    if let Some(role) = model.role.as_ref() {
+        update_clauses.push(" role = ").push_bind_unseparated(role);
+    }
+
+    if let Some(method) = model.method.as_ref() {
+        update_clauses
+            .push(" method = ")
+            .push_bind_unseparated(method);
+    }
+
+    if let Some(password) = model.password {
+        let hashed_password = hash_password(&password)?;
+        update_clauses
+            .push(" password = ")
+            .push_bind_unseparated(hashed_password);
+    }
+
+    update_clauses
+        .push(" tenant = ")
+        .push_bind_unseparated(tenant.as_ref());
+
+    query_builder.push(" WHERE id = ");
+    query_builder.push_bind(model.id);
+
+    query_builder.push(r" RETURNING id, tenant, provider_id, email, role, method");
+
+    let query = query_builder.build_query_as::<User>();
+
+    let user = query
+        .fetch_one(executor)
+        .await
+        .map_err(StoreError::SQLXError)?;
+
+    Ok(user)
 }
 
-fn delete_user<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn delete_user<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     id: &'a str,
-) -> impl Future<Output = Result<(), OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let _user = sqlx::query_as!(
-            User,
-            r#"
-                DELETE FROM users
-                WHERE tenant = $1 AND id = $2
-                RETURNING id, tenant as "tenant: TenantId", provider_id, email, role as "role: UserRole", method as "method: AuthMethod"
-            "#,
-            tenant.as_ref(),
-            id
-        ).fetch_optional(&mut *conn).await.map_err(StoreError::SQLXError)?;
+) -> Result<(), OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    sqlx::query(
+        r"
+            DELETE FROM users
+            WHERE tenant = $1 AND id = $2
+        ",
+    )
+    .bind(tenant.as_ref())
+    .bind(id)
+    .execute(executor)
+    .await
+    .map_err(StoreError::SQLXError)?;
 
-        Ok(())
-    }
+    Ok(())
 }
 
-fn search_user<'a, 'c, Connection: Acquire<'c, Database = Postgres> + Send + 'a>(
-    connection: Connection,
+async fn search_user<'a, 'e, E>(
+    executor: E,
     tenant: &'a TenantId,
     clauses: &'a UserSearchClauses,
-) -> impl Future<Output = Result<Vec<User>, OperationOutcomeError>> + Send + 'a {
-    async move {
-        let mut conn = connection.acquire().await.map_err(StoreError::SQLXError)?;
-        let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
-            r#"SELECT id, tenant, email, role, method, provider_id FROM users WHERE  "#,
-        );
+) -> Result<Vec<User>, OperationOutcomeError>
+where
+    E: PgExecutor<'e>,
+{
+    let mut query_builder: QueryBuilder<sqlx::Postgres> =
+        QueryBuilder::new(r"SELECT id, tenant, email, role, method, provider_id FROM users WHERE ");
 
-        let mut seperator = query_builder.separated(" AND ");
-        seperator
-            .push(" tenant = ")
-            .push_bind_unseparated(tenant.as_ref());
+    let mut seperator = query_builder.separated(" AND ");
+    seperator
+        .push(" tenant = ")
+        .push_bind_unseparated(tenant.as_ref());
 
-        if let Some(email) = clauses.email.as_ref() {
-            seperator.push(" email = ").push_bind_unseparated(email);
-        }
-
-        if let Some(role) = clauses.role.as_ref() {
-            seperator.push(" role = ").push_bind_unseparated(role);
-        }
-
-        if let Some(method) = clauses.method.as_ref() {
-            seperator.push(" method = ").push_bind_unseparated(method);
-        }
-
-        let query = query_builder.build_query_as();
-
-        let users: Vec<User> = query
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(StoreError::from)?;
-
-        Ok(users)
+    if let Some(email) = clauses.email.as_ref() {
+        seperator.push(" email = ").push_bind_unseparated(email);
     }
+
+    if let Some(role) = clauses.role.as_ref() {
+        seperator.push(" role = ").push_bind_unseparated(role);
+    }
+
+    if let Some(method) = clauses.method.as_ref() {
+        seperator.push(" method = ").push_bind_unseparated(method);
+    }
+
+    let query = query_builder.build_query_as::<User>();
+
+    let users: Vec<User> = query.fetch_all(executor).await.map_err(StoreError::from)?;
+
+    Ok(users)
 }
 
 impl<Key: AsRef<str> + Send + Sync>
@@ -313,7 +328,7 @@ impl<Key: AsRef<str> + Send + Sync>
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = create_user(&mut *tx, tenant, new_user).await?;
+                let res = create_user(&mut **tx, tenant, new_user).await?;
                 Ok(res)
             }
         }
@@ -331,7 +346,7 @@ impl<Key: AsRef<str> + Send + Sync>
             }
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = read_user(&mut *tx, tenant, id.as_ref()).await?;
+                let res = read_user(&mut **tx, tenant, id.as_ref()).await?;
                 Ok(res)
             }
         }
@@ -343,28 +358,20 @@ impl<Key: AsRef<str> + Send + Sync>
         user: UpdateUser,
     ) -> Result<User, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = update_user(pool, &tenant, user).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => update_user(pool, tenant, user).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = update_user(&mut *tx, &tenant, user).await?;
-                Ok(res)
+                update_user(&mut **tx, tenant, user).await
             }
         }
     }
 
     async fn delete(&self, tenant: &TenantId, id: &Key) -> Result<(), OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = delete_user(pool, tenant, id.as_ref()).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => delete_user(pool, tenant, id.as_ref()).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = delete_user(&mut *tx, tenant, id.as_ref()).await?;
-                Ok(res)
+                delete_user(&mut **tx, tenant, id.as_ref()).await
             }
         }
     }
@@ -375,14 +382,10 @@ impl<Key: AsRef<str> + Send + Sync>
         clauses: &UserSearchClauses,
     ) -> Result<Vec<User>, OperationOutcomeError> {
         match self {
-            PGConnection::Pool(pool, _) => {
-                let res = search_user(pool, tenant, clauses).await?;
-                Ok(res)
-            }
+            PGConnection::Pool(pool, _) => search_user(pool, tenant, clauses).await,
             PGConnection::Transaction(tx, _) => {
                 let mut tx = tx.lock().await;
-                let res = search_user(&mut *tx, tenant, clauses).await?;
-                Ok(res)
+                search_user(&mut **tx, tenant, clauses).await
             }
         }
     }

--- a/backend/crates/repository/src/pg/utilities.rs
+++ b/backend/crates/repository/src/pg/utilities.rs
@@ -30,13 +30,15 @@ pub async fn commit_transaction(
     tx: Arc<Mutex<Transaction<'static, Postgres>>>,
 ) -> Result<(), OperationOutcomeError> {
     let conn = Mutex::into_inner(Arc::try_unwrap(tx).map_err(|e| {
-        println!("Error during commit: {:?}", e);
+        println!("Error during commit: {e:?}");
         StoreError::FailedCommitTransaction
     })?);
 
     // Handle PgConnection connection
-    let res = conn.commit().await.map_err(StoreError::from)?;
-    Ok(res)
+    conn.commit()
+        .await
+        .map_err(StoreError::from)
+        .map_err(OperationOutcomeError::from)
 }
 
 #[allow(dead_code)]
@@ -44,11 +46,13 @@ pub async fn rollback_transaction(
     tx: Arc<Mutex<Transaction<'static, Postgres>>>,
 ) -> Result<(), OperationOutcomeError> {
     let conn = Mutex::into_inner(Arc::try_unwrap(tx).map_err(|e| {
-        println!("Error during rollback: {:?}", e);
+        println!("Error during rollback: {e:?}");
         StoreError::FailedCommitTransaction
     })?);
 
     // Handle PgConnection connection
-    let res = conn.rollback().await.map_err(StoreError::from)?;
-    Ok(res)
+    conn.rollback()
+        .await
+        .map_err(StoreError::from)
+        .map_err(OperationOutcomeError::from)
 }

--- a/backend/crates/repository/src/types/mfa.rs
+++ b/backend/crates/repository/src/types/mfa.rs
@@ -66,13 +66,16 @@ pub struct MFAId(pub String);
 
 pub struct MFAKey(UserId, MFAId);
 impl MFAKey {
+    #[must_use]
     pub fn new(user_id: UserId, mfa_id: String) -> Self {
         MFAKey(user_id, MFAId(mfa_id))
     }
+    #[must_use]
     pub fn user_id(&self) -> &UserId {
         &self.0
     }
 
+    #[must_use]
     pub fn mfa_id(&self) -> &MFAId {
         &self.1
     }

--- a/backend/crates/repository/src/types/mod.rs
+++ b/backend/crates/repository/src/types/mod.rs
@@ -44,7 +44,7 @@ impl TryFrom<&str> for FHIRMethod {
             "read" => Ok(FHIRMethod::Read),
             "update" => Ok(FHIRMethod::Update),
             "delete" => Ok(FHIRMethod::Delete),
-            _ => Err(format!("Unsupported FHIR method: {}", value)),
+            _ => Err(format!("Unsupported FHIR method: {value}")),
         }
     }
 }

--- a/backend/crates/repository/src/types/scope.rs
+++ b/backend/crates/repository/src/types/scope.rs
@@ -9,6 +9,7 @@ impl From<ClientId> for String {
     }
 }
 impl ClientId {
+    #[must_use]
     pub fn new(id: String) -> Self {
         ClientId(id)
     }
@@ -27,6 +28,7 @@ impl From<UserId> for String {
     }
 }
 impl UserId {
+    #[must_use]
     pub fn new(id: String) -> Self {
         UserId(id)
     }
@@ -64,6 +66,7 @@ pub struct CreateScope {
 
 pub struct ScopeKey(pub ClientId, pub UserId);
 impl ScopeKey {
+    #[must_use]
     pub fn new(client: ClientId, user_: UserId) -> Self {
         ScopeKey(client, user_)
     }

--- a/backend/crates/repository/src/utilities.rs
+++ b/backend/crates/repository/src/utilities.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use haste_fhir_model::r4::generated::{
     resources::Resource,
     terminology::IssueType,
@@ -18,16 +20,26 @@ pub fn generate_id(len: Option<usize>) -> String {
     nanoid::nanoid!(len, ID_CHARACTERS).to_string()
 }
 
-pub fn validate_id(id: &str) -> Result<(), OperationOutcomeError> {
+static ID_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
     let characters_allowed = ID_CHARACTERS.iter().collect::<String>();
-    let re = regex::Regex::new(&format!("^[{}]*$", characters_allowed)).unwrap();
-    if !re.is_match(id) {
+    regex::Regex::new(&format!("^[{characters_allowed}]*$"))
+        .expect("ID_CHARACTERS should produce a valid regex")
+});
+
+/// Validates a FHIR resource ID.
+///
+/// # Errors
+///
+/// Returns an [`OperationOutcomeError`] if `id` contains characters that are
+/// not permitted in a FHIR resource ID.
+pub fn validate_id(id: &str) -> Result<(), OperationOutcomeError> {
+    if ID_REGEX.is_match(id) {
+        Ok(())
+    } else {
         Err(OperationOutcomeError::fatal(
             IssueType::invalid(),
-            format!("ID contains invalid characters: {}", id),
+            format!("ID contains invalid characters: {id}"),
         ))
-    } else {
-        Ok(())
     }
 }
 
@@ -39,6 +51,15 @@ pub enum DataTransformError {
     NotFound(String),
 }
 
+/// Sets the ID of a FHIR resource.
+///
+/// If `id_` is `Some`, that value is assigned as the resource ID. Otherwise, a
+/// new ID is generated and assigned.
+///
+/// # Errors
+///
+/// Returns an [`OperationOutcomeError`] if the resource does not contain an `id`
+/// field or if the `id` field is not of type [`Option<String>`].
 pub fn set_resource_id(
     resource: &mut Resource,
     id_: Option<String>,
@@ -58,6 +79,15 @@ pub fn set_resource_id(
     Ok(())
 }
 
+/// Sets the version ID of a FHIR resource.
+///
+/// If the resource does not have a `meta` element, one is created. The
+/// `versionId` field is then populated with a newly generated ID.
+///
+/// # Errors
+///
+/// Returns an [`OperationOutcomeError`] if the resource does not contain a
+/// `meta` field or if the `meta` field is not of type [`Option<Box<Meta>>`].
 pub fn set_version_id(resource: &mut Resource) -> Result<(), OperationOutcomeError> {
     let meta: &mut dyn std::any::Any =
         resource
@@ -72,15 +102,15 @@ pub fn set_version_id(resource: &mut Resource) -> Result<(), OperationOutcomeErr
             ))?;
 
     if meta.is_none() {
-        *meta = Some(Box::new(Meta::default()))
+        *meta = Some(Box::new(Meta::default()));
     }
-    meta.as_mut().map(|meta| {
+    if let Some(meta) = meta.as_mut() {
         meta.versionId = Some(Box::new(FHIRId {
             id: None,
             extension: None,
             value: Some(generate_id(None)),
         }));
-    });
+    }
 
     Ok(())
 }


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.