### PR TITLE
Resolve `clippy` lints for `hl7v2` crate

### DIFF
--- a/backend/crates/fhir-converter/src/jinja_extensions/conversions/hl7v2.rs
+++ b/backend/crates/fhir-converter/src/jinja_extensions/conversions/hl7v2.rs
@@ -5,7 +5,7 @@ use haste_fhir_model::r4::generated::resources::{
     HL7V2SegmentsFieldsValueValue,
 };
 use haste_hl7v2::serialize::{
-    EncodingInformation, SerializeMessage, component_to_string, segment_field_repititon_to_string,
+    EncodingInformation, SerializeMessage, component_to_string, segment_field_repetition_to_string,
     segment_field_to_string, segment_to_string,
 };
 use minijinja::{
@@ -195,7 +195,7 @@ impl Object for JHL7V2SegmentsFieldsValue<'_> {
         write!(
             f,
             "{}",
-            segment_field_repititon_to_string(&DEFAULT_ENCODING, self.0)
+            segment_field_repetition_to_string(&DEFAULT_ENCODING, self.0)
         )
     }
 }

--- a/backend/crates/hl7v2/src/mllp.rs
+++ b/backend/crates/hl7v2/src/mllp.rs
@@ -11,6 +11,7 @@ const COMMIT_NAK: u8 = 0x15;
 pub struct MllpFormatter;
 
 impl MllpFormatter {
+    #[must_use]
     pub fn encode(payload: &[u8]) -> Vec<u8> {
         let mut buf = Vec::with_capacity(payload.len() + 3);
         buf.push(START_BLOCK);
@@ -20,6 +21,13 @@ impl MllpFormatter {
         buf
     }
 
+    /// Decodes an MLLP-framed message and returns the enclosed payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OperationOutcomeError`] if `framed` is not a valid MLLP frame,
+    /// that is, if it is shorter than the minimum frame length or does not start
+    /// with `<SB>` and end with `<EB><CR>`.
     pub fn decode(framed: &[u8]) -> Result<&[u8], OperationOutcomeError> {
         if framed.len() < 4
             || framed[0] != START_BLOCK
@@ -29,31 +37,42 @@ impl MllpFormatter {
             let k = String::from_utf8_lossy(framed);
             return Err(OperationOutcomeError::error(
                 IssueType::exception(),
-                format!("Expected MLLP frame <SB>...<EB><CR>, got: {:?}", k),
+                format!("Expected MLLP frame <SB>...<EB><CR>, got: {k:?}"),
             ));
         }
         Ok(&framed[1..framed.len() - 2])
     }
 
+    #[must_use]
     pub fn ack() -> [u8; 4] {
         [START_BLOCK, COMMIT_ACK, END_BLOCK, CARRIAGE_RETURN]
     }
 
+    #[must_use]
     pub fn nak() -> [u8; 4] {
         [START_BLOCK, COMMIT_NAK, END_BLOCK, CARRIAGE_RETURN]
     }
 
+    #[must_use]
     pub fn is_ack(bytes: &[u8]) -> bool {
         bytes == Self::ack()
     }
 
+    #[must_use]
     pub fn is_nak(bytes: &[u8]) -> bool {
         bytes == Self::nak()
     }
 
-    /// Reads a single MLLP frame from `reader`, returning the raw framed bytes
-    /// (including the START_BLOCK / END_BLOCK / CARRIAGE_RETURN wrappers).
-    /// Returns an error on EOF mid-frame or an I/O error.
+    /// Reads a single MLLP frame from `reader`, returning the raw framed bytes,
+    /// including the `START_BLOCK`, `END_BLOCK`, and `CARRIAGE_RETURN`
+    /// delimiters.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OperationOutcomeError`] if:
+    /// - the stream ends before a complete MLLP frame is received,
+    /// - the frame does not begin with `START_BLOCK`, or
+    /// - an I/O error occurs while reading from the stream.
     pub fn read_frame<R: Read>(reader: &mut R) -> Result<Vec<u8>, OperationOutcomeError> {
         let mut buf = Vec::new();
         let mut byte = [0u8; 1];
@@ -83,7 +102,7 @@ impl MllpFormatter {
                 Err(e) => {
                     return Err(OperationOutcomeError::error(
                         IssueType::exception(),
-                        format!("Failed to read from stream: {}", e),
+                        format!("Failed to read from stream: {e}"),
                     ));
                 }
             }

--- a/backend/crates/hl7v2/src/serialize.rs
+++ b/backend/crates/hl7v2/src/serialize.rs
@@ -88,7 +88,7 @@ pub fn segment_to_string(
     encoding_characters: &EncodingInformation,
     segment: &HL7V2Segments,
 ) -> String {
-    let mut result = segment.id.value.as_deref().map_or("", |s| s).to_string();
+    let mut result = segment.id.value.as_deref().unwrap_or("").to_string();
 
     result.push_str(&encoding_characters.field_separator);
 
@@ -135,18 +135,14 @@ pub struct SerializeMessage<'a>(pub &'a HL7V2);
 impl<'a> From<SerializeMessage<'a>> for String {
     fn from(value: SerializeMessage<'a>) -> Self {
         let hl7v2_message = value.0;
-        let field_seperator = hl7v2_message
-            .fieldSeparator
-            .value
-            .as_deref()
-            .map_or("|", |s| s);
+        let field_separator = hl7v2_message.fieldSeparator.value.as_deref().unwrap_or("|");
         let encoding_characters_str =
             get_encoding_characters(hl7v2_message).unwrap_or("^~\\&".to_string());
 
         let mut result = String::new();
 
         let encoding_characters = EncodingInformation {
-            field_separator: field_seperator.to_string(),
+            field_separator: field_separator.to_string(),
             component_separator: encoding_characters_str
                 .chars()
                 .nth(0)

--- a/backend/crates/hl7v2/src/serialize.rs
+++ b/backend/crates/hl7v2/src/serialize.rs
@@ -12,21 +12,20 @@ pub struct EncodingInformation {
     pub subcomponent_separator: String,
 }
 
-// component separator, repetition separator, escape character, and subcomponent separator.
-
+#[must_use]
 pub fn component_to_string(
     encoding_characters: &EncodingInformation,
     component: &HL7V2SegmentsFieldsValueValue,
 ) -> Option<String> {
     if let Some(subcomponents) = &component.subcomponents {
         let value = subcomponents
-            .into_iter()
+            .iter()
             .map(|s| &s.value)
             .map(|v| {
                 if let Some(s) = v {
                     s.clone()
                 } else {
-                    "".to_string()
+                    String::new()
                 }
             })
             .collect::<Vec<_>>()
@@ -37,20 +36,21 @@ pub fn component_to_string(
     }
 }
 
+#[must_use]
 pub fn segment_field_repititon_to_string(
     encoding_characters: &EncodingInformation,
     segment: &HL7V2SegmentsFieldsValue,
 ) -> String {
-    let mut result = "".to_string();
+    let mut result = String::new();
 
     if let Some(components) = &segment.components {
         result.push_str(
             &components
-                .into_iter()
+                .iter()
                 .map(|c| component_to_string(encoding_characters, c).unwrap_or_default())
                 .collect::<Vec<_>>()
                 .join(&encoding_characters.component_separator),
-        )
+        );
     } else if let Some(value) = &segment.value {
         result.push_str(&component_to_string(encoding_characters, value).unwrap_or_default());
     }
@@ -58,16 +58,17 @@ pub fn segment_field_repititon_to_string(
     result
 }
 
+#[must_use]
 pub fn segment_field_to_string(
     encoding_characters: &EncodingInformation,
     segment: &HL7V2SegmentsFields,
 ) -> String {
-    let mut result = "".to_string();
+    let mut result = String::new();
 
     if let Some(repititions) = &segment.repetitions {
         result.push_str(
             &repititions
-                .into_iter()
+                .iter()
                 .map(|r| segment_field_repititon_to_string(encoding_characters, r))
                 .collect::<Vec<_>>()
                 .join(&encoding_characters.repetition_separator),
@@ -82,27 +83,22 @@ pub fn segment_field_to_string(
     result
 }
 
+#[must_use]
 pub fn segment_to_string(
     encoding_characters: &EncodingInformation,
     segment: &HL7V2Segments,
 ) -> String {
-    let mut result = segment
-        .id
-        .value
-        .as_ref()
-        .map(|s| s.as_str())
-        .unwrap_or("")
-        .to_string();
+    let mut result = segment.id.value.as_deref().map_or("", |s| s).to_string();
 
     result.push_str(&encoding_characters.field_separator);
 
-    let default_fields = vec![];
+    let default_fields = Vec::new();
     result.push_str(
         &segment
             .fields
             .as_ref()
             .unwrap_or(&default_fields)
-            .into_iter()
+            .iter()
             .map(|s| segment_field_to_string(encoding_characters, s))
             .collect::<Vec<_>>()
             .join(&encoding_characters.field_separator),
@@ -112,29 +108,24 @@ pub fn segment_to_string(
 }
 
 fn get_encoding_characters(hl7v2_message: &HL7V2) -> Option<String> {
-    let Some(msh) = hl7v2_message.segments.as_ref().and_then(|segments| {
+    let msh = hl7v2_message.segments.as_ref().and_then(|segments| {
         segments
             .iter()
-            .find(|s| s.id.value.as_ref().map(|s| s.as_str()) == Some("MSH"))
-    }) else {
-        return None;
-    };
+            .find(|s| s.id.value.as_deref() == Some("MSH"))
+    })?;
 
-    let Some(encoding_characters_str) = msh
+    let encoding_characters_str = msh
         .fields
         .as_ref()
-        .and_then(|fields| fields.into_iter().next())
+        .and_then(|fields| fields.iter().next())
         .and_then(|field| {
             field.value.as_ref().and_then(|v| {
                 v.value
                     .as_ref()
                     .and_then(|s| s.value.as_ref())
-                    .and_then(|s| s.value.as_ref().map(|s| s.as_str()))
+                    .and_then(|s| s.value.as_deref())
             })
-        })
-    else {
-        return None;
-    };
+        })?;
 
     Some(encoding_characters_str.to_string())
 }
@@ -147,13 +138,12 @@ impl<'a> From<SerializeMessage<'a>> for String {
         let field_seperator = hl7v2_message
             .fieldSeparator
             .value
-            .as_ref()
-            .map(|s| s.as_str())
-            .unwrap_or("|");
+            .as_deref()
+            .map_or("|", |s| s);
         let encoding_characters_str =
-            get_encoding_characters(&hl7v2_message).unwrap_or("^~\\&".to_string());
+            get_encoding_characters(hl7v2_message).unwrap_or("^~\\&".to_string());
 
-        let mut result = "".to_string();
+        let mut result = String::new();
 
         let encoding_characters = EncodingInformation {
             field_separator: field_seperator.to_string(),
@@ -182,7 +172,7 @@ impl<'a> From<SerializeMessage<'a>> for String {
 
         if let Some(segments) = &hl7v2_message.segments {
             let k = segments
-                .into_iter()
+                .iter()
                 .map(|s| segment_to_string(&encoding_characters, s))
                 .collect::<Vec<_>>()
                 .join("\n");

--- a/backend/crates/hl7v2/src/serialize.rs
+++ b/backend/crates/hl7v2/src/serialize.rs
@@ -37,7 +37,7 @@ pub fn component_to_string(
 }
 
 #[must_use]
-pub fn segment_field_repititon_to_string(
+pub fn segment_field_repetition_to_string(
     encoding_characters: &EncodingInformation,
     segment: &HL7V2SegmentsFieldsValue,
 ) -> String {
@@ -65,16 +65,16 @@ pub fn segment_field_to_string(
 ) -> String {
     let mut result = String::new();
 
-    if let Some(repititions) = &segment.repetitions {
+    if let Some(repetitions) = &segment.repetitions {
         result.push_str(
-            &repititions
+            &repetitions
                 .iter()
-                .map(|r| segment_field_repititon_to_string(encoding_characters, r))
+                .map(|r| segment_field_repetition_to_string(encoding_characters, r))
                 .collect::<Vec<_>>()
                 .join(&encoding_characters.repetition_separator),
         );
     } else if let Some(value) = &segment.value {
-        result.push_str(&segment_field_repititon_to_string(
+        result.push_str(&segment_field_repetition_to_string(
             encoding_characters,
             value,
         ));


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.