### PR TITLE
Offset Count Test and Alignment

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  e2e:
+  e2e-tests:
     runs-on: ubuntu-latest
     env:
       HASTE_CERTIFICATION_DIR: certifications

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: cargo fmt --all -- --check --verbose
         working-directory: ./backend
 
-  build:
+  unit-tests:
     runs-on: ubuntu-latest
 
     needs: rustfmt

--- a/backend/crates/fhir-search/src/elastic_search/search/mod.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/mod.rs
@@ -296,7 +296,7 @@ async fn build_elastic_search_query<ParameterResolver: SearchParameterResolve>(
     };
     let mut show_total = false;
     let mut sort: Vec<serde_json::Value> = Vec::new();
-    let mut offset: usize = 0;
+    let mut offset: u64 = 0;
 
     for parameter in parameters.parameters().iter() {
         match parameter {
@@ -312,24 +312,40 @@ async fn build_elastic_search_query<ParameterResolver: SearchParameterResolve>(
             }
             ParsedParameter::Result(result_param) => match result_param.name.as_str() {
                 "_count" => {
-                    max_count = std::cmp::min(
+                    let count_param = std::cmp::min(
                         result_param
                             .value
                             .get(0)
-                            .and_then(|v| v.parse::<usize>().ok())
+                            .and_then(|v| v.parse::<i64>().ok())
                             .unwrap_or(100),
-                        DEFAULT_MAX_COUNT,
+                        DEFAULT_MAX_COUNT as i64,
                     );
+
+                    if count_param < 0 {
+                        return Err(OperationOutcomeError::fatal(
+                            IssueType::invalid(),
+                            "Invalid _count parameter value. Must be greater than 0.".to_string(),
+                        ));
+                    }
+
+                    max_count = count_param as usize;
                 }
                 "_offset" => {
-                    offset = std::cmp::max(
-                        result_param
-                            .value
-                            .get(0)
-                            .and_then(|v| v.parse::<usize>().ok())
-                            .unwrap_or(0),
-                        0,
-                    );
+                    let offset_param = result_param
+                        .value
+                        .get(0)
+                        .and_then(|v| v.parse::<i64>().ok())
+                        .unwrap_or(0);
+
+                    if offset_param < 0 {
+                        return Err(OperationOutcomeError::fatal(
+                            IssueType::invalid(),
+                            "Invalid _offset parameter value. Must be greater than or equal to 0."
+                                .to_string(),
+                        ));
+                    }
+
+                    offset = offset_param as u64;
                 }
                 "_total" => {
                     match result_param

--- a/backend/crates/fhir-search/src/elastic_search/search/mod.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/mod.rs
@@ -324,7 +324,8 @@ async fn build_elastic_search_query<ParameterResolver: SearchParameterResolve>(
                     if count_param < 0 {
                         return Err(OperationOutcomeError::fatal(
                             IssueType::invalid(),
-                            "Invalid _count parameter value. Must be greater than 0.".to_string(),
+                            "Invalid _count parameter value. Must be greater than or equal to 0."
+                                .to_string(),
                         ));
                     }
 

--- a/backend/crates/repository/src/pg/fhir.rs
+++ b/backend/crates/repository/src/pg/fhir.rs
@@ -595,19 +595,30 @@ where
         1000
     };
 
+    if limit < 0 {
+        return Err(OperationOutcomeError::fatal(
+            IssueType::invalid(),
+            "Invalid _count parameter value. Must be greater than 0.".to_string(),
+        ));
+    }
+
     query_builder
         .push(" ORDER BY sequence DESC LIMIT ")
         .push_bind(limit);
 
     if let Some(ParsedParameter::Result(offset_param)) = history_parameters.get("_offset") {
-        let offset = std::cmp::max(
-            offset_param
-                .value
-                .first()
-                .and_then(|v| v.parse::<i64>().ok())
-                .unwrap_or(0),
-            0,
-        );
+        let offset = offset_param
+            .value
+            .first()
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(0);
+
+        if offset < 0 {
+            return Err(OperationOutcomeError::fatal(
+                IssueType::invalid(),
+                "Invalid _offset parameter value. Must be greater than or equal to 0.".to_string(),
+            ));
+        }
 
         query_builder.push(" OFFSET ").push_bind(offset);
     }

--- a/backend/crates/repository/src/pg/fhir.rs
+++ b/backend/crates/repository/src/pg/fhir.rs
@@ -598,7 +598,7 @@ where
     if limit < 0 {
         return Err(OperationOutcomeError::fatal(
             IssueType::invalid(),
-            "Invalid _count parameter value. Must be greater than 0.".to_string(),
+            "Invalid _count parameter value. Must be greater than or equal to 0.".to_string(),
         ));
     }
 

--- a/backend/testscripts/base/search/count_limit.testscript.json
+++ b/backend/testscripts/base/search/count_limit.testscript.json
@@ -1,0 +1,373 @@
+{
+    "id": "limit-count-test",
+    "url": "https://haste.health/fhir/TestScript/limit-count-test",
+    "title": "Limit and count checks",
+    "name": "Limit and Count tests",
+    "status": "active",
+    "resourceType": "TestScript",
+    "contained": [
+        {
+            "id": "patient-chalmers",
+            "resourceType": "Patient",
+            "meta": {
+                "tag": [
+                    {
+                        "code": "limit-count-test"
+                    }
+                ]
+            },
+            "name": [
+                {
+                    "family": "Chalmers",
+                    "given": [
+                        "Peter"
+                    ]
+                }
+            ]
+        }
+    ],
+    "fixture": [
+        {
+            "id": "fixture-patient-create",
+            "resource": {
+                "reference": "#patient-chalmers",
+                "display": "Peter Chalmers"
+            },
+            "autocreate": false,
+            "autodelete": false
+        }
+    ],
+    "test": [
+        {
+            "id": "01-count-checks",
+            "name": "Search Count checks.",
+            "action": [
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "create"
+                        },
+                        "resource": "Patient",
+                        "sourceId": "fixture-patient-create",
+                        "responseId": "create-response",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "create"
+                        },
+                        "resource": "Patient",
+                        "sourceId": "fixture-patient-create",
+                        "responseId": "create-response",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "create"
+                        },
+                        "resource": "Patient",
+                        "sourceId": "fixture-patient-create",
+                        "responseId": "create-response",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "search"
+                        },
+                        "params": "_tag=limit-count-test",
+                        "resource": "Patient",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "expression": "Bundle.entry.count()",
+                        "operator": "equals",
+                        "value": "3",
+                        "warningOnly": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "search"
+                        },
+                        "resource": "Patient",
+                        "params": "_tag=limit-count-test&_count=2",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "expression": "Bundle.entry.count()",
+                        "operator": "equals",
+                        "value": "2",
+                        "warningOnly": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "search"
+                        },
+                        "resource": "Patient",
+                        "params": "_tag=limit-count-test&_count=5",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "expression": "Bundle.entry.count()",
+                        "operator": "equals",
+                        "value": "3",
+                        "warningOnly": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "search"
+                        },
+                        "resource": "Patient",
+                        "params": "_tag=limit-count-test&_count=-5",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "resource": "OperationOutcome",
+                        "warningOnly": false
+                    }
+                }
+            ]
+        },
+        {
+            "id": "02-offset-checks",
+            "name": "Search Offset checks.",
+            "action": [
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "search"
+                        },
+                        "resource": "Patient",
+                        "params": "_tag=limit-count-test&_offset=1",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "expression": "Bundle.entry.count()",
+                        "operator": "equals",
+                        "value": "2",
+                        "warningOnly": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "search"
+                        },
+                        "resource": "Patient",
+                        "params": "_tag=limit-count-test&_offset=2",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "expression": "Bundle.entry.count()",
+                        "operator": "equals",
+                        "value": "1",
+                        "warningOnly": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "search"
+                        },
+                        "resource": "Patient",
+                        "params": "_tag=limit-count-test&_offset=5",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "expression": "Bundle.entry.count()",
+                        "operator": "equals",
+                        "value": "0",
+                        "warningOnly": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "search"
+                        },
+                        "resource": "Patient",
+                        "params": "_tag=limit-count-test&_offset=-1",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "resource": "OperationOutcome",
+                        "warningOnly": false
+                    }
+                }
+            ]
+        },
+        {
+            "id": "03-history-count-checks",
+            "name": "History Count checks.",
+            "action": [
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "history"
+                        },
+                        "resource": "Patient",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "expression": "Bundle.entry.count() > 0",
+                        "operator": "equals",
+                        "value": "true",
+                        "warningOnly": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "history"
+                        },
+                        "params": "_count=2",
+                        "resource": "Patient",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "expression": "Bundle.entry.count()",
+                        "operator": "equals",
+                        "value": "2",
+                        "warningOnly": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "history"
+                        },
+                        "params": "_count=-2",
+                        "resource": "Patient",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "resource": "OperationOutcome",
+                        "warningOnly": false
+                    }
+                }
+            ]
+        },
+        {
+            "id": "03-history-count-checks",
+            "name": "History Offset checks.",
+            "action": [
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "history"
+                        },
+                        "resource": "Patient",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "expression": "Bundle.entry.count() > 0",
+                        "operator": "equals",
+                        "value": "true",
+                        "warningOnly": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "history"
+                        },
+                        "params": "_offset=2",
+                        "resource": "Patient",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "expression": "Bundle.entry.count() > 0",
+                        "operator": "equals",
+                        "value": "true",
+                        "warningOnly": false
+                    }
+                },
+                {
+                    "operation": {
+                        "type": {
+                            "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                            "code": "history"
+                        },
+                        "params": "_offset=-2",
+                        "resource": "Patient",
+                        "encodeRequestUrl": false
+                    }
+                },
+                {
+                    "assert": {
+                        "resource": "OperationOutcome",
+                        "warningOnly": false
+                    }
+                }
+            ]
+        }
+    ],
+    "teardown": {
+        "action": [
+            {
+                "operation": {
+                    "type": {
+                        "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+                        "code": "deleteCondMultiple"
+                    },
+                    "params": "_tag=limit-count-test",
+                    "resource": "Patient",
+                    "encodeRequestUrl": false
+                }
+            }
+        ]
+    }
+}

--- a/backend/testscripts/base/search/count_limit.testscript.json
+++ b/backend/testscripts/base/search/count_limit.testscript.json
@@ -295,7 +295,7 @@
             ]
         },
         {
-            "id": "03-history-count-checks",
+            "id": "04-history-offset-checks",
             "name": "History Offset checks.",
             "action": [
                 {


### PR DESCRIPTION
Alters so that _count and _total negative values error (would silently set to zero). And aligns errors for history queries which just touch repo with the _count and _total errors that happen in search repository.