### PR TITLE
Resolve `clippy` lints for `fhir-converter` crate

### DIFF
--- a/backend/crates/fhir-converter/src/jinja_extensions/conversions/hl7v2.rs
+++ b/backend/crates/fhir-converter/src/jinja_extensions/conversions/hl7v2.rs
@@ -33,10 +33,10 @@ impl Object for JHL7V2 {
 
             let found_segments = segments
                 .iter()
-                .filter(|segment| segment.id.value.as_ref().map(|s| s.as_str()) == Some(key))
+                .filter(|segment| segment.id.value.as_deref() == Some(key))
                 .collect::<Vec<_>>();
 
-            if found_segments.len() == 0 {
+            if found_segments.is_empty() {
                 return None;
             }
 
@@ -68,7 +68,7 @@ impl Object for JHL7V2 {
         Self: Sized + 'static,
     {
         let hl7v2_string: String = SerializeMessage(&self.0).into();
-        write!(f, "{}", hl7v2_string)
+        write!(f, "{hl7v2_string}")
     }
 }
 
@@ -82,7 +82,7 @@ static DEFAULT_ENCODING: LazyLock<EncodingInformation> = LazyLock::new(|| Encodi
 
 #[derive(Debug)]
 pub struct JHL7V2Segment<'a>(&'a HL7V2Segments);
-impl<'a> Object for JHL7V2Segment<'a> {
+impl Object for JHL7V2Segment<'_> {
     fn repr(self: &Arc<Self>) -> ObjectRepr {
         ObjectRepr::Plain
     }
@@ -108,13 +108,13 @@ impl<'a> Object for JHL7V2Segment<'a> {
     where
         Self: Sized + 'static,
     {
-        write!(f, "{}", segment_to_string(&*DEFAULT_ENCODING, self.0))
+        write!(f, "{}", segment_to_string(&DEFAULT_ENCODING, self.0))
     }
 }
 
 #[derive(Debug)]
 pub struct JHL7V2SegmentsFields<'a>(&'a HL7V2SegmentsFields);
-impl<'a> Object for JHL7V2SegmentsFields<'a> {
+impl Object for JHL7V2SegmentsFields<'_> {
     fn repr(self: &Arc<Self>) -> ObjectRepr {
         ObjectRepr::Plain
     }
@@ -146,13 +146,13 @@ impl<'a> Object for JHL7V2SegmentsFields<'a> {
     where
         Self: Sized + 'static,
     {
-        write!(f, "{}", segment_field_to_string(&*DEFAULT_ENCODING, self.0))
+        write!(f, "{}", segment_field_to_string(&DEFAULT_ENCODING, self.0))
     }
 }
 
 #[derive(Debug)]
 pub struct JHL7V2SegmentsFieldsValue<'a>(&'a HL7V2SegmentsFieldsValue);
-impl<'a> Object for JHL7V2SegmentsFieldsValue<'a> {
+impl Object for JHL7V2SegmentsFieldsValue<'_> {
     fn repr(self: &Arc<Self>) -> ObjectRepr {
         ObjectRepr::Plain
     }
@@ -195,14 +195,14 @@ impl<'a> Object for JHL7V2SegmentsFieldsValue<'a> {
         write!(
             f,
             "{}",
-            segment_field_repititon_to_string(&*DEFAULT_ENCODING, self.0)
+            segment_field_repititon_to_string(&DEFAULT_ENCODING, self.0)
         )
     }
 }
 
 #[derive(Debug)]
 pub struct JHL7V2SegmentsFieldComponent<'a>(&'a HL7V2SegmentsFieldsValueValue);
-impl<'a> Object for JHL7V2SegmentsFieldComponent<'a> {
+impl Object for JHL7V2SegmentsFieldComponent<'_> {
     fn repr(self: &Arc<Self>) -> ObjectRepr {
         ObjectRepr::Plain
     }
@@ -212,12 +212,7 @@ impl<'a> Object for JHL7V2SegmentsFieldComponent<'a> {
             && let Some(value) = self.0.value.as_ref()
         {
             Some(Value::from_safe_string(
-                value
-                    .value
-                    .as_ref()
-                    .map(|s| s.as_str())
-                    .unwrap_or("")
-                    .to_string(),
+                value.value.as_deref().map_or("", |s| s).to_string(),
             ))
         } else {
             self.0
@@ -226,12 +221,7 @@ impl<'a> Object for JHL7V2SegmentsFieldComponent<'a> {
                 .get(index)
                 .map(|subcomponent| {
                     Value::from_safe_string(
-                        subcomponent
-                            .value
-                            .as_ref()
-                            .map(|s| s.as_str())
-                            .unwrap_or("")
-                            .to_string(),
+                        subcomponent.value.as_deref().map_or("", |s| s).to_string(),
                     )
                 })
         }
@@ -248,7 +238,7 @@ impl<'a> Object for JHL7V2SegmentsFieldComponent<'a> {
         write!(
             f,
             "{}",
-            component_to_string(&*DEFAULT_ENCODING, self.0).unwrap_or("".to_string())
+            component_to_string(&DEFAULT_ENCODING, self.0).unwrap_or_default()
         )
     }
 }

--- a/backend/crates/fhir-converter/src/jinja_extensions/conversions/meta_value.rs
+++ b/backend/crates/fhir-converter/src/jinja_extensions/conversions/meta_value.rs
@@ -10,7 +10,7 @@ use minijinja::{
 #[allow(dead_code)]
 pub struct ObjectConverter<'a>(&'a dyn MetaValue);
 
-impl<'a> Object for ObjectConverter<'a> {
+impl Object for ObjectConverter<'_> {
     fn repr(self: &Arc<Self>) -> ObjectRepr {
         ObjectRepr::Plain
     }
@@ -34,9 +34,8 @@ impl<'a> Object for ObjectConverter<'a> {
             };
 
             return k;
-        } else {
-            None
         }
+        None
     }
 
     fn enumerate(self: &Arc<Self>) -> Enumerator {

--- a/backend/crates/fhir-converter/src/jinja_extensions/filters/hl7v2.rs
+++ b/backend/crates/fhir-converter/src/jinja_extensions/filters/hl7v2.rs
@@ -2,12 +2,10 @@ use minijinja::Value;
 
 use crate::jinja_extensions::conversions::hl7v2::JHL7V2;
 
-pub fn hl7v2_segments(value: Value) -> Value {
+pub fn hl7v2_segments(value: &Value) -> Value {
     if let Some(object) = value.as_object() {
         let _k = object.downcast_ref::<JHL7V2>();
     }
 
-    let none = Value::from("hl7v2_segments".to_string());
-
-    none
+    Value::from("hl7v2_segments".to_string())
 }

--- a/backend/crates/fhir-converter/src/lib.rs
+++ b/backend/crates/fhir-converter/src/lib.rs
@@ -10,10 +10,20 @@ mod liquid_extensions;
 
 pub enum Input {
     HL7V2(String),
-    FHIR(Resource),
+    FHIR(Box<Resource>),
     JSON(serde_json::Value),
 }
 
+/// Converts an [`Input`] into a [`minijinja::Value`] suitable for template
+/// rendering.
+///
+/// HL7 v2 messages are parsed and wrapped in a Jinja-compatible object, while
+/// FHIR resources and JSON values are converted using Serde serialization.
+///
+/// # Errors
+///
+/// Returns an [`OperationOutcomeError`] if the input is an HL7 v2 message that
+/// cannot be parsed.
 pub fn convert_input(input: Input) -> Result<minijinja::Value, OperationOutcomeError> {
     match input {
         Input::HL7V2(message) => {
@@ -36,7 +46,7 @@ pub enum OutputFormat {
 }
 
 pub enum Output {
-    FHIR(Resource),
+    FHIR(Box<Resource>),
     JSON(serde_json::Value),
     HL7V2(String),
 }
@@ -45,13 +55,13 @@ pub enum Output {
 fn derive_template_name(template_dir: &Path, path: &Path) -> Option<String> {
     let relative_path = path.strip_prefix(template_dir).unwrap_or(path);
     let Some(template_file_stem) = relative_path.file_stem().and_then(|s| s.to_str()) else {
-        eprintln!("Failed to get template name from path: {:?}", path);
+        eprintln!("Failed to get template name from path: {}", path.display());
         return None;
     };
     let Some(parent) = relative_path.parent() else {
         eprintln!(
-            "Failed to get parent directory for template: {:?}",
-            relative_path
+            "Failed to get parent directory for template: {}",
+            relative_path.display()
         );
         return None;
     };
@@ -60,8 +70,8 @@ fn derive_template_name(template_dir: &Path, path: &Path) -> Option<String> {
 
     let Some(template_name) = template_name_path.to_str() else {
         eprintln!(
-            "Failed to convert template name to string: {:?}",
-            template_name_path
+            "Failed to convert template name to string: {}",
+            template_name_path.display()
         );
         return None;
     };
@@ -71,19 +81,25 @@ fn derive_template_name(template_dir: &Path, path: &Path) -> Option<String> {
 
 fn add_template(env: &mut Environment<'_>, template_dir: &Path, path: &Path) -> Option<()> {
     let Ok(template_content) = std::fs::read_to_string(path) else {
-        eprintln!("Failed to read template file: {:?}", path);
+        eprintln!("Failed to read template file: {}", path.display());
         return None;
     };
 
     let Some(template_name) = derive_template_name(template_dir, path) else {
-        eprintln!("Failed to derive template name for file: {:?}", path);
+        eprintln!(
+            "Failed to derive template name for file: {}",
+            path.display()
+        );
         return None;
     };
 
-    println!("Adding template '{}' from file: {:?}", template_name, path);
+    println!(
+        "Adding template '{template_name}' from file: {}",
+        path.display()
+    );
 
-    if let Err(e) = env.add_template_owned(template_name.to_string(), template_content) {
-        eprintln!("Failed to add template '{}': {}", template_name, e);
+    if let Err(e) = env.add_template_owned(template_name.clone(), template_content) {
+        eprintln!("Failed to add template '{template_name}': {e}");
     }
 
     Some(())
@@ -100,12 +116,12 @@ pub fn create_environment<'a>(template_dir: Option<&str>) -> Environment<'a> {
         let template_dir = Path::new(template_dir);
         walkdir::WalkDir::new(template_dir)
             .into_iter()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .filter(|e| {
                 e.file_type().is_file()
                     && e.path()
                         .extension()
-                        .map_or(false, |ext| ext == "jinja" || ext == "j2")
+                        .is_some_and(|ext| ext == "jinja" || ext == "j2")
             })
             .for_each(|entry| {
                 let path = entry.path();
@@ -116,6 +132,23 @@ pub fn create_environment<'a>(template_dir: Option<&str>) -> Environment<'a> {
     env
 }
 
+/// Renders a template into the requested output format.
+///
+/// The template is rendered using the provided serializable context and the
+/// resulting text is validated or parsed according to `output`.
+///
+/// - [`OutputFormat::FHIR`] parses the rendered output as a FHIR resource.
+/// - [`OutputFormat::JSON`] parses the rendered output as arbitrary JSON.
+/// - [`OutputFormat::HL7V2`] validates that the rendered output is a valid
+///   HL7 v2 message.
+///
+/// # Errors
+///
+/// Returns an [`OperationOutcomeError`] if:
+///
+/// - template rendering fails,
+/// - the rendered output cannot be parsed as the requested format, or
+/// - HL7 v2 validation fails.
 pub fn transform<S>(
     template: &Template<'_, '_>,
     ctx: S,
@@ -138,7 +171,7 @@ where
         )),
         OutputFormat::HL7V2 => {
             // Verify that the output is a valid HL7v2 message by attempting to parse it.
-            ParsedHL7V2Message::try_from(output_data.as_str())?.0;
+            ParsedHL7V2Message::try_from(output_data.as_str())?;
 
             Ok(Output::HL7V2(output_data))
         }

--- a/backend/crates/fhir-converter/src/liquid_extensions/conversions.rs
+++ b/backend/crates/fhir-converter/src/liquid_extensions/conversions.rs
@@ -11,11 +11,12 @@ use haste_reflect::MetaValue;
 use liquid::{Error, Object, model::KString};
 use liquid_core::Value;
 
-/// Convert a liquid `Value` to FHIR context entries.
+/// Convert a liquid [`Value`] to FHIR context entries.
 ///
 /// Scalars map to a single FHIR primitive. Arrays are flattened so each
-/// element becomes a separate context value, matching the FHIRPath collection
-/// model. Objects become a lazy `BackboneElement`-typed `MetaObject`. Nil
+/// element becomes a separate context value, matching the `FHIRPath` collection
+/// model.
+/// Objects become a lazy `BackboneElement`-typed `MetaObject`. Nil
 /// produces an empty context.
 pub fn liquid_to_metavalue(value: Value) -> Result<Vec<Box<dyn MetaValue + Send + Sync>>, Error> {
     match value {
@@ -48,16 +49,16 @@ pub fn liquid_to_metavalue(value: Value) -> Result<Vec<Box<dyn MetaValue + Send 
             .into_iter()
             .map(liquid_to_metavalue)
             .flat_map(|result| match result {
-                Ok(vec) => vec.into_iter().map(|item| Ok(item)).collect(),
+                Ok(vec) => vec.into_iter().map(Ok).collect(),
                 Err(er) => vec![Err(er)],
             })
             .collect::<Result<Vec<Box<dyn MetaValue + Send + Sync>>, Error>>(),
         Value::Object(obj) => {
             let k: Resource = serde_json::from_value(
-                serde_json::to_value(&obj).map_err(|e| Error::with_msg(format!("{}", e)))?,
+                serde_json::to_value(&obj).map_err(|e| Error::with_msg(format!("{e}")))?,
             )
             .map_err(|e| {
-                println!("{}", e);
+                println!("{e}");
                 Error::with_msg(
                     "Must be a valid resource type to use fhirpath filter on.".to_string(),
                 )
@@ -71,29 +72,31 @@ pub fn liquid_to_metavalue(value: Value) -> Result<Vec<Box<dyn MetaValue + Send 
     }
 }
 
-/// Convert a `MetaValue` to a liquid `Value`.
+/// Convert a [`MetaValue`] to a liquid [`Value`].
 ///
 /// Primitive FHIR types are dispatched via `fhir_type()` and converted to
 /// the matching liquid scalar. Complex types are recursively converted to
-/// `Value::Object` using the same `flatten()` traversal that the FHIRPath
+/// [`Value::Object`] using the same `flatten()` traversal that the `FHIRPath`
 /// engine uses, so field semantics are consistent.
 pub fn fhir_to_liquid(value: &dyn MetaValue) -> Value {
     let fhir_type = value.fhir_type();
 
-    if NUMBER_TYPES.contains(fhir_type) {
-        if let Ok(n) = downcast_number(value) {
-            return Value::scalar(n);
-        }
+    if NUMBER_TYPES.contains(fhir_type)
+        && let Ok(n) = downcast_number(value)
+    {
+        return Value::scalar(n);
     }
-    if BOOLEAN_TYPES.contains(fhir_type) {
-        if let Ok(b) = downcast_bool(value) {
-            return Value::scalar(b);
-        }
+
+    if BOOLEAN_TYPES.contains(fhir_type)
+        && let Ok(b) = downcast_bool(value)
+    {
+        return Value::scalar(b);
     }
-    if STRING_TYPES.contains(fhir_type) {
-        if let Ok(s) = downcast_string(value) {
-            return Value::scalar(s);
-        }
+
+    if STRING_TYPES.contains(fhir_type)
+        && let Ok(s) = downcast_string(value)
+    {
+        return Value::scalar(s);
     }
 
     // Complex type: build a liquid Object from the reflected fields.
@@ -103,7 +106,7 @@ pub fn fhir_to_liquid(value: &dyn MetaValue) -> Value {
     //   - collection fields     → flatten() yields each element
     let fields = value.fields();
     if fields.is_empty() {
-        return Value::scalar(format!("{:?}", value));
+        return Value::scalar(format!("{value:?}"));
     }
 
     let mut obj = Object::new();

--- a/backend/crates/fhir-converter/src/liquid_extensions/filters/fhirpath.rs
+++ b/backend/crates/fhir-converter/src/liquid_extensions/filters/fhirpath.rs
@@ -51,11 +51,11 @@ impl Filter for FHIRPathFilter {
                     .evaluate(fhirpath.as_str(), refs)
                     .await?;
 
-                let converted: Vec<Value> = ctx.iter().map(|value| fhir_to_liquid(value)).collect();
+                let converted: Vec<Value> = ctx.iter().map(fhir_to_liquid).collect();
                 Ok::<Vec<Value>, haste_fhirpath::FHIRPathError>(converted)
             })
         })
-        .map_err(|err| Error::with_msg(format!("FHIRPath evaluation error: {}", err)))?;
+        .map_err(|err| Error::with_msg(format!("FHIRPath evaluation error: {err}")))?;
 
         Ok(Value::Array(values))
     }

--- a/backend/crates/fhir-converter/src/main.rs
+++ b/backend/crates/fhir-converter/src/main.rs
@@ -38,10 +38,11 @@ fn read_stdin() -> Result<String, std::io::Error> {
     Ok(input)
 }
 
-fn parse_input_value(input_type: &InputType, raw_input: String) -> Result<Input, String> {
+fn parse_input_value(input_type: InputType, raw_input: String) -> Result<Input, String> {
     match input_type {
         InputType::HL7V2 => Ok(Input::HL7V2(raw_input)),
         InputType::Fhir => serde_json::from_str::<Resource>(&raw_input)
+            .map(Box::new)
             .map(Input::FHIR)
             .map_err(|e| format!("failed to parse FHIR input: {e}")),
         InputType::Json => serde_json::from_str::<serde_json::Value>(&raw_input)
@@ -114,7 +115,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => read_stdin()?,
     };
 
-    let input = parse_input_value(input_type, raw_input)?;
+    let input = parse_input_value(*input_type, raw_input)?;
     let converted_input = convert_input(input).map_err(|e| e.to_string())?;
 
     let mut context = HashMap::<&str, Value>::new();
@@ -134,7 +135,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let env = create_environment(Some(template_directory));
     let template = env
-        .get_template(&main_template_id)
+        .get_template(main_template_id)
         .map_err(|e| e.to_string())?;
 
     let output = transform(&template, context, output_type).map_err(|e| e.to_string())?;

--- a/backend/src/commands/hl7v2.rs
+++ b/backend/src/commands/hl7v2.rs
@@ -103,7 +103,7 @@ pub(crate) async fn hl7v2(
 
                     tracing::info!("total transformation: {:?}", start.elapsed());
 
-                    match resource {
+                    match *resource {
                         Resource::Bundle(bundle) => match &bundle.type_ {
                             b if b == &BundleType::batch() => {
                                 match fhir_client.batch((), bundle).await {
@@ -147,7 +147,7 @@ pub(crate) async fn hl7v2(
                         },
                         _ => {
                             let resource_type = resource.resource_type();
-                            match fhir_client.create((), resource_type, resource).await {
+                            match fhir_client.create((), resource_type, *resource).await {
                                 Ok(_) => {
                                     if let Err(e) = stream.write_all(&MllpFormatter::ack()) {
                                         eprintln!("Failed to send ACK: {}", e);


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.