### PR TITLE
Resolve small clippy lints 

### DIFF
--- a/backend/crates/codegen/src/type_gen/rust_types/data_types.rs
+++ b/backend/crates/codegen/src/type_gen/rust_types/data_types.rs
@@ -323,6 +323,7 @@ fn from_rust_type_to_fhir_primitive(
         .as_ref()
         .map(|s| &s.element)
         .and_then(|element_definitions| {
+            #[allow(clippy::case_sensitive_file_extension_comparisons)]
             element_definitions
                 .iter()
                 .find(|e| e.path.value.as_ref().is_some_and(|p| p.ends_with(".value")))

--- a/backend/crates/server/build.rs
+++ b/backend/crates/server/build.rs
@@ -22,9 +22,10 @@ fn main() {
         .wait()
         .expect("Failed to install node packages.");
 
-    if !npm_result.success() {
-        panic!("NPM INSTALL EXITED WITH: {:?}", npm_result);
-    }
+    assert!(
+        npm_result.success(),
+        "NPM INSTALL EXITED WITH: {npm_result:?}",
+    );
 
     let mut tailwindcss_process = std::process::Command::new(NPX)
         .arg("@tailwindcss/cli")
@@ -36,7 +37,5 @@ fn main() {
 
     let result = tailwindcss_process.wait().expect("TAILWIND FAILED");
 
-    if !result.success() {
-        panic!("TAILWIND EXITED WITH: {:?}", result);
-    }
+    assert!(result.success(), "TAILWIND EXITED WITH: {result:?}");
 }


### PR DESCRIPTION
This PR resolves small `clippy` lints for:

- codegen crate
- server crate `build.rs` file