### PR TITLE
Resolve `clippy` lints for `fhir-search` crate

### DIFF
--- a/backend/crates/fhir-search/src/elastic_search/migration.rs
+++ b/backend/crates/fhir-search/src/elastic_search/migration.rs
@@ -80,34 +80,32 @@ fn reference_index_mapping() -> serde_json::Value {
     })
 }
 
-pub async fn create_elasticsearch_searchparameter_mappings(
-    parameters: &Vec<ResolvedParameter>,
-) -> Result<Value, OperationOutcomeError> {
+pub fn create_elasticsearch_searchparameter_mappings(parameters: &[ResolvedParameter]) -> Value {
     let mut property_mapping: HashMap<String, Value> = HashMap::new();
-    for parameter in parameters.iter() {
+    for parameter in parameters {
         let search_parameter = &parameter.search_parameter;
         if let Some(parameter_url) = search_parameter.url.value.as_ref() {
             match &search_parameter.type_ {
                 param_type if param_type == &SearchParamType::number() => {
-                    property_mapping.insert(parameter_url.to_string(), number_index_mapping());
+                    property_mapping.insert(parameter_url.clone(), number_index_mapping());
                 }
                 param_type if param_type == &SearchParamType::string() => {
-                    property_mapping.insert(parameter_url.to_string(), string_index_mapping());
+                    property_mapping.insert(parameter_url.clone(), string_index_mapping());
                 }
                 param_type if param_type == &SearchParamType::uri() => {
-                    property_mapping.insert(parameter_url.to_string(), uri_index_mapping());
+                    property_mapping.insert(parameter_url.clone(), uri_index_mapping());
                 }
                 param_type if param_type == &SearchParamType::token() => {
-                    property_mapping.insert(parameter_url.to_string(), token_index_mapping());
+                    property_mapping.insert(parameter_url.clone(), token_index_mapping());
                 }
                 param_type if param_type == &SearchParamType::date() => {
-                    property_mapping.insert(parameter_url.to_string(), date_index_mapping());
+                    property_mapping.insert(parameter_url.clone(), date_index_mapping());
                 }
                 param_type if param_type == &SearchParamType::reference() => {
-                    property_mapping.insert(parameter_url.to_string(), reference_index_mapping());
+                    property_mapping.insert(parameter_url.clone(), reference_index_mapping());
                 }
                 param_type if param_type == &SearchParamType::quantity() => {
-                    property_mapping.insert(parameter_url.to_string(), quantity_index_mapping());
+                    property_mapping.insert(parameter_url.clone(), quantity_index_mapping());
                 }
                 // Not Supported yet
                 param_type
@@ -184,10 +182,10 @@ pub async fn create_elasticsearch_searchparameter_mappings(
         }),
     );
 
-    Ok(json!({
+    json!({
         "dynamic": true,
         "properties" : property_mapping
-    }))
+    })
 }
 
 pub async fn create_mapping<ParameterResolver: SearchParameterResolve>(
@@ -197,9 +195,7 @@ pub async fn create_mapping<ParameterResolver: SearchParameterResolve>(
 ) -> Result<(), OperationOutcomeError> {
     let exists_res = elastic_search
         .indices()
-        .exists(elasticsearch::indices::IndicesExistsParts::Index(&vec![
-            index,
-        ]))
+        .exists(elasticsearch::indices::IndicesExistsParts::Index(&[index]))
         .send()
         .await
         .unwrap();
@@ -208,9 +204,7 @@ pub async fn create_mapping<ParameterResolver: SearchParameterResolve>(
         &parameter_resolver
             .all(&TenantId::System, &ProjectId::System)
             .await?,
-    )
-    .await
-    .unwrap();
+    );
 
     let index_exists = exists_res.status_code().is_success();
 

--- a/backend/crates/fhir-search/src/elastic_search/mod.rs
+++ b/backend/crates/fhir-search/src/elastic_search/mod.rs
@@ -91,6 +91,14 @@ pub struct ElasticSearchEngine<SearchParameterResolver: SearchParameterResolve +
     client: Arc<Elasticsearch>,
 }
 
+/// Creates an Elasticsearch client using the provided URL and credentials.
+///
+/// # Errors
+///
+/// Returns [`SearchConfigError::UrlParseError`] if url is not a valid URL.
+///
+/// Returns a [`SearchConfigError`] if the Elasticsearch transport cannot be
+/// constructed.
 pub fn create_es_client(
     url: &str,
     username: String,
@@ -108,6 +116,10 @@ pub fn create_es_client(
     Ok(Arc::new(elasticsearch_client))
 }
 
+type Tasks = tokio::task::JoinHandle<
+    Result<BulkOperation<HashMap<String, InsertableIndex>>, OperationOutcomeError>,
+>;
+
 impl<SearchParameterResolver: SearchParameterResolve + 'static>
     ElasticSearchEngine<SearchParameterResolver>
 {
@@ -123,6 +135,14 @@ impl<SearchParameterResolver: SearchParameterResolve + 'static>
         }
     }
 
+    /// Checks whether the Elasticsearch client is connected.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchError::NotConnected`] if Elasticsearch responds with a
+    /// non-success status code.
+    ///
+    /// Returns a [`SearchError`] if the ping request fails.
     pub async fn is_connected(&self) -> Result<(), SearchError> {
         let res = self.client.ping().send().await.map_err(SearchError::from)?;
 
@@ -132,16 +152,187 @@ impl<SearchParameterResolver: SearchParameterResolve + 'static>
             Err(SearchError::NotConnected)
         }
     }
+
+    async fn send_bulk_operations(
+        &self,
+        search_index_name: &'static str,
+        bulk_ops: Vec<BulkOperation<HashMap<String, InsertableIndex>>>,
+    ) -> Result<SuccessfullyIndexedCount, OperationOutcomeError> {
+        if bulk_ops.is_empty() {
+            return Ok(SuccessfullyIndexedCount(0));
+        }
+
+        let res = self
+            .client
+            .bulk(BulkParts::Index(search_index_name))
+            .body(bulk_ops)
+            .send()
+            .await
+            .map_err(SearchError::from)?;
+
+        let response_body = res.json::<serde_json::Value>().await.map_err(|_e| {
+            OperationOutcomeError::fatal(
+                IssueType::exception(),
+                "Failed to parse response body.".to_string(),
+            )
+        })?;
+
+        if response_body["errors"].as_bool().unwrap() {
+            tracing::error!("Failed to index resources. Response: '{:?}'", response_body);
+            return Err(SearchError::Fatal(500).into());
+        }
+
+        Ok(SuccessfullyIndexedCount(
+            response_body["items"].as_array().unwrap().len(),
+        ))
+    }
+
+    fn spawn_index_tasks(
+        &self,
+        resources: Vec<IndexResource>,
+        search_index_name: &'static str,
+    ) -> Vec<Tasks> {
+        resources
+            .into_iter()
+            .filter(|r| {
+                matches!(
+                    r.fhir_method,
+                    FHIRMethod::Create | FHIRMethod::Update | FHIRMethod::Delete
+                )
+            })
+            .map(|r| {
+                let engine = self.fp_engine.clone();
+                let parameter_resolver = self.parameter_resolver.clone();
+
+                tokio::spawn(async move {
+                    Self::build_bulk_operation(engine, parameter_resolver, r, search_index_name)
+                        .await
+                })
+            })
+            .collect()
+    }
+
+    async fn collect_bulk_operations(
+        &self,
+        tasks: Vec<Tasks>,
+        resources_total: usize,
+    ) -> Result<Vec<BulkOperation<HashMap<String, InsertableIndex>>>, OperationOutcomeError> {
+        tracing::trace!("Awaiting {} indexing tasks.", tasks.len());
+
+        let mut bulk_ops = Vec::with_capacity(resources_total);
+
+        for task in tasks {
+            let res = task.await.map_err(|e| {
+                OperationOutcomeError::fatal(IssueType::exception(), e.to_string())
+            })??;
+
+            bulk_ops.push(res);
+        }
+
+        Ok(bulk_ops)
+    }
+
+    async fn build_bulk_operation<ParameterResolver: SearchParameterResolve>(
+        engine: Arc<FPEngine>,
+        parameter_resolver: Arc<ParameterResolver>,
+        resource: IndexResource,
+        search_index_name: &'static str,
+    ) -> Result<BulkOperation<HashMap<String, InsertableIndex>>, OperationOutcomeError> {
+        match &resource.fhir_method {
+            FHIRMethod::Create | FHIRMethod::Update => {
+                Self::build_index_operation(
+                    engine,
+                    parameter_resolver,
+                    &resource,
+                    search_index_name,
+                )
+                .await
+            }
+
+            FHIRMethod::Delete => Ok(BulkOperation::delete(unique_index_id(
+                &resource.tenant,
+                &resource.project,
+                &resource.resource_type,
+                &resource.id,
+            ))
+            .index(search_index_name)
+            .into()),
+
+            method @ FHIRMethod::Read => Err(OperationOutcomeError::from(
+                SearchError::UnsupportedFHIRMethod((*method).clone()),
+            )),
+        }
+    }
+
+    async fn build_index_operation<ParameterResolver: SearchParameterResolve>(
+        engine: Arc<FPEngine>,
+        parameter_resolver: Arc<ParameterResolver>,
+        resource: &IndexResource,
+        search_index_name: &'static str,
+    ) -> Result<BulkOperation<HashMap<String, InsertableIndex>>, OperationOutcomeError> {
+        // Id is not sufficient because different Resourcetypes may have the same id.
+        // Additionally should be namespaced by tenant and project to avoid conflicts across tenants and projects.
+        let index_id = unique_index_id(
+            &resource.tenant,
+            &resource.project,
+            &resource.resource_type,
+            &resource.id,
+        );
+
+        let params = parameter_resolver
+            .by_resource_type(&resource.tenant, &resource.project, &resource.resource_type)
+            .await?;
+
+        let mut elastic_index =
+            resource_to_elastic_index(engine, &params, &resource.resource).await?;
+
+        Self::add_index_metadata(&mut elastic_index, resource);
+
+        Ok(BulkOperation::index(elastic_index)
+            .id(index_id)
+            .index(search_index_name)
+            .into())
+    }
+
+    fn add_index_metadata(
+        elastic_index: &mut HashMap<String, InsertableIndex>,
+        resource: &IndexResource,
+    ) {
+        elastic_index.insert(
+            "resource_type".to_string(),
+            InsertableIndex::Meta(resource.resource_type.as_ref().to_string()),
+        );
+
+        elastic_index.insert(
+            "id".to_string(),
+            InsertableIndex::Meta(resource.id.as_ref().to_string()),
+        );
+
+        elastic_index.insert(
+            "version_id".to_string(),
+            InsertableIndex::Meta(resource.version_id.as_ref().to_string()),
+        );
+
+        elastic_index.insert(
+            "project".to_string(),
+            InsertableIndex::Meta(resource.project.as_ref().to_string()),
+        );
+
+        elastic_index.insert(
+            "tenant".to_string(),
+            InsertableIndex::Meta(resource.tenant.as_ref().to_string()),
+        );
+    }
 }
 
 async fn resource_to_elastic_index(
     fp_engine: Arc<FPEngine>,
-    parameters: &Vec<ResolvedParameter>,
+    parameters: &[ResolvedParameter],
     resource: &Resource,
 ) -> Result<HashMap<String, InsertableIndex>, OperationOutcomeError> {
     let mut map = HashMap::new();
     let mut dynamic_parameters = HashMap::new();
-    for param in parameters.iter() {
+    for param in parameters {
         if let Some(expression) = param
             .search_parameter
             .expression
@@ -160,12 +351,12 @@ async fn resource_to_elastic_index(
                     expression,
                 );
 
-                return Err(SearchError::from(err).into());
+                return Err(err.into());
             }
 
             let result_vec = indexing_conversion::to_insertable_index(
                 param,
-                result?.iter().collect::<Vec<_>>(),
+                &result?.iter().collect::<Vec<_>>(),
             )?;
 
             match param.level {
@@ -191,13 +382,9 @@ async fn resource_to_elastic_index(
 
 static R4_FHIR_INDEX: &str = "r4_search_index";
 
-pub fn get_index_name(
-    fhir_version: &SupportedFHIRVersions,
-) -> Result<&'static str, SearchConfigError> {
-    match fhir_version {
-        SupportedFHIRVersions::R4 => Ok(R4_FHIR_INDEX),
-        // _ => Err(SearchConfigError::UnsupportedIndex(fhir_version.clone())),
-    }
+#[must_use]
+pub const fn get_index_name() -> &'static str {
+    R4_FHIR_INDEX
 }
 
 #[derive(serde::Deserialize, Debug)]
@@ -247,7 +434,7 @@ impl<SearchParameterResolver: SearchParameterResolve> SearchEngine
 {
     async fn search(
         &self,
-        fhir_version: &SupportedFHIRVersions,
+        _fhir_version: &SupportedFHIRVersions,
         tenant: &TenantId,
         project: &ProjectId,
         search_request: &SearchRequest,
@@ -256,141 +443,40 @@ impl<SearchParameterResolver: SearchParameterResolve> SearchEngine
         search::execute_search(
             self.client.clone(),
             self.parameter_resolver.clone(),
-            fhir_version,
             tenant,
             project,
             search_request,
-            &options,
+            options.as_ref(),
         )
         .await
     }
 
-    fn index(
+    async fn index(
         &self,
-        fhir_version: SupportedFHIRVersions,
+        _fhir_version: SupportedFHIRVersions,
         resources: Vec<IndexResource>,
-    ) -> impl Future<Output = Result<SuccessfullyIndexedCount, OperationOutcomeError>> + Send {
-        async move {
-            // Iterator used to evaluate all of the search expressions for indexing.
+    ) -> Result<SuccessfullyIndexedCount, OperationOutcomeError> {
+        // Iterator used to evaluate all of the search expressions for indexing.
 
-            let mut tasks = Vec::with_capacity(resources.len());
-            let resources_total = resources.len();
-            let search_index_name = get_index_name(&fhir_version)?;
+        let resources_total = resources.len();
+        let search_index_name = get_index_name();
 
-            tracing::trace!(
-                "Indexing {} resources into index: '{}'",
-                resources_total,
-                search_index_name
-            );
+        tracing::trace!(
+            "Indexing {} resources into index: '{}'",
+            resources_total,
+            search_index_name
+        );
 
-            for r in resources.into_iter().filter(|r| match r.fhir_method {
-                FHIRMethod::Create | FHIRMethod::Update | FHIRMethod::Delete => true,
-                _ => false,
-            }) {
-                let engine = self.fp_engine.clone();
-                let parameter_resolver = self.parameter_resolver.clone();
-                tasks.push(tokio::spawn(async move {
-                    match &r.fhir_method {
-                        FHIRMethod::Create | FHIRMethod::Update => {
-                            // Id is not sufficient because different Resourcetypes may have the same id.
-                            // Additionally should be namespaced by tenant and project to avoid conflicts across tenants and projects.
-                            let index_id =
-                                unique_index_id(&r.tenant, &r.project, &r.resource_type, &r.id);
-                            let params = parameter_resolver
-                                .by_resource_type(&r.tenant, &r.project, &r.resource_type)
-                                .await?;
+        let tasks = self.spawn_index_tasks(resources, search_index_name);
+        let bulk_ops = self.collect_bulk_operations(tasks, resources_total).await?;
 
-                            let mut elastic_index =
-                                resource_to_elastic_index(engine, &params, &r.resource).await?;
+        tracing::trace!(
+            "Bulk indexing {} resources into index: '{}'",
+            bulk_ops.len(),
+            search_index_name
+        );
 
-                            elastic_index.insert(
-                                "resource_type".to_string(),
-                                InsertableIndex::Meta(r.resource_type.as_ref().to_string()),
-                            );
-
-                            elastic_index.insert(
-                                "id".to_string(),
-                                InsertableIndex::Meta(r.id.as_ref().to_string()),
-                            );
-
-                            elastic_index.insert(
-                                "version_id".to_string(),
-                                InsertableIndex::Meta(r.version_id.as_ref().to_string()),
-                            );
-                            elastic_index.insert(
-                                "project".to_string(),
-                                InsertableIndex::Meta(r.project.as_ref().to_string()),
-                            );
-                            elastic_index.insert(
-                                "tenant".to_string(),
-                                InsertableIndex::Meta(r.tenant.as_ref().to_string()),
-                            );
-
-                            Ok(BulkOperation::index(elastic_index)
-                                .id(index_id)
-                                .index(search_index_name)
-                                .into())
-                        }
-                        FHIRMethod::Delete => Ok(BulkOperation::delete(unique_index_id(
-                            &r.tenant,
-                            &r.project,
-                            &r.resource_type,
-                            &r.id,
-                        ))
-                        .index(search_index_name)
-                        .into()),
-                        method => Err(SearchError::UnsupportedFHIRMethod((*method).clone()))
-                            .map_err(OperationOutcomeError::from),
-                    }
-                }));
-            }
-
-            let client = self.client.clone();
-
-            let mut bulk_ops: Vec<BulkOperation<HashMap<String, InsertableIndex>>> =
-                Vec::with_capacity(resources_total);
-
-            tracing::trace!("Awaiting {} indexing tasks.", tasks.len());
-
-            for task in tasks {
-                let res = task.await.map_err(|e| {
-                    OperationOutcomeError::fatal(IssueType::exception(), e.to_string())
-                })??;
-                bulk_ops.push(res);
-            }
-
-            tracing::trace!(
-                "Bulk indexing {} resources into index: '{}'",
-                bulk_ops.len(),
-                search_index_name
-            );
-
-            if !bulk_ops.is_empty() {
-                let res = client
-                    .bulk(BulkParts::Index(search_index_name))
-                    .body(bulk_ops)
-                    .send()
-                    .await
-                    .map_err(SearchError::from)?;
-
-                let response_body = res.json::<serde_json::Value>().await.map_err(|_e| {
-                    OperationOutcomeError::fatal(
-                        IssueType::exception(),
-                        "Failed to parse response body.".to_string(),
-                    )
-                })?;
-
-                if response_body["errors"].as_bool().unwrap() == true {
-                    tracing::error!("Failed to index resources. Response: '{:?}'", response_body);
-                    return Err(SearchError::Fatal(500).into());
-                }
-                Ok(SuccessfullyIndexedCount(
-                    response_body["items"].as_array().unwrap().len(),
-                ))
-            } else {
-                Ok(SuccessfullyIndexedCount(0))
-            }
-        }
+        self.send_bulk_operations(search_index_name, bulk_ops).await
     }
 
     async fn migrate(
@@ -400,7 +486,7 @@ impl<SearchParameterResolver: SearchParameterResolve> SearchEngine
         migration::create_mapping(
             self.parameter_resolver.clone(),
             &self.client,
-            get_index_name(_fhir_version)?,
+            get_index_name(),
         )
         .await?;
         Ok(())

--- a/backend/crates/fhir-search/src/elastic_search/search/clauses/date.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/clauses/date.rs
@@ -12,155 +12,159 @@ pub fn date(
     search_param: &SearchParameter,
 ) -> Result<serde_json::Value, QueryBuildError> {
     let column_name = namespace_parameter(namespace, search_param);
+
     let params = parsed_parameter
         .value
         .iter()
-        .map(|value| {
-            let (prefix, value) = parse_prefix(value);
-
-            let date_time = parse_datetime(value)
-                .map_err(|_e| QueryBuildError::InvalidDateFormat(value.to_string()))?;
-
-            let date_range = date_time_range(&date_time)
-                .map_err(|_e| QueryBuildError::InvalidDateFormat(value.to_string()))?;
-
-            match prefix {
-                Some("gt") => Ok(json!({
-                    "nested": {
-                        "path": &column_name,
-                        "query": {
-                            "bool": {
-                                "filter": [
-                                    {
-                                        "range": {
-                                            format!("{}.start", column_name): {
-                                                "gt": date_range.end
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                })),
-                Some("lt") => Ok(json!({
-                    "nested": {
-                        "path": &column_name,
-                        "query": {
-                            "bool": {
-                                "filter": [
-                                    {
-                                        "range": {
-                                            format!("{}.end", column_name): {
-                                                "lt": date_range.start
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                })),
-                Some("ge") => Ok(json!({
-                    "nested": {
-                        "path": &column_name,
-                        "query": {
-                            "bool": {
-                                "filter": [
-                                    {
-                                        "range": {
-                                            format!("{}.start", column_name): {
-                                                "gte": date_range.start
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                })),
-                Some("le") => Ok(json!({
-                    "nested": {
-                        "path": &column_name,
-                        "query": {
-                            "bool": {
-                                "filter": [
-                                    {
-                                        "range": {
-                                            format!("{}.end", column_name): {
-                                                "lte": date_range.end
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                })),
-                Some("ne") => Ok(json!({
-                    "nested": {
-                        "path": &column_name,
-                        "query": {
-                            "bool": {
-                                "must_not": [
-                                    {
-                                        "bool": {
-                                            "filter": [
-                                                {
-                                                    "range": {
-                                                        format!("{}.start", column_name): {
-                                                            "lte": date_range.end
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "range": {
-                                                        format!("{}.end", column_name): {
-                                                            "gte": date_range.start
-                                                        }
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                })),
-                Some("eq") | None => Ok(json!({
-                    "nested": {
-                        "path": &column_name,
-                        "query": {
-                            "bool": {
-                                "filter": [
-                                    {
-                                        "range": {
-                                            format!("{}.start", column_name): {
-                                                "lte": date_range.end
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "range": {
-                                            format!("{}.end", column_name): {
-                                                "gte": date_range.start
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                })),
-                Some(prefix) => Err(QueryBuildError::UnsupportedModifier(prefix.to_string())),
-            }
-        })
-        .collect::<Result<Vec<serde_json::Value>, QueryBuildError>>()?;
+        .map(|value| build_date_query(value, &column_name))
+        .collect::<Result<Vec<_>, QueryBuildError>>()?;
 
     Ok(json!({
         "bool": {
             "should": params
         }
     }))
+}
+
+fn build_date_query(value: &str, column_name: &str) -> Result<serde_json::Value, QueryBuildError> {
+    let (prefix, value) = parse_prefix(value);
+
+    let date_time = parse_datetime(value)
+        .map_err(|_e| QueryBuildError::InvalidDateFormat(value.to_string()))?;
+
+    let date_range = date_time_range(&date_time)
+        .map_err(|_e| QueryBuildError::InvalidDateFormat(value.to_string()))?;
+
+    match prefix {
+        Some("gt") => Ok(date_range_query(
+            column_name,
+            &json!({
+                "gt": date_range.end
+            }),
+        )),
+
+        Some("lt") => Ok(date_range_query(
+            column_name,
+            &json!({
+                "lt": date_range.start
+            }),
+        )),
+
+        Some("ge") => Ok(date_range_query(
+            column_name,
+            &json!({
+                "gte": date_range.start
+            }),
+        )),
+
+        Some("le") => Ok(date_range_query(
+            column_name,
+            &json!({
+                "lte": date_range.end
+            }),
+        )),
+
+        Some("ne") => Ok(date_not_overlapping_query(
+            column_name,
+            date_range.start,
+            date_range.end,
+        )),
+
+        Some("eq") | None => Ok(date_overlapping_query(
+            column_name,
+            date_range.start,
+            date_range.end,
+        )),
+
+        Some(prefix) => Err(QueryBuildError::UnsupportedModifier(prefix.to_string())),
+    }
+}
+
+fn date_range_query(column_name: &str, range: &serde_json::Value) -> serde_json::Value {
+    json!({
+        "nested": {
+            "path": column_name,
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "range": {
+                                format!("{}.start", column_name): range
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    })
+}
+
+fn date_overlapping_query(
+    column_name: &str,
+    start: impl serde::Serialize,
+    end: impl serde::Serialize,
+) -> serde_json::Value {
+    json!({
+        "nested": {
+            "path": column_name,
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "range": {
+                                format!("{}.start", column_name): {
+                                    "lte": end
+                                }
+                            }
+                        },
+                        {
+                            "range": {
+                                format!("{}.end", column_name): {
+                                    "gte": start
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    })
+}
+
+fn date_not_overlapping_query(
+    column_name: &str,
+    start: impl serde::Serialize,
+    end: impl serde::Serialize,
+) -> serde_json::Value {
+    json!({
+        "nested": {
+            "path": column_name,
+            "query": {
+                "bool": {
+                    "must_not": [
+                        {
+                            "bool": {
+                                "filter": [
+                                    {
+                                        "range": {
+                                            format!("{}.start", column_name): {
+                                                "lte": end
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "range": {
+                                            format!("{}.end", column_name): {
+                                                "gte": start
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    })
 }

--- a/backend/crates/fhir-search/src/elastic_search/search/clauses/mod.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/clauses/mod.rs
@@ -17,24 +17,15 @@ pub use token::*;
 pub use uri::*;
 
 pub fn namespace_parameter(namespace: Option<&str>, search_parameter: &SearchParameter) -> String {
-    namespace
-        .map(|ns| {
-            ns.to_string()
-                + "."
-                + search_parameter
-                    .url
-                    .value
-                    .as_ref()
-                    .map(|s| s.as_str())
-                    .unwrap_or("")
-        })
-        .unwrap_or_else(|| {
+    namespace.map_or_else(
+        || {
             search_parameter
                 .url
                 .value
-                .as_ref()
-                .map(|s| s.as_str())
-                .unwrap_or("")
+                .as_deref()
+                .map_or("", |s| s)
                 .to_string()
-        })
+        },
+        |ns| ns.to_string() + "." + search_parameter.url.value.as_deref().map_or("", |s| s),
+    )
 }

--- a/backend/crates/fhir-search/src/elastic_search/search/clauses/number.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/clauses/number.rs
@@ -13,13 +13,9 @@ pub fn number(
     parsed_parameter: &Parameter,
     search_param: &SearchParameter,
 ) -> Result<serde_json::Value, QueryBuildError> {
-    match parsed_parameter.modifier.as_ref().map(|m| m.as_str()) {
-        Some("missing") => {
-            return simple_missing_modifier(search_param, parsed_parameter);
-        }
-        Some(modifier) => {
-            return Err(QueryBuildError::UnsupportedModifier(modifier.to_string()));
-        }
+    match parsed_parameter.modifier.as_deref() {
+        Some("missing") => simple_missing_modifier(search_param, parsed_parameter),
+        Some(modifier) => Err(QueryBuildError::UnsupportedModifier(modifier.to_string())),
         None => {
             let column_name = namespace_parameter(namespace, search_param);
             let params = parsed_parameter

--- a/backend/crates/fhir-search/src/elastic_search/search/clauses/quantity.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/clauses/quantity.rs
@@ -18,7 +18,7 @@ pub fn quantity(
                 3 => {
                     let mut clauses = vec![];
 
-                    let value = pieces.get(0).unwrap_or(&"");
+                    let value = pieces.first().unwrap_or(&"");
                     let system = pieces.get(1).unwrap_or(&"");
                     let code = pieces.get(2).unwrap_or(&"");
 
@@ -91,10 +91,8 @@ pub fn quantity(
                         }
                     }))
                 }
-                4 => Err(QueryBuildError::UnsupportedParameterValue(
-                    value.to_string(),
-                )),
-                _ => Err(QueryBuildError::InvalidParameterValue(value.to_string())),
+                4 => Err(QueryBuildError::UnsupportedParameterValue(value.clone())),
+                _ => Err(QueryBuildError::InvalidParameterValue(value.clone())),
             }
         })
         .collect::<Result<Vec<serde_json::Value>, QueryBuildError>>()?;

--- a/backend/crates/fhir-search/src/elastic_search/search/clauses/reference.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/clauses/reference.rs
@@ -22,7 +22,7 @@ pub fn reference(
                         "query": {
                             "match": {
                                 format!("{}.id", &column_name): {
-                                    "query": pieces.get(0)
+                                    "query": pieces.first()
                                 }
                             }
                         }
@@ -37,7 +37,7 @@ pub fn reference(
                                     {
                                         "match": {
                                             format!("{}.resource_type", &column_name): {
-                                                "query": pieces.get(0)
+                                                "query": pieces.first()
                                             }
                                         }
                                     },
@@ -53,7 +53,7 @@ pub fn reference(
                         }
                     }
                 })),
-                _ => Err(QueryBuildError::InvalidParameterValue(value.to_string())),
+                _ => Err(QueryBuildError::InvalidParameterValue(value.clone())),
             }
         })
         .collect::<Result<Vec<serde_json::Value>, QueryBuildError>>()?;

--- a/backend/crates/fhir-search/src/elastic_search/search/clauses/string.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/clauses/string.rs
@@ -12,7 +12,7 @@ pub fn string(
 ) -> Result<serde_json::Value, QueryBuildError> {
     let column_name = namespace_parameter(namespace, search_param);
 
-    match parsed_parameter.modifier.as_ref().map(|m| m.as_str()) {
+    match parsed_parameter.modifier.as_deref() {
         Some("missing") => simple_missing_modifier(search_param, parsed_parameter),
         Some("exact") => {
             let string_params = parsed_parameter

--- a/backend/crates/fhir-search/src/elastic_search/search/clauses/token.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/clauses/token.rs
@@ -3,8 +3,8 @@ use haste_fhir_client::url::Parameter;
 use haste_fhir_model::r4::generated::resources::SearchParameter;
 use serde_json::json;
 
-fn matching_modifier(modifier: &Option<String>) -> Result<String, QueryBuildError> {
-    match modifier.as_ref().map(|s| s.as_str()) {
+fn matching_modifier(modifier: Option<&str>) -> Result<String, QueryBuildError> {
+    match modifier {
         Some("not") => Ok("must_not".to_string()),
         Some(modifier) => Err(QueryBuildError::ModifierNotSupported(modifier.into())),
         None => Ok("must".to_string()),
@@ -16,7 +16,7 @@ pub fn token(
     parameter: &Parameter,
     search_param: &SearchParameter,
 ) -> Result<serde_json::Value, QueryBuildError> {
-    let matching_type = matching_modifier(&parameter.modifier)?;
+    let matching_type = matching_modifier(parameter.modifier.as_deref())?;
     let column_name = namespace_parameter(namespace, search_param);
 
     let params = parameter
@@ -33,7 +33,7 @@ pub fn token(
                                 &matching_type: [{
                                     "match": {
                                         format!("{}.code", column_name): {
-                                        "query": pieces.get(0)
+                                        "query": pieces.first()
                                     }
                                 }}]
                             }
@@ -58,7 +58,7 @@ pub fn token(
                                             {
                                                 "match": {
                                                     format!("{}.system", column_name): {
-                                                        "query": pieces.get(0)
+                                                        "query": pieces.first()
                                                     }
                                                 }
                                             }
@@ -69,7 +69,7 @@ pub fn token(
                         }
                     }
                 })),
-                _ => Err(QueryBuildError::InvalidParameterValue(value.to_string())),
+                _ => Err(QueryBuildError::InvalidParameterValue(value.clone())),
             }
         })
         .collect::<Result<Vec<serde_json::Value>, QueryBuildError>>()?;

--- a/backend/crates/fhir-search/src/elastic_search/search/clauses/uri.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/clauses/uri.rs
@@ -11,13 +11,9 @@ pub fn uri(
     parsed_parameter: &Parameter,
     search_parameter: &SearchParameter,
 ) -> Result<serde_json::Value, QueryBuildError> {
-    match parsed_parameter.modifier.as_ref().map(|m| m.as_str()) {
-        Some("missing") => {
-            return simple_missing_modifier(search_parameter, parsed_parameter);
-        }
-        Some(modifier) => {
-            return Err(QueryBuildError::UnsupportedModifier(modifier.to_string()));
-        }
+    match parsed_parameter.modifier.as_deref() {
+        Some("missing") => simple_missing_modifier(search_parameter, parsed_parameter),
+        Some(modifier) => Err(QueryBuildError::UnsupportedModifier(modifier.to_string())),
         None => {
             let column_name = namespace_parameter(namespace, search_parameter);
 

--- a/backend/crates/fhir-search/src/elastic_search/search/mod.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/mod.rs
@@ -18,7 +18,6 @@ use haste_fhir_model::r4::generated::{
 };
 use haste_fhir_operation_error::{OperationOutcomeError, derive::OperationOutcomeError};
 use haste_jwt::{ProjectId, TenantId};
-use haste_repository::types::SupportedFHIRVersions;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -141,11 +140,9 @@ fn sort_build(
                 }))
             }
         },
-        _ => {
-            return Err(QueryBuildError::UnsupportedSortParameter(
-                search_param.name.value.clone().unwrap_or_default(),
-            ));
-        }
+        _ => Err(QueryBuildError::UnsupportedSortParameter(
+            search_param.name.value.clone().unwrap_or_default(),
+        )),
     }
 }
 
@@ -158,12 +155,7 @@ fn simple_missing_modifier(
         return Err(QueryBuildError::UnsupportedModifier("missing".to_string()));
     }
 
-    let url = search_param
-        .url
-        .value
-        .as_ref()
-        .map(|v| v.as_str())
-        .unwrap_or_default();
+    let url = search_param.url.value.as_deref().unwrap_or_default();
 
     let field_name = match &search_param.type_ {
         param_type
@@ -198,11 +190,9 @@ fn simple_missing_modifier(
                 parsed_parameter.name.clone(),
             )),
         },
-        _ => {
-            return Err(QueryBuildError::InvalidParameterValue(
-                parsed_parameter.name.clone(),
-            ));
-        }
+        _ => Err(QueryBuildError::InvalidParameterValue(
+            parsed_parameter.name.clone(),
+        )),
     }
 }
 
@@ -258,14 +248,14 @@ fn parameter_to_elasticsearch_clauses(
 static ABSOLUTE_MAX: usize = 10_000;
 static DEFAULT_MAX_COUNT: usize = 50;
 
-fn get_resource_type<'a>(request: &'a SearchRequest) -> Option<&'a ResourceType> {
+fn get_resource_type(request: &SearchRequest) -> Option<&ResourceType> {
     match request {
         SearchRequest::Type(type_search_request) => Some(&type_search_request.resource_type),
-        _ => None,
+        SearchRequest::System(_) => None,
     }
 }
 
-fn get_parameters<'a>(request: &'a SearchRequest) -> &'a ParsedParameters {
+fn get_parameters(request: &SearchRequest) -> &ParsedParameters {
     match request {
         SearchRequest::Type(type_search_request) => &type_search_request.parameters,
         SearchRequest::System(system_search_request) => &system_search_request.parameters,
@@ -277,139 +267,205 @@ async fn build_elastic_search_query<ParameterResolver: SearchParameterResolve>(
     tenant: &TenantId,
     project: &ProjectId,
     request: &SearchRequest,
-    options: &Option<SearchOptions>,
+    options: Option<&SearchOptions>,
 ) -> Result<serde_json::Value, OperationOutcomeError> {
     let resource_type = get_resource_type(request);
     let parameters = get_parameters(request);
 
-    let mut clauses: Vec<serde_json::Value> = vec![];
-    let mut max_count = if let Some(count_limit) = options.as_ref().and_then(|o| o.count_limit) {
+    let mut clauses = Vec::new();
+    let mut state = ElasticSearchQueryState {
+        max_count: get_max_count(options)?,
+        offset: 0,
+        show_total: false,
+        sort: Vec::new(),
+    };
+
+    for parameter in parameters.parameters() {
+        match parameter {
+            ParsedParameter::Resource(resource_param) => {
+                let clause = build_resource_clause(
+                    &parameter_resolver,
+                    tenant,
+                    project,
+                    resource_type,
+                    resource_param,
+                )
+                .await?;
+
+                clauses.push(clause);
+            }
+            ParsedParameter::Result(result_param) => {
+                handle_result_parameter(
+                    &parameter_resolver,
+                    tenant,
+                    project,
+                    resource_type,
+                    result_param,
+                    &mut state,
+                )
+                .await?;
+            }
+        }
+    }
+
+    add_context_clauses(&mut clauses, resource_type, tenant, project);
+
+    Ok(build_elastic_query(
+        &clauses,
+        state.max_count,
+        state.show_total,
+        state.offset,
+        &state.sort,
+    ))
+}
+
+fn get_max_count(options: Option<&SearchOptions>) -> Result<usize, OperationOutcomeError> {
+    if let Some(count_limit) = options.as_ref().and_then(|o| o.count_limit) {
         if count_limit > ABSOLUTE_MAX {
             return Err(OperationOutcomeError::fatal(
                 IssueType::too_costly(),
                 "Count limit passed exceeds maxiumum allowed by ES".to_string(),
             ));
         }
-        count_limit
+
+        Ok(count_limit)
     } else {
-        DEFAULT_MAX_COUNT
-    };
-    let mut show_total = false;
-    let mut sort: Vec<serde_json::Value> = Vec::new();
-    let mut offset: u64 = 0;
+        Ok(DEFAULT_MAX_COUNT)
+    }
+}
 
-    for parameter in parameters.parameters().iter() {
-        match parameter {
-            ParsedParameter::Resource(resource_param) => {
-                let parameter = parameter_resolver
-                    .by_name(tenant, project, resource_type, &resource_param.name)
-                    .await?
-                    .ok_or_else(|| {
-                        QueryBuildError::MissingParameter(resource_param.name.to_string())
-                    })?;
-                let clause = parameter_to_elasticsearch_clauses(&parameter, &resource_param)?;
-                clauses.push(clause);
-            }
-            ParsedParameter::Result(result_param) => match result_param.name.as_str() {
-                "_count" => {
-                    let count_param = std::cmp::min(
-                        result_param
-                            .value
-                            .get(0)
-                            .and_then(|v| v.parse::<i64>().ok())
-                            .unwrap_or(100),
-                        DEFAULT_MAX_COUNT as i64,
-                    );
+async fn build_resource_clause<ParameterResolver: SearchParameterResolve>(
+    parameter_resolver: &Arc<ParameterResolver>,
+    tenant: &TenantId,
+    project: &ProjectId,
+    resource_type: Option<&ResourceType>,
+    resource_param: &Parameter,
+) -> Result<serde_json::Value, OperationOutcomeError> {
+    let parameter = parameter_resolver
+        .by_name(tenant, project, resource_type, &resource_param.name)
+        .await?
+        .ok_or_else(|| QueryBuildError::MissingParameter(resource_param.name.clone()))?;
 
-                    if count_param < 0 {
-                        return Err(OperationOutcomeError::fatal(
-                            IssueType::invalid(),
-                            "Invalid _count parameter value. Must be greater than or equal to 0."
-                                .to_string(),
-                        ));
-                    }
+    Ok(parameter_to_elasticsearch_clauses(
+        &parameter,
+        resource_param,
+    )?)
+}
 
-                    max_count = count_param as usize;
-                }
-                "_offset" => {
-                    let offset_param = result_param
-                        .value
-                        .get(0)
-                        .and_then(|v| v.parse::<i64>().ok())
-                        .unwrap_or(0);
+struct ElasticSearchQueryState {
+    max_count: usize,
+    offset: u64,
+    show_total: bool,
+    sort: Vec<serde_json::Value>,
+}
 
-                    if offset_param < 0 {
-                        return Err(OperationOutcomeError::fatal(
-                            IssueType::invalid(),
-                            "Invalid _offset parameter value. Must be greater than or equal to 0."
-                                .to_string(),
-                        ));
-                    }
-
-                    offset = offset_param as u64;
-                }
-                "_total" => {
-                    match result_param
-                        .value
-                        .iter()
-                        .map(|s| s.as_str())
-                        .collect::<Vec<_>>()
-                        .as_slice()
-                    {
-                        ["none"] => {
-                            show_total = false;
-                        }
-                        ["accurate"] => {
-                            show_total = true;
-                        }
-                        ["estimate"] => {
-                            show_total = true;
-                        }
-                        _ => {
-                            return Err(QueryBuildError::InvalidParameterValue(
-                                result_param.name.to_string(),
-                            )
-                            .into());
-                        }
-                    }
-                }
-                "_sort" => {
-                    for sort_param in result_param.value.iter() {
-                        let parameter_name = if sort_param.starts_with("-") {
-                            &sort_param[1..]
-                        } else {
-                            sort_param
-                        };
-
-                        let sort_direction = if sort_param.starts_with("-") {
-                            SortDirection::Desc
-                        } else {
-                            SortDirection::Asc
-                        };
-
-                        let parameter = parameter_resolver
-                            .by_name(tenant, project, resource_type, parameter_name)
-                            .await?
-                            .ok_or_else(|| {
-                                QueryBuildError::MissingParameter(parameter_name.to_string())
-                            })?;
-
-                        sort.push(sort_build(
-                            parameter.search_parameter.as_ref(),
-                            &sort_direction,
-                        )?);
-                    }
-                }
-                _ => {
-                    return Err(QueryBuildError::UnsupportedParameter(
-                        result_param.name.to_string(),
-                    )
-                    .into());
-                }
-            },
+async fn handle_result_parameter<ParameterResolver: SearchParameterResolve>(
+    parameter_resolver: &Arc<ParameterResolver>,
+    tenant: &TenantId,
+    project: &ProjectId,
+    resource_type: Option<&ResourceType>,
+    result_param: &Parameter,
+    state: &mut ElasticSearchQueryState,
+) -> Result<(), OperationOutcomeError> {
+    match result_param.name.as_str() {
+        "_count" => {
+            state.max_count = parse_count_parameter(result_param);
+        }
+        "_offset" => {
+            state.offset = parse_offset_parameter(result_param);
+        }
+        "_total" => {
+            state.show_total = parse_total_parameter(result_param)?;
+        }
+        "_sort" => {
+            build_sort_parameters(
+                parameter_resolver,
+                tenant,
+                project,
+                resource_type,
+                result_param,
+                &mut state.sort,
+            )
+            .await?;
+        }
+        _ => {
+            return Err(QueryBuildError::UnsupportedParameter(result_param.name.clone()).into());
         }
     }
 
+    Ok(())
+}
+
+fn parse_count_parameter(result_param: &Parameter) -> usize {
+    std::cmp::min(
+        result_param
+            .value
+            .first()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(100),
+        DEFAULT_MAX_COUNT,
+    )
+}
+
+fn parse_offset_parameter(result_param: &Parameter) -> u64 {
+    result_param
+        .value
+        .first()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0)
+}
+
+fn parse_total_parameter(result_param: &Parameter) -> Result<bool, OperationOutcomeError> {
+    match result_param
+        .value
+        .iter()
+        .map(std::string::String::as_str)
+        .collect::<Vec<_>>()
+        .as_slice()
+    {
+        ["none"] => Ok(false),
+        ["accurate" | "estimate"] => Ok(true),
+        _ => Err(QueryBuildError::InvalidParameterValue(result_param.name.clone()).into()),
+    }
+}
+
+async fn build_sort_parameters<ParameterResolver: SearchParameterResolve>(
+    parameter_resolver: &Arc<ParameterResolver>,
+    tenant: &TenantId,
+    project: &ProjectId,
+    resource_type: Option<&ResourceType>,
+    result_param: &Parameter,
+    sort: &mut Vec<serde_json::Value>,
+) -> Result<(), OperationOutcomeError> {
+    for sort_param in &result_param.value {
+        let parameter_name = sort_param.strip_prefix('-').unwrap_or(sort_param);
+
+        let sort_direction = if sort_param.starts_with('-') {
+            SortDirection::Desc
+        } else {
+            SortDirection::Asc
+        };
+
+        let parameter = parameter_resolver
+            .by_name(tenant, project, resource_type, parameter_name)
+            .await?
+            .ok_or_else(|| QueryBuildError::MissingParameter(parameter_name.to_string()))?;
+
+        sort.push(sort_build(
+            parameter.search_parameter.as_ref(),
+            &sort_direction,
+        )?);
+    }
+
+    Ok(())
+}
+
+fn add_context_clauses(
+    clauses: &mut Vec<serde_json::Value>,
+    resource_type: Option<&ResourceType>,
+    tenant: &TenantId,
+    project: &ProjectId,
+) {
     if let Some(resource_type) = resource_type {
         clauses.push(json!({
             "match": {
@@ -418,7 +474,7 @@ async fn build_elastic_search_query<ParameterResolver: SearchParameterResolve>(
         }));
     }
 
-    clauses.push(json! ({
+    clauses.push(json!({
         "match": {
             "tenant": tenant.as_ref()
         }
@@ -430,8 +486,16 @@ async fn build_elastic_search_query<ParameterResolver: SearchParameterResolve>(
             "project": project.as_ref()
         }
     }));
+}
 
-    let query = json!({
+fn build_elastic_query(
+    clauses: &[serde_json::Value],
+    max_count: usize,
+    show_total: bool,
+    offset: u64,
+    sort: &[serde_json::Value],
+) -> serde_json::Value {
+    json!({
         "fields": ["version_id", "id", "resource_type", "project"],
         "size": max_count,
         "track_total_hits": show_total,
@@ -443,33 +507,28 @@ async fn build_elastic_search_query<ParameterResolver: SearchParameterResolve>(
             }
         },
         "sort": sort,
-    });
-
-    // println!("{}", serde_json::to_string_pretty(&query).unwrap());
-
-    Ok(query)
+    })
 }
 
 pub async fn execute_search<ParameterResolver: SearchParameterResolve>(
     es: Arc<Elasticsearch>,
     parameter_resolver: Arc<ParameterResolver>,
-    fhir_version: &SupportedFHIRVersions,
     tenant: &TenantId,
     project: &ProjectId,
     search_request: &SearchRequest,
-    options: &Option<SearchOptions>,
+    options: Option<&SearchOptions>,
 ) -> Result<SearchReturn, haste_fhir_operation_error::OperationOutcomeError> {
     let query = build_elastic_search_query(
         parameter_resolver.clone(),
         tenant,
         project,
-        &search_request,
+        search_request,
         options,
     )
     .await?;
 
     let search_response = es
-        .search(SearchParts::Index(&[get_index_name(&fhir_version)?]))
+        .search(SearchParts::Index(&[get_index_name()]))
         .body(query)
         .send()
         .await

--- a/backend/crates/fhir-search/src/elastic_search/search/mod.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search/mod.rs
@@ -369,10 +369,10 @@ async fn handle_result_parameter<ParameterResolver: SearchParameterResolve>(
 ) -> Result<(), OperationOutcomeError> {
     match result_param.name.as_str() {
         "_count" => {
-            state.max_count = parse_count_parameter(result_param);
+            state.max_count = parse_count_parameter(result_param)?;
         }
         "_offset" => {
-            state.offset = parse_offset_parameter(result_param);
+            state.offset = parse_offset_parameter(result_param)?;
         }
         "_total" => {
             state.show_total = parse_total_parameter(result_param)?;
@@ -396,23 +396,38 @@ async fn handle_result_parameter<ParameterResolver: SearchParameterResolve>(
     Ok(())
 }
 
-fn parse_count_parameter(result_param: &Parameter) -> usize {
-    std::cmp::min(
-        result_param
-            .value
-            .first()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(100),
-        DEFAULT_MAX_COUNT,
-    )
-}
-
-fn parse_offset_parameter(result_param: &Parameter) -> u64 {
-    result_param
+fn parse_count_parameter(result_param: &Parameter) -> Result<usize, OperationOutcomeError> {
+    let count_param = result_param
         .value
         .first()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(0)
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(100);
+
+    if count_param < 0 {
+        return Err(OperationOutcomeError::fatal(
+            IssueType::invalid(),
+            "Invalid _count parameter value. Must be greater than or equal to 0.".to_string(),
+        ));
+    }
+
+    Ok(std::cmp::min(count_param as usize, DEFAULT_MAX_COUNT))
+}
+
+fn parse_offset_parameter(result_param: &Parameter) -> Result<u64, OperationOutcomeError> {
+    let offset_param = result_param
+        .value
+        .first()
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(0);
+
+    if offset_param < 0 {
+        return Err(OperationOutcomeError::fatal(
+            IssueType::invalid(),
+            "Invalid _offset parameter value. Must be greater than or equal to 0.".to_string(),
+        ));
+    }
+
+    Ok(offset_param as u64)
 }
 
 fn parse_total_parameter(result_param: &Parameter) -> Result<bool, OperationOutcomeError> {

--- a/backend/crates/fhir-search/src/elastic_search/search_parameter_resolver.rs
+++ b/backend/crates/fhir-search/src/elastic_search/search_parameter_resolver.rs
@@ -23,7 +23,7 @@ static SEARCHPARAMETER_CACHE: LazyLock<Cache<(TenantId, ProjectId), Arc<SearchPa
     LazyLock::new(|| {
         CacheBuilder::new(50_000)
             // Duration for 2 hour for search parameters.
-            .time_to_idle(std::time::Duration::from_secs(2 * 60 * 60))
+            .time_to_idle(std::time::Duration::from_hours(2))
             .build()
     });
 
@@ -42,16 +42,16 @@ async fn create_project_sp_index<Repo: Repository + Send + Sync>(
     let result = search::execute_search(
         es,
         R4_SEARCH_PARAMETERS_INDEX.clone(),
-        &haste_repository::types::SupportedFHIRVersions::R4,
         tenant,
         project,
         &SearchRequest::Type(FHIRSearchTypeRequest {
             resource_type: ResourceType::SearchParameter,
             parameters: vec![("status".to_string(), vec!["active".to_string()])].into(),
         }),
-        &Some(SearchOptions {
+        Some(SearchOptions {
             count_limit: Some(10_000),
-        }),
+        })
+        .as_ref(),
     )
     .await?;
 
@@ -83,19 +83,18 @@ async fn get_or_create_sp_index_for_project<Repo: Repository + Send + Sync>(
     tenant: TenantId,
     project: ProjectId,
 ) -> Result<Option<Arc<SearchParametersIndex>>, OperationOutcomeError> {
-    match (&tenant, &project) {
-        (TenantId::System, ProjectId::System) => Ok(None),
-        _ => {
-            let index_key = (tenant, project);
-            if let Some(index) = SEARCHPARAMETER_CACHE.get(&index_key).await {
-                Ok(Some(index))
-            } else {
-                let index =
-                    Arc::new(create_project_sp_index(es, repo, &index_key.0, &index_key.1).await?);
-                SEARCHPARAMETER_CACHE.insert(index_key, index.clone()).await;
+    if let (TenantId::System, ProjectId::System) = (&tenant, &project) {
+        Ok(None)
+    } else {
+        let index_key = (tenant, project);
+        if let Some(index) = SEARCHPARAMETER_CACHE.get(&index_key).await {
+            Ok(Some(index))
+        } else {
+            let index =
+                Arc::new(create_project_sp_index(es, repo, &index_key.0, &index_key.1).await?);
+            SEARCHPARAMETER_CACHE.insert(index_key, index.clone()).await;
 
-                Ok(Some(index))
-            }
+            Ok(Some(index))
         }
     }
 }

--- a/backend/crates/fhir-search/src/indexing_conversion.rs
+++ b/backend/crates/fhir-search/src/indexing_conversion.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-/// Reference of conversions found here https://www.hl7.org/fhir/R4/search.html#table
+/// Reference of conversions found here <https://www.hl7.org/fhir/R4/search.html#table>
 use haste_fhir_model::r4::{
     datetime::{Date, DateTime, Instant},
     generated::{
@@ -104,22 +104,19 @@ fn convert_fp_string(value: &FHIRString) -> Vec<String> {
     value
         .value
         .as_ref()
-        .map(|v| vec![v.to_string()])
-        .unwrap_or_else(|| vec![])
+        .map_or_else(Vec::new, |v| vec![v.clone()])
 }
 
-fn convert_optional_fp_string(value: &Option<Box<FHIRString>>) -> Vec<String> {
+fn convert_optional_fp_string(value: Option<&FHIRString>) -> Vec<String> {
     value
         .as_ref()
-        .map(|v| convert_fp_string(v))
-        .unwrap_or_else(|| vec![])
+        .map_or_else(Vec::new, |v| convert_fp_string(v))
 }
 
-fn convert_optional_fp_string_vec(value: &Option<Vec<FHIRString>>) -> Vec<String> {
+fn convert_optional_fp_string_vec(value: Option<&Vec<FHIRString>>) -> Vec<String> {
     value
         .as_ref()
-        .map(|v| v.iter().flat_map(|s| convert_fp_string(s)).collect())
-        .unwrap_or_else(|| vec![])
+        .map_or_else(Vec::new, |v| v.iter().flat_map(convert_fp_string).collect())
 }
 
 fn index_string(value: &dyn MetaValue) -> Result<Vec<String>, InsertableIndexError> {
@@ -131,8 +128,7 @@ fn index_string(value: &dyn MetaValue) -> Result<Vec<String>, InsertableIndexErr
             Ok(fp_string
                 .value
                 .as_ref()
-                .map(|v| vec![v.to_string()])
-                .unwrap_or_else(|| vec![]))
+                .map_or_else(Vec::new, |v| vec![v.clone()]))
         }
         // Even though spec states won't encounter this it does. [ImplementationGuide.description]
         "markdown" => {
@@ -145,34 +141,33 @@ fn index_string(value: &dyn MetaValue) -> Result<Vec<String>, InsertableIndexErr
             Ok(fp_markdown
                 .value
                 .as_ref()
-                .map(|v| vec![v.to_string()])
-                .unwrap_or_else(|| vec![]))
+                .map_or_else(Vec::new, |v| vec![v.clone()]))
         }
         "HumanName" => {
             let human_name = value.as_any().downcast_ref::<HumanName>().ok_or_else(|| {
                 InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
             })?;
 
-            let mut string_index = vec![];
-            string_index.extend(convert_optional_fp_string(&human_name.text));
-            string_index.extend(convert_optional_fp_string(&human_name.family));
-            string_index.extend(convert_optional_fp_string_vec(&human_name.given));
-            string_index.extend(convert_optional_fp_string_vec(&human_name.prefix));
-            string_index.extend(convert_optional_fp_string_vec(&human_name.suffix));
+            let mut string_index = Vec::new();
+            string_index.extend(convert_optional_fp_string(human_name.text.as_deref()));
+            string_index.extend(convert_optional_fp_string(human_name.family.as_deref()));
+            string_index.extend(convert_optional_fp_string_vec(human_name.given.as_ref()));
+            string_index.extend(convert_optional_fp_string_vec(human_name.prefix.as_ref()));
+            string_index.extend(convert_optional_fp_string_vec(human_name.suffix.as_ref()));
             Ok(string_index)
         }
         "Address" => {
-            let mut string_index = vec![];
+            let mut string_index = Vec::new();
             let address = value.as_any().downcast_ref::<Address>().ok_or_else(|| {
                 InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
             })?;
-            string_index.extend(convert_optional_fp_string(&address.text));
-            string_index.extend(convert_optional_fp_string_vec(&address.line));
-            string_index.extend(convert_optional_fp_string(&address.city));
-            string_index.extend(convert_optional_fp_string(&address.district));
-            string_index.extend(convert_optional_fp_string(&address.state));
-            string_index.extend(convert_optional_fp_string(&address.postalCode));
-            string_index.extend(convert_optional_fp_string(&address.country));
+            string_index.extend(convert_optional_fp_string(address.text.as_deref()));
+            string_index.extend(convert_optional_fp_string_vec(address.line.as_ref()));
+            string_index.extend(convert_optional_fp_string(address.city.as_deref()));
+            string_index.extend(convert_optional_fp_string(address.district.as_deref()));
+            string_index.extend(convert_optional_fp_string(address.state.as_deref()));
+            string_index.extend(convert_optional_fp_string(address.postalCode.as_deref()));
+            string_index.extend(convert_optional_fp_string(address.country.as_deref()));
 
             Ok(string_index)
         }
@@ -190,11 +185,11 @@ fn index_number(value: &dyn MetaValue) -> Result<Vec<f64>, InsertableIndexError>
                 .ok_or_else(|| {
                     InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
                 })?;
+            #[allow(clippy::cast_precision_loss)]
             Ok(fp_integer
                 .value
                 .as_ref()
-                .map(|v| vec![*v as f64])
-                .unwrap_or_else(|| vec![]))
+                .map_or_else(Vec::new, |v| vec![*v as f64]))
         }
         "decimal" => {
             let fp_decimal = value
@@ -203,11 +198,11 @@ fn index_number(value: &dyn MetaValue) -> Result<Vec<f64>, InsertableIndexError>
                 .ok_or_else(|| {
                     InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
                 })?;
+            #[allow(clippy::cast_precision_loss)]
             Ok(fp_decimal
                 .value
                 .as_ref()
-                .map(|v| vec![*v as f64])
-                .unwrap_or_else(|| vec![]))
+                .map_or_else(Vec::new, |v| vec![*v]))
         }
         "positiveInt" => {
             let fp_positive_int = value
@@ -217,11 +212,11 @@ fn index_number(value: &dyn MetaValue) -> Result<Vec<f64>, InsertableIndexError>
                     InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
                 })?;
 
+            #[allow(clippy::cast_precision_loss)]
             Ok(fp_positive_int
                 .value
                 .as_ref()
-                .map(|v| vec![*v as f64])
-                .unwrap_or_else(|| vec![]))
+                .map_or_else(Vec::new, |v| vec![*v as f64]))
         }
         "unsignedInt" => {
             let fp_unsigned_int = value
@@ -231,11 +226,11 @@ fn index_number(value: &dyn MetaValue) -> Result<Vec<f64>, InsertableIndexError>
                     InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
                 })?;
 
+            #[allow(clippy::cast_precision_loss)]
             Ok(fp_unsigned_int
                 .value
                 .as_ref()
-                .map(|v| vec![*v as f64])
-                .unwrap_or_else(|| vec![]))
+                .map_or_else(Vec::new, |v| vec![*v as f64]))
         }
         type_name => Err(InsertableIndexError::FailedDowncast(type_name.to_string())),
     }
@@ -250,8 +245,7 @@ fn index_uri(value: &dyn MetaValue) -> Result<Vec<String>, InsertableIndexError>
             Ok(fp_uri
                 .value
                 .as_ref()
-                .map(|v| vec![v.to_string()])
-                .unwrap_or_else(|| vec![]))
+                .map_or_else(Vec::new, |v| vec![v.clone()]))
         }
         "uuid" => {
             let fp_uri = value.as_any().downcast_ref::<FHIRUuid>().ok_or_else(|| {
@@ -260,8 +254,7 @@ fn index_uri(value: &dyn MetaValue) -> Result<Vec<String>, InsertableIndexError>
             Ok(fp_uri
                 .value
                 .as_ref()
-                .map(|v| vec![v.to_string()])
-                .unwrap_or_else(|| vec![]))
+                .map_or_else(Vec::new, |v| vec![v.clone()]))
         }
         "canonical" => {
             let fp_uri = value
@@ -273,8 +266,7 @@ fn index_uri(value: &dyn MetaValue) -> Result<Vec<String>, InsertableIndexError>
             Ok(fp_uri
                 .value
                 .as_ref()
-                .map(|v| vec![v.to_string()])
-                .unwrap_or_else(|| vec![]))
+                .map_or_else(Vec::new, |v| vec![v.clone()]))
         }
         "uri" => {
             let fp_uri = value.as_any().downcast_ref::<FHIRUri>().ok_or_else(|| {
@@ -283,8 +275,7 @@ fn index_uri(value: &dyn MetaValue) -> Result<Vec<String>, InsertableIndexError>
             Ok(fp_uri
                 .value
                 .as_ref()
-                .map(|v| vec![v.to_string()])
-                .unwrap_or_else(|| vec![]))
+                .map_or_else(Vec::new, |v| vec![v.clone()]))
         }
         type_name => Err(InsertableIndexError::FailedDowncast(type_name.to_string())),
     }
@@ -292,124 +283,141 @@ fn index_uri(value: &dyn MetaValue) -> Result<Vec<String>, InsertableIndexError>
 
 fn index_token(value: &dyn MetaValue) -> Result<Vec<TokenIndex>, InsertableIndexError> {
     match value.fhir_type() {
-        "Coding" => {
-            let fp_coding = value.as_any().downcast_ref::<Coding>().ok_or_else(|| {
-                InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-            })?;
-
-            Ok(vec![TokenIndex {
-                system: fp_coding.system.as_ref().and_then(|s| s.value.clone()),
-                code: fp_coding.code.as_ref().and_then(|v| v.value.clone()),
-            }])
-        }
-        "CodeableConcept" => {
-            let fp_codeable_concept = value
-                .as_any()
-                .downcast_ref::<CodeableConcept>()
-                .ok_or_else(|| {
-                    InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-                })?;
-
-            Ok(fp_codeable_concept
-                .coding
-                .as_ref()
-                .and_then(|coding| {
-                    Some(
-                        coding
-                            .iter()
-                            .map(|c| TokenIndex {
-                                system: c.system.as_ref().and_then(|s| s.value.clone()),
-                                code: c.code.as_ref().and_then(|v| v.value.clone()),
-                            })
-                            .collect::<Vec<_>>(),
-                    )
-                })
-                .unwrap_or_else(|| vec![]))
-        }
-        "Identifier" => {
-            let fp_identifier = value.as_any().downcast_ref::<Identifier>().ok_or_else(|| {
-                InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-            })?;
-
-            Ok(vec![TokenIndex {
-                system: fp_identifier.system.as_ref().and_then(|s| s.value.clone()),
-                code: fp_identifier.value.as_ref().and_then(|v| v.value.clone()),
-            }])
-        }
-        "ContactPoint" => {
-            let fp_contact_point =
-                value
-                    .as_any()
-                    .downcast_ref::<ContactPoint>()
-                    .ok_or_else(|| {
-                        InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-                    })?;
-
-            Ok(vec![TokenIndex {
-                system: None,
-                code: fp_contact_point
-                    .value
-                    .as_ref()
-                    .and_then(|v| v.value.clone()),
-            }])
-        }
-        "code" => {
-            let fp_code = value
-                .get_field("value")
-                .and_then(|v| v.as_any().downcast_ref::<String>());
-
-            Ok(vec![TokenIndex {
-                system: None,
-                code: fp_code.map(|v| v.to_string()),
-            }])
-        }
-        "boolean" => {
-            let fp_boolean = value
-                .as_any()
-                .downcast_ref::<FHIRBoolean>()
-                .ok_or_else(|| {
-                    InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-                })?;
-
-            Ok(vec![TokenIndex {
-                system: Some("http://hl7.org/fhir/special-values".to_string()),
-                code: fp_boolean.value.as_ref().map(|v| v.to_string()),
-            }])
-        }
-        "http://hl7.org/fhirpath/System.String" => {
-            let string = value.as_any().downcast_ref::<String>().ok_or_else(|| {
-                InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-            })?;
-
-            Ok(vec![TokenIndex {
-                system: None,
-                code: Some(string.clone()),
-            }])
-        }
-        "string" => {
-            let fp_string = value.as_any().downcast_ref::<FHIRString>().ok_or_else(|| {
-                InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-            })?;
-
-            Ok(vec![TokenIndex {
-                system: None,
-                code: fp_string.value.as_ref().map(|v| v.to_string()),
-            }])
-        }
-        "id" => {
-            let fp_id = value.as_any().downcast_ref::<FHIRId>().ok_or_else(|| {
-                InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-            })?;
-
-            Ok(vec![TokenIndex {
-                system: None,
-                code: fp_id.value.as_ref().map(|v| v.to_string()),
-            }])
-        }
+        "Coding" => index_token_coding(value),
+        "CodeableConcept" => index_token_codeable_concept(value),
+        "Identifier" => index_token_identifier(value),
+        "ContactPoint" => index_token_contact_point(value),
+        "code" => Ok(index_token_code(value)),
+        "boolean" => index_token_boolean(value),
+        "http://hl7.org/fhirpath/System.String" => index_token_system_string(value),
+        "string" => index_token_string(value),
+        "id" => index_token_id(value),
         _ => Err(InsertableIndexError::FailedDowncast(
             value.fhir_type().to_string(),
         )),
     }
+}
+
+fn index_token_coding(value: &dyn MetaValue) -> Result<Vec<TokenIndex>, InsertableIndexError> {
+    let coding = value
+        .as_any()
+        .downcast_ref::<Coding>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(vec![TokenIndex {
+        system: coding.system.as_ref().and_then(|s| s.value.clone()),
+        code: coding.code.as_ref().and_then(|v| v.value.clone()),
+    }])
+}
+
+fn index_token_codeable_concept(
+    value: &dyn MetaValue,
+) -> Result<Vec<TokenIndex>, InsertableIndexError> {
+    let codeable_concept = value
+        .as_any()
+        .downcast_ref::<CodeableConcept>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(codeable_concept
+        .coding
+        .as_ref()
+        .map(|coding| {
+            coding
+                .iter()
+                .map(|c| TokenIndex {
+                    system: c.system.as_ref().and_then(|s| s.value.clone()),
+                    code: c.code.as_ref().and_then(|v| v.value.clone()),
+                })
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+fn index_token_identifier(value: &dyn MetaValue) -> Result<Vec<TokenIndex>, InsertableIndexError> {
+    let identifier = value
+        .as_any()
+        .downcast_ref::<Identifier>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(vec![TokenIndex {
+        system: identifier.system.as_ref().and_then(|s| s.value.clone()),
+        code: identifier.value.as_ref().and_then(|v| v.value.clone()),
+    }])
+}
+
+fn index_token_contact_point(
+    value: &dyn MetaValue,
+) -> Result<Vec<TokenIndex>, InsertableIndexError> {
+    let contact_point = value
+        .as_any()
+        .downcast_ref::<ContactPoint>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(vec![TokenIndex {
+        system: None,
+        code: contact_point.value.as_ref().and_then(|v| v.value.clone()),
+    }])
+}
+
+fn index_token_code(value: &dyn MetaValue) -> Vec<TokenIndex> {
+    let code = value
+        .get_field("value")
+        .and_then(|v| v.as_any().downcast_ref::<String>());
+
+    vec![TokenIndex {
+        system: None,
+        code: code.cloned(),
+    }]
+}
+
+fn index_token_boolean(value: &dyn MetaValue) -> Result<Vec<TokenIndex>, InsertableIndexError> {
+    let boolean = value
+        .as_any()
+        .downcast_ref::<FHIRBoolean>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(vec![TokenIndex {
+        system: Some("http://hl7.org/fhir/special-values".to_string()),
+        code: boolean.value.as_ref().map(std::string::ToString::to_string),
+    }])
+}
+
+fn index_token_system_string(
+    value: &dyn MetaValue,
+) -> Result<Vec<TokenIndex>, InsertableIndexError> {
+    let string = value
+        .as_any()
+        .downcast_ref::<String>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(vec![TokenIndex {
+        system: None,
+        code: Some(string.clone()),
+    }])
+}
+
+fn index_token_string(value: &dyn MetaValue) -> Result<Vec<TokenIndex>, InsertableIndexError> {
+    let string = value
+        .as_any()
+        .downcast_ref::<FHIRString>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(vec![TokenIndex {
+        system: None,
+        code: string.value.clone(),
+    }])
+}
+
+fn index_token_id(value: &dyn MetaValue) -> Result<Vec<TokenIndex>, InsertableIndexError> {
+    let id = value
+        .as_any()
+        .downcast_ref::<FHIRId>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(vec![TokenIndex {
+        system: None,
+        code: id.value.clone(),
+    }])
 }
 
 fn get_decimal_precision(value: &str) -> u32 {
@@ -429,158 +437,184 @@ pub struct DecimalRange {
     pub end: f64,
 }
 
-// Number and quantity dependent on the precision for indexing.
+/// Calculates the decimal range used for indexing a number or quantity,
+/// based on the precision of the input value.
+///
+/// # Errors
+///
+/// Returns [`InsertableIndexError::FailedDowncast`] if `value` cannot be
+/// parsed as an `f64`.
 pub fn get_decimal_range(value: &str) -> Result<DecimalRange, InsertableIndexError> {
     let decimal_precision = get_decimal_precision(value);
     let parsed_v = value
         .parse::<f64>()
         .map_err(|_e| InsertableIndexError::FailedDowncast(value.to_string()))?;
 
-    return Ok(DecimalRange {
-        start: parsed_v - 0.5 * 10f64.powi(-(decimal_precision as i32)),
-        end: parsed_v + 0.5 * 10f64.powi(-(decimal_precision as i32)),
-    });
+    Ok(DecimalRange {
+        start: parsed_v - 0.5 * 10f64.powi(-(decimal_precision.cast_signed())),
+        end: parsed_v + 0.5 * 10f64.powi(-(decimal_precision.cast_signed())),
+    })
 }
 
-fn fhirdecimal_to_quantity_range(value: &Option<Box<FHIRDecimal>>) -> Option<DecimalRange> {
-    let decimal_range = value.as_ref().and_then(|v| {
+fn fhirdecimal_to_quantity_range(value: Option<&FHIRDecimal>) -> Option<DecimalRange> {
+    value.as_ref().and_then(|v| {
         v.value
             .as_ref()
             .and_then(|v| get_decimal_range(&v.to_string()).ok())
-    });
-
-    decimal_range
+    })
 }
 
 fn index_quantity(value: &dyn MetaValue) -> Result<Vec<QuantityRange>, InsertableIndexError> {
     match value.fhir_type() {
-        "Range" => {
-            let fp_range = value.as_any().downcast_ref::<Range>().ok_or_else(|| {
-                InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-            })?;
-            if fp_range.low.is_some() || fp_range.high.is_some() {
-                let start_value = fp_range
-                    .low
-                    .as_ref()
-                    .and_then(|v| v.value.as_ref().and_then(|v| v.value));
-                let start_system = fp_range
-                    .low
-                    .as_ref()
-                    .and_then(|v| v.system.as_ref().and_then(|s| s.value.clone()));
-                let start_code = fp_range
-                    .low
-                    .as_ref()
-                    .and_then(|v| v.code.as_ref().and_then(|c| c.value.clone()));
-
-                let end_value = fp_range
-                    .high
-                    .as_ref()
-                    .and_then(|v| v.value.as_ref().and_then(|v| v.value));
-                let end_system = fp_range
-                    .high
-                    .as_ref()
-                    .and_then(|v| v.system.as_ref().and_then(|s| s.value.clone()));
-                let end_code = fp_range
-                    .high
-                    .as_ref()
-                    .and_then(|v| v.code.as_ref().and_then(|c| c.value.clone()));
-
-                return Ok(vec![QuantityRange {
-                    start_system: start_system,
-                    start_code: start_code,
-                    start_value: start_value
-                        .map_or(RangeValue::Infinity, |v| RangeValue::Number(v)),
-                    end_system: end_system,
-                    end_code: end_code,
-                    end_value: end_value.map_or(RangeValue::Infinity, |v| RangeValue::Number(v)),
-                }]);
-            }
-            return Ok(vec![]);
-        }
-        "Age" => {
-            let fp_age = value.as_any().downcast_ref::<Age>().ok_or_else(|| {
-                InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-            })?;
-
-            if let Some(decimal_range) = fhirdecimal_to_quantity_range(&fp_age.value) {
-                return Ok(vec![QuantityRange {
-                    start_system: fp_age.system.as_ref().and_then(|s| s.value.clone()),
-                    start_code: fp_age.code.as_ref().and_then(|c| c.value.clone()),
-                    start_value: RangeValue::Number(decimal_range.start),
-                    end_system: fp_age.system.as_ref().and_then(|s| s.value.clone()),
-                    end_code: fp_age.code.as_ref().and_then(|c| c.value.clone()),
-                    end_value: RangeValue::Number(decimal_range.end),
-                }]);
-            } else {
-                return Ok(vec![]);
-            }
-        }
-        "Money" => {
-            let fp_money = value.as_any().downcast_ref::<Money>().ok_or_else(|| {
-                InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-            })?;
-
-            if let Some(decimal_range) = fhirdecimal_to_quantity_range(&fp_money.value) {
-                return Ok(vec![QuantityRange {
-                    start_system: Some("urn:iso:std:iso:4217".to_string()),
-                    start_code: fp_money.currency.as_ref().and_then(|c| c.value.clone()),
-                    start_value: RangeValue::Number(decimal_range.start),
-                    end_system: Some("urn:iso:std:iso:4217".to_string()),
-                    end_code: fp_money.currency.as_ref().and_then(|c| c.value.clone()),
-                    end_value: RangeValue::Number(decimal_range.end),
-                }]);
-            } else {
-                return Ok(vec![]);
-            }
-        }
-        "Duration" => {
-            let fp_duration = value.as_any().downcast_ref::<Duration>().ok_or_else(|| {
-                InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-            })?;
-
-            if let Some(decimal_range) = fhirdecimal_to_quantity_range(&fp_duration.value) {
-                return Ok(vec![QuantityRange {
-                    start_system: fp_duration.system.as_ref().and_then(|s| s.value.clone()),
-                    start_code: fp_duration.code.as_ref().and_then(|c| c.value.clone()),
-                    start_value: RangeValue::Number(decimal_range.start),
-                    end_system: fp_duration.system.as_ref().and_then(|s| s.value.clone()),
-                    end_code: fp_duration.code.as_ref().and_then(|c| c.value.clone()),
-                    end_value: RangeValue::Number(decimal_range.end),
-                }]);
-            } else {
-                return Ok(vec![]);
-            }
-        }
-        "Quantity" => {
-            let fp_quantity = value.as_any().downcast_ref::<Quantity>().ok_or_else(|| {
-                InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
-            })?;
-
-            if let Some(decimal_range) = fhirdecimal_to_quantity_range(&fp_quantity.value) {
-                return Ok(vec![QuantityRange {
-                    start_system: fp_quantity.system.as_ref().and_then(|s| s.value.clone()),
-                    start_code: fp_quantity.code.as_ref().and_then(|c| c.value.clone()),
-                    start_value: RangeValue::Number(decimal_range.start),
-                    end_system: fp_quantity.system.as_ref().and_then(|s| s.value.clone()),
-                    end_code: fp_quantity.code.as_ref().and_then(|c| c.value.clone()),
-                    end_value: RangeValue::Number(decimal_range.end),
-                }]);
-            } else {
-                return Ok(vec![]);
-            }
-        }
+        "Range" => index_range_quantity(value),
+        "Age" => index_age_quantity(value),
+        "Money" => index_money_quantity(value),
+        "Duration" => index_duration_quantity(value),
+        "Quantity" => index_fhir_quantity(value),
         _ => Err(InsertableIndexError::FailedDowncast(
             value.fhir_type().to_string(),
         )),
     }
 }
 
+fn index_range_quantity(value: &dyn MetaValue) -> Result<Vec<QuantityRange>, InsertableIndexError> {
+    let fp_range = value
+        .as_any()
+        .downcast_ref::<Range>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    if fp_range.low.is_some() || fp_range.high.is_some() {
+        let start_value = fp_range
+            .low
+            .as_ref()
+            .and_then(|v| v.value.as_ref().and_then(|v| v.value));
+
+        let start_system = fp_range
+            .low
+            .as_ref()
+            .and_then(|v| v.system.as_ref().and_then(|s| s.value.clone()));
+
+        let start_code = fp_range
+            .low
+            .as_ref()
+            .and_then(|v| v.code.as_ref().and_then(|c| c.value.clone()));
+
+        let end_value = fp_range
+            .high
+            .as_ref()
+            .and_then(|v| v.value.as_ref().and_then(|v| v.value));
+
+        let end_system = fp_range
+            .high
+            .as_ref()
+            .and_then(|v| v.system.as_ref().and_then(|s| s.value.clone()));
+
+        let end_code = fp_range
+            .high
+            .as_ref()
+            .and_then(|v| v.code.as_ref().and_then(|c| c.value.clone()));
+
+        return Ok(vec![QuantityRange {
+            start_system,
+            start_code,
+            start_value: start_value.map_or(RangeValue::Infinity, RangeValue::Number),
+            end_system,
+            end_code,
+            end_value: end_value.map_or(RangeValue::Infinity, RangeValue::Number),
+        }]);
+    }
+
+    Ok(Vec::new())
+}
+
+fn index_age_quantity(value: &dyn MetaValue) -> Result<Vec<QuantityRange>, InsertableIndexError> {
+    let fp_age = value
+        .as_any()
+        .downcast_ref::<Age>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(fhirdecimal_to_quantity_range(fp_age.value.as_deref())
+        .map(|decimal_range| {
+            vec![QuantityRange {
+                start_system: fp_age.system.as_ref().and_then(|s| s.value.clone()),
+                start_code: fp_age.code.as_ref().and_then(|c| c.value.clone()),
+                start_value: RangeValue::Number(decimal_range.start),
+                end_system: fp_age.system.as_ref().and_then(|s| s.value.clone()),
+                end_code: fp_age.code.as_ref().and_then(|c| c.value.clone()),
+                end_value: RangeValue::Number(decimal_range.end),
+            }]
+        })
+        .unwrap_or_default())
+}
+
+fn index_money_quantity(value: &dyn MetaValue) -> Result<Vec<QuantityRange>, InsertableIndexError> {
+    let fp_money = value
+        .as_any()
+        .downcast_ref::<Money>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(fhirdecimal_to_quantity_range(fp_money.value.as_deref())
+        .map(|decimal_range| {
+            vec![QuantityRange {
+                start_system: Some("urn:iso:std:iso:4217".to_string()),
+                start_code: fp_money.currency.as_ref().and_then(|c| c.value.clone()),
+                start_value: RangeValue::Number(decimal_range.start),
+                end_system: Some("urn:iso:std:iso:4217".to_string()),
+                end_code: fp_money.currency.as_ref().and_then(|c| c.value.clone()),
+                end_value: RangeValue::Number(decimal_range.end),
+            }]
+        })
+        .unwrap_or_default())
+}
+
+fn index_duration_quantity(
+    value: &dyn MetaValue,
+) -> Result<Vec<QuantityRange>, InsertableIndexError> {
+    let fp_duration = value
+        .as_any()
+        .downcast_ref::<Duration>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(fhirdecimal_to_quantity_range(fp_duration.value.as_deref())
+        .map(|decimal_range| {
+            vec![QuantityRange {
+                start_system: fp_duration.system.as_ref().and_then(|s| s.value.clone()),
+                start_code: fp_duration.code.as_ref().and_then(|c| c.value.clone()),
+                start_value: RangeValue::Number(decimal_range.start),
+                end_system: fp_duration.system.as_ref().and_then(|s| s.value.clone()),
+                end_code: fp_duration.code.as_ref().and_then(|c| c.value.clone()),
+                end_value: RangeValue::Number(decimal_range.end),
+            }]
+        })
+        .unwrap_or_default())
+}
+
+fn index_fhir_quantity(value: &dyn MetaValue) -> Result<Vec<QuantityRange>, InsertableIndexError> {
+    let fp_quantity = value
+        .as_any()
+        .downcast_ref::<Quantity>()
+        .ok_or_else(|| InsertableIndexError::FailedDowncast(value.fhir_type().to_string()))?;
+
+    Ok(fhirdecimal_to_quantity_range(fp_quantity.value.as_deref())
+        .map(|decimal_range| {
+            vec![QuantityRange {
+                start_system: fp_quantity.system.as_ref().and_then(|s| s.value.clone()),
+                start_code: fp_quantity.code.as_ref().and_then(|c| c.value.clone()),
+                start_value: RangeValue::Number(decimal_range.start),
+                end_system: fp_quantity.system.as_ref().and_then(|s| s.value.clone()),
+                end_code: fp_quantity.code.as_ref().and_then(|c| c.value.clone()),
+                end_value: RangeValue::Number(decimal_range.end),
+            }]
+        })
+        .unwrap_or_default())
+}
+
 fn year_to_daterange(year: u16) -> Result<DateRange, InsertableIndexError> {
-    let start_date = chrono::NaiveDate::from_ymd_opt(year as i32, 1, 1)
+    let start_date = chrono::NaiveDate::from_ymd_opt(i32::from(year), 1, 1)
         .and_then(|d| d.and_hms_opt(0, 0, 0))
         .ok_or_else(|| InsertableIndexError::FailedDowncast("Date".to_string()))?;
 
-    let end_date = chrono::NaiveDate::from_ymd_opt(year as i32 + 1, 1, 1)
+    let end_date = chrono::NaiveDate::from_ymd_opt(i32::from(year) + 1, 1, 1)
         .and_then(|d| d.pred_opt())
         .and_then(|d| d.and_hms_milli_opt(23, 59, 59, 999))
         .ok_or_else(|| InsertableIndexError::FailedDowncast("Date".to_string()))?;
@@ -594,16 +628,16 @@ fn year_to_daterange(year: u16) -> Result<DateRange, InsertableIndexError> {
 }
 
 fn year_month_to_daterange(year: u16, month: u8) -> Result<DateRange, InsertableIndexError> {
-    let start_date = chrono::NaiveDate::from_ymd_opt(year as i32, month as u32, 1)
+    let start_date = chrono::NaiveDate::from_ymd_opt(i32::from(year), u32::from(month), 1)
         .and_then(|d| d.and_hms_opt(0, 0, 0))
         .ok_or_else(|| InsertableIndexError::FailedDowncast("Date".to_string()))?;
 
     let end_date = if month < 12 {
-        chrono::NaiveDate::from_ymd_opt(year as i32, (month + 1).into(), 1)
+        chrono::NaiveDate::from_ymd_opt(i32::from(year), (month + 1).into(), 1)
             .and_then(|d| d.pred_opt())
             .and_then(|d| d.and_hms_milli_opt(23, 59, 59, 999))
     } else {
-        chrono::NaiveDate::from_ymd_opt(year as i32 + 1, 1, 1)
+        chrono::NaiveDate::from_ymd_opt(i32::from(year) + 1, 1, 1)
             .and_then(|d| d.pred_opt())
             .and_then(|d| d.and_hms_milli_opt(23, 59, 59, 999))
     }
@@ -622,13 +656,15 @@ fn year_month_day_to_daterange(
     month: u8,
     day: u8,
 ) -> Result<DateRange, InsertableIndexError> {
-    let start_date = chrono::NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32)
-        .and_then(|d| d.and_hms_opt(0, 0, 0))
-        .ok_or_else(|| InsertableIndexError::FailedDowncast("Date".to_string()))?;
+    let start_date =
+        chrono::NaiveDate::from_ymd_opt(i32::from(year), u32::from(month), u32::from(day))
+            .and_then(|d| d.and_hms_opt(0, 0, 0))
+            .ok_or_else(|| InsertableIndexError::FailedDowncast("Date".to_string()))?;
 
-    let end_date = chrono::NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32)
-        .and_then(|d| d.and_hms_milli_opt(23, 59, 59, 999))
-        .ok_or_else(|| InsertableIndexError::FailedDowncast("Date".to_string()))?;
+    let end_date =
+        chrono::NaiveDate::from_ymd_opt(i32::from(year), u32::from(month), u32::from(day))
+            .and_then(|d| d.and_hms_milli_opt(23, 59, 59, 999))
+            .ok_or_else(|| InsertableIndexError::FailedDowncast("Date".to_string()))?;
 
     Ok(DateRange {
         start: chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(start_date, chrono::Utc)
@@ -638,6 +674,13 @@ fn year_month_day_to_daterange(
     })
 }
 
+/// Converts a FHIR date/time value into a date range suitable for indexing.
+///
+///
+/// # Errors
+///
+/// Returns an [`InsertableIndexError`] if the supplied year, year/month, or
+/// year/month/day value cannot be converted into a valid date range.
 pub fn date_time_range(value: &DateTime) -> Result<DateRange, InsertableIndexError> {
     match value {
         DateTime::Year(year) => Ok(year_to_daterange(*year)?),
@@ -645,12 +688,10 @@ pub fn date_time_range(value: &DateTime) -> Result<DateRange, InsertableIndexErr
         DateTime::YearMonthDay(year, month, day) => {
             Ok(year_month_day_to_daterange(*year, *month, *day)?)
         }
-        DateTime::Iso8601(date_time) => {
-            return Ok(DateRange {
-                start: date_time.timestamp_millis(),
-                end: date_time.timestamp_millis(),
-            });
-        }
+        DateTime::Iso8601(date_time) => Ok(DateRange {
+            start: date_time.timestamp_millis(),
+            end: date_time.timestamp_millis(),
+        }),
     }
 }
 
@@ -668,7 +709,7 @@ fn index_date(value: &dyn MetaValue) -> Result<Vec<DateRange>, InsertableIndexEr
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(date_ranges.into_iter().flatten().collect())
             } else {
-                Ok(vec![])
+                Ok(Vec::new())
             }
         }
         "date" => {
@@ -687,7 +728,7 @@ fn index_date(value: &dyn MetaValue) -> Result<Vec<DateRange>, InsertableIndexEr
                 Some(Date::YearMonthDay(year, month, day)) => {
                     Ok(vec![year_month_day_to_daterange(*year, *month, *day)?])
                 }
-                None => Ok(vec![]),
+                None => Ok(Vec::new()),
             }
         }
         "dateTime" => {
@@ -700,9 +741,7 @@ fn index_date(value: &dyn MetaValue) -> Result<Vec<DateRange>, InsertableIndexEr
 
             match &fp_datetime {
                 Some(date_time) => date_time_range(date_time).map(|date_range| vec![date_range]),
-                None => {
-                    return Ok(vec![]);
-                }
+                None => Ok(Vec::new()),
             }
         }
         "instant" => {
@@ -716,14 +755,12 @@ fn index_date(value: &dyn MetaValue) -> Result<Vec<DateRange>, InsertableIndexEr
             match &fp_instant.value {
                 Some(Instant::Iso8601(instant)) => {
                     let timestamp = instant.timestamp_millis();
-                    return Ok(vec![DateRange {
+                    Ok(vec![DateRange {
                         start: timestamp,
                         end: timestamp,
-                    }]);
+                    }])
                 }
-                None => {
-                    return Ok(vec![]);
-                }
+                None => Ok(Vec::new()),
             }
         }
         "Period" => {
@@ -734,7 +771,7 @@ fn index_date(value: &dyn MetaValue) -> Result<Vec<DateRange>, InsertableIndexEr
                 let date = date.as_ref();
                 let date_range = index_date(date)?;
                 date_range
-                    .get(0)
+                    .first()
                     .ok_or_else(|| {
                         InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
                     })?
@@ -747,7 +784,7 @@ fn index_date(value: &dyn MetaValue) -> Result<Vec<DateRange>, InsertableIndexEr
                 let date = date.as_ref();
                 let date_range = index_date(date)?;
                 date_range
-                    .get(0)
+                    .first()
                     .ok_or_else(|| {
                         InsertableIndexError::FailedDowncast(value.fhir_type().to_string())
                     })?
@@ -804,7 +841,7 @@ fn index_reference(value: &dyn MetaValue) -> Result<Vec<ReferenceIndex>, Inserta
                 return Ok(vec![ReferenceIndex {
                     id: None,
                     resource_type: None,
-                    uri: Some(canonical.to_string()),
+                    uri: Some(canonical.clone()),
                 }]);
             }
             Ok(vec![])
@@ -817,7 +854,7 @@ fn index_reference(value: &dyn MetaValue) -> Result<Vec<ReferenceIndex>, Inserta
                 return Ok(vec![ReferenceIndex {
                     id: None,
                     resource_type: None,
-                    uri: Some(uri.to_string()),
+                    uri: Some(uri.clone()),
                 }]);
             }
             Ok(vec![])
@@ -828,9 +865,18 @@ fn index_reference(value: &dyn MetaValue) -> Result<Vec<ReferenceIndex>, Inserta
     }
 }
 
+/// Converts resolved search parameter values into an indexable representation.
+///
+/// Values that cannot be converted to the corresponding index type are
+/// skipped.
+///
+/// # Errors
+///
+/// Returns [`OperationOutcomeError`] if the search parameter has an
+/// unsupported or invalid type.
 pub fn to_insertable_index(
     parameter: &ResolvedParameter,
-    result: Vec<&dyn MetaValue>,
+    result: &[&dyn MetaValue],
 ) -> Result<InsertableIndex, OperationOutcomeError> {
     let search_parameter = &parameter.search_parameter;
     match &search_parameter.type_ {
@@ -900,9 +946,7 @@ pub fn to_insertable_index(
         _ => {
             let type_name = search_parameter.type_.as_str();
             Err(InsertableIndexError::InvalidType(
-                type_name
-                    .map(|s| s.to_string())
-                    .unwrap_or("unknown".to_string()),
+                type_name.map_or("unknown".to_string(), std::string::ToString::to_string),
             )
             .into())
         }
@@ -1011,7 +1055,7 @@ mod tests {
         };
 
         let range = index_date(&fhir_date).unwrap();
-        let date_range = range.get(0).unwrap();
+        let date_range = range.first().unwrap();
 
         assert_eq!(
             date_range.start,
@@ -1051,7 +1095,7 @@ mod tests {
         };
 
         let range = index_date(&period).unwrap();
-        let date_range = range.get(0).unwrap();
+        let date_range = range.first().unwrap();
 
         assert_eq!(
             date_range.start,
@@ -1089,7 +1133,7 @@ mod tests {
         };
 
         let range = index_date(&period).unwrap();
-        let date_range = range.get(0).unwrap();
+        let date_range = range.first().unwrap();
 
         assert_eq!(date_range.start, 0);
         assert_eq!(
@@ -1107,7 +1151,7 @@ mod tests {
         };
 
         let range = index_date(&period).unwrap();
-        let date_range = range.get(0).unwrap();
+        let date_range = range.first().unwrap();
 
         assert_eq!(
             date_range.start,
@@ -1158,19 +1202,21 @@ mod tests {
 
     #[test]
     fn test_timing() {
-        let mut timing = Timing::default();
-        timing.event = Some(vec![
-            FHIRDateTime {
-                id: None,
-                extension: None,
-                value: Some(DateTime::YearMonthDay(2023, 12, 31)),
-            },
-            FHIRDateTime {
-                id: None,
-                extension: None,
-                value: Some(DateTime::YearMonthDay(2024, 1, 1)),
-            },
-        ]);
+        let timing = Timing {
+            event: Some(vec![
+                FHIRDateTime {
+                    id: None,
+                    extension: None,
+                    value: Some(DateTime::YearMonthDay(2023, 12, 31)),
+                },
+                FHIRDateTime {
+                    id: None,
+                    extension: None,
+                    value: Some(DateTime::YearMonthDay(2024, 1, 1)),
+                },
+            ]),
+            ..Default::default()
+        };
 
         let date_ranges = index_date(&timing).unwrap();
         assert_eq!(date_ranges.len(), 2);
@@ -1239,7 +1285,7 @@ mod tests {
 
         let result = index_reference(&reference);
 
-        assert!(result.is_err())
+        assert!(result.is_err());
     }
 
     #[test]

--- a/backend/crates/fhir-search/src/memory/mod.rs
+++ b/backend/crates/fhir-search/src/memory/mod.rs
@@ -13,7 +13,7 @@ pub enum ArtifactError {
     InvalidResource(String),
 }
 
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct SearchParametersIndex {
     by_url: HashMap<String, ResolvedParameter>,
     by_resource_type: HashMap<String, HashMap<String, ResolvedParameter>>,
@@ -83,15 +83,6 @@ impl SearchParameterResolve for SearchParametersIndex {
     }
 }
 
-impl Default for SearchParametersIndex {
-    fn default() -> Self {
-        SearchParametersIndex {
-            by_url: HashMap::new(),
-            by_resource_type: HashMap::new(),
-        }
-    }
-}
-
 fn build_search_parameter_index_map(
     level: &ParameterLevel,
     index: &mut SearchParametersIndex,
@@ -103,7 +94,7 @@ fn build_search_parameter_index_map(
                 .entry
                 .unwrap_or(vec![])
                 .into_iter()
-                .flat_map(|e| e.resource)
+                .filter_map(|e| e.resource)
                 .filter_map(|resource| match *resource {
                     Resource::SearchParameter(search_param) => Some(Arc::new(search_param)),
                     _ => None,
@@ -122,7 +113,7 @@ fn build_search_parameter_index_map(
                             .entry(resource_type.to_string())
                             .or_default()
                             .insert(
-                                param.code.value.as_ref().unwrap().to_string(),
+                                param.code.value.as_ref().unwrap().clone(),
                                 ResolvedParameter::new(level.clone(), param.clone()),
                             );
                     }
@@ -145,7 +136,7 @@ fn build_search_parameter_index_map(
                         .entry(resource_type.to_string())
                         .or_default()
                         .insert(
-                            param.code.value.as_ref().unwrap().to_string(),
+                            param.code.value.as_ref().unwrap().clone(),
                             ResolvedParameter::new(level.clone(), param.clone()),
                         );
                 }
@@ -161,19 +152,23 @@ fn build_search_parameter_index_map(
 pub static R4_SEARCH_PARAMETERS_INDEX: LazyLock<Arc<SearchParametersIndex>> = LazyLock::new(|| {
     Arc::new(create_index_map(
         &ParameterLevel::System,
-        R4_SEARCH_PARAMETERS
-            .iter()
-            .map(|param| param.clone())
-            .collect(),
+        R4_SEARCH_PARAMETERS.iter().cloned().collect(),
     ))
 });
 
+/// Creates an index of search parameters for the specified parameter level.
+///
+/// # Panics
+///
+/// Panics if a search parameter cannot be added to the index.
+#[must_use]
 pub fn create_index_map(
     level: &ParameterLevel,
     search_parameters: Vec<SearchParameter>,
 ) -> SearchParametersIndex {
     let mut index = SearchParametersIndex::default();
-    for param in search_parameters.into_iter() {
+
+    for param in search_parameters {
         build_search_parameter_index_map(level, &mut index, Resource::SearchParameter(param))
             .expect("Failed to build search parameter index");
     }

--- a/backend/crates/fhir-subscription-processor/src/lib.rs
+++ b/backend/crates/fhir-subscription-processor/src/lib.rs
@@ -174,7 +174,7 @@ async fn fits_subscription_parameter(
 
     let conversions = indexing_conversion::to_insertable_index(
         &subscription_parameter.parameter,
-        result.iter().collect::<Vec<_>>(),
+        &result.iter().collect::<Vec<_>>(),
     )?;
 
     match conversions {

--- a/backend/crates/repository/src/pg/models/fhir.rs
+++ b/backend/crates/repository/src/pg/models/fhir.rs
@@ -402,9 +402,8 @@ where
     .map_err(StoreError::from)?;
 
     match response {
-        Some((_, true)) => Ok(None),
+        Some((_, true)) | None => Ok(None),
         Some((json, _)) => Ok(Some(json.0)),
-        None => Ok(None),
     }
 }
 

--- a/backend/crates/repository/src/pg/pending.rs
+++ b/backend/crates/repository/src/pg/pending.rs
@@ -166,6 +166,7 @@ where
 pub struct PendingRows(Arc<Mutex<Vec<PendingResourceRow>>>);
 
 impl PendingRows {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -199,8 +200,13 @@ impl PendingRows {
 
     /// Drains and inserts every buffered row, so a subsequent read on the
     /// same transaction observes prior writes that haven't reached Postgres
-    /// yet. The internal lock is released before `tx` is locked, so the two
+    /// yet. The internal lock is released before tx is locked, so the two
     /// are never held simultaneously.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OperationOutcomeError`] if inserting the buffered rows
+    /// into Postgres fails.
     pub async fn flush(
         &self,
         tx: &Arc<Mutex<sqlx::Transaction<'static, Postgres>>>,

--- a/backend/crates/repository/src/utilities.rs
+++ b/backend/crates/repository/src/utilities.rs
@@ -132,10 +132,10 @@ fn filter_and_set_haste_extensions(
     meta.extension = Some(
         meta.extension
             .take()
-            .unwrap_or_else(|| vec![])
+            .unwrap_or_default()
             .into_iter()
             .filter(|ext| !HASTE_EXTENSIONS.contains(&ext.url.as_str()))
-            .chain(haste_extensions.into_iter())
+            .chain(haste_extensions)
             .collect::<Vec<Extension>>(),
     );
 }


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.