### PR TITLE
Resolve `clippy` lints for the `encryption` crate

### DIFF
--- a/backend/crates/encryption/src/encryption/aes.rs
+++ b/backend/crates/encryption/src/encryption/aes.rs
@@ -17,6 +17,12 @@ pub struct AesGcmEncryptor {
 }
 
 impl AesGcmEncryptor {
+    /// Creates a new AES-256-GCM cipher from the provided key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OperationOutcomeError`] if `key` is not exactly `KEY_LEN` bytes
+    /// long.
     pub fn new(key: &[u8]) -> Result<Self, OperationOutcomeError> {
         let key_array = Key::<Aes256Gcm>::try_from(key)
             .map_err(|_| EncryptionError::InvalidKeyLength(KEY_LEN, key.len()))?;

--- a/backend/crates/encryption/src/lib.rs
+++ b/backend/crates/encryption/src/lib.rs
@@ -23,6 +23,7 @@ pub enum SecretsProviderKind {
     },
 }
 
+#[must_use]
 pub fn get_secrets_provider(kind: SecretsProviderKind) -> Arc<dyn SecretsProvider> {
     match kind {
         SecretsProviderKind::Environment { prefix } => Arc::new(

--- a/backend/crates/encryption/src/providers/environment.rs
+++ b/backend/crates/encryption/src/providers/environment.rs
@@ -13,6 +13,7 @@ pub struct EnvironmentSecretsProvider {
 }
 
 impl EnvironmentSecretsProvider {
+    #[must_use]
     pub fn new(prefix: Option<String>) -> Self {
         Self { prefix }
     }

--- a/backend/crates/encryption/src/traits.rs
+++ b/backend/crates/encryption/src/traits.rs
@@ -6,10 +6,12 @@ use std::{future::Future, pin::Pin};
 pub struct Secret(Vec<u8>);
 
 impl Secret {
+    #[must_use]
     pub fn new(bytes: Vec<u8>) -> Self {
         Self(bytes)
     }
 
+    #[must_use]
     pub fn expose_bytes(&self) -> &[u8] {
         &self.0
     }
@@ -36,8 +38,26 @@ pub struct EncryptionResult {
     pub ciphertext: Vec<u8>,
 }
 
-/// Symmetric encryption/decryption of arbitrary byte payloads.
+/// Provides symmetric authenticated encryption and decryption of arbitrary
+/// byte payloads.
+///
+/// Implementations are expected to encrypt data in a way that ensures both
+/// confidentiality and integrity. A value returned by [`Self::encrypt`]
+/// should be decryptable only by the same implementation initialized with the
+/// same keying material.
 pub trait Encryptor: Sync + Send {
+    /// Encrypts the given plaintext.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OperationOutcomeError`] if the plaintext cannot be
+    /// encrypted.
     fn encrypt(&self, plaintext: &[u8]) -> Result<EncryptionResult, OperationOutcomeError>;
+    /// Decrypts a previously encrypted payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OperationOutcomeError`] if the ciphertext is invalid,
+    /// has been tampered with, or cannot be decrypted.
     fn decrypt(&self, ciphertext: &EncryptionResult) -> Result<Vec<u8>, OperationOutcomeError>;
 }


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.