### PR TITLE
Resolve `clippy` lints for `wal_worker` crate

### DIFF
--- a/backend/crates/wal_worker/src/es_search_destination.rs
+++ b/backend/crates/wal_worker/src/es_search_destination.rs
@@ -32,8 +32,8 @@ pub struct ESSearchDestination<Search: SearchEngine + Clone> {
 }
 
 impl<Search: SearchEngine + Clone> ESSearchDestination<Search> {
-    pub fn new(search_client: Search) -> EtlResult<Self> {
-        Ok(Self { search_client })
+    pub fn new(search_client: Search) -> Self {
+        Self { search_client }
     }
 }
 
@@ -42,18 +42,18 @@ impl<Search: SearchEngine + Clone> Destination for ESSearchDestination<Search> {
         "http"
     }
 
-    async fn truncate_table(&self, _table_id: TableId) -> EtlResult<()> {
+    async fn truncate_table(&self, table_id: TableId) -> EtlResult<()> {
         warn!(
             "truncate_table is not implemented for ESSearchDestination as it is not intended to be used for writing table rows directly. Received table_id: {:?}",
-            _table_id
+            table_id
         );
         Ok(())
     }
 
-    async fn write_table_rows(&self, _table_id: TableId, _rows: Vec<TableRow>) -> EtlResult<()> {
+    async fn write_table_rows(&self, table_id: TableId, rows: Vec<TableRow>) -> EtlResult<()> {
         warn!(
             "write_table_rows is not implemented for ESSearchDestination as it is not intended to be used for writing table rows directly. Received table_id: {:?} and rows: {:?}",
-            _table_id, _rows
+            table_id, rows
         );
         Ok(())
     }
@@ -96,12 +96,10 @@ impl<Search: SearchEngine + Clone> Destination for ESSearchDestination<Search> {
                         panic!("Unexpected cell type for project: {:?}", i[1]);
                     }
                 };
-                let resource_json = match resource {
-                    Cell::Json(json) => json,
-                    _ => {
-                        panic!("Unexpected cell type for resource: {:?}", i[5]);
-                    }
+                let Cell::Json(resource_json) = resource else {
+                    panic!("Unexpected cell type for resource: {:?}", i[5]);
                 };
+
                 // account for the 3 popped values
                 let fhir_method = match fhir_method {
                     Cell::String(fhir_method) => {

--- a/backend/crates/wal_worker/src/main.rs
+++ b/backend/crates/wal_worker/src/main.rs
@@ -21,7 +21,7 @@ mod es_search_destination;
 
 static PIPELINE_ID: u64 = 1;
 
-pub enum ESSearchWorkerEnvironmentVariables {
+enum ESSearchWorkerEnvironmentVariables {
     ElasticSearchURL,
     ElasticSearchUsername,
     ElasticSearchPassword,
@@ -46,23 +46,25 @@ impl From<ESSearchWorkerEnvironmentVariables> for String {
 
 static POOL: OnceCell<Pool<Postgres>> = OnceCell::const_new();
 
-pub async fn get_pool(
+async fn get_pool(
     config: &dyn Config<ESSearchWorkerEnvironmentVariables>,
 ) -> &'static Pool<Postgres> {
     POOL.get_or_init(async || {
         let database_url = config
             .get(ESSearchWorkerEnvironmentVariables::DataBaseURL)
-            .expect(&format!(
-                "'{}' must be set",
-                String::from(ESSearchWorkerEnvironmentVariables::DataBaseURL)
-            ));
+            .unwrap_or_else(|_| {
+                panic!(
+                    "'{}' must be set",
+                    String::from(ESSearchWorkerEnvironmentVariables::DataBaseURL)
+                )
+            });
+
         info!("Connecting to postgres database");
-        let connection = PgPoolOptions::new()
+        PgPoolOptions::new()
             .max_connections(5)
             .connect(&database_url)
             .await
-            .expect("Failed to create database connection pool");
-        connection
+            .expect("Failed to create database connection pool")
     })
     .await
 }
@@ -74,22 +76,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let es_client = create_es_client(
         &config
             .get(ESSearchWorkerEnvironmentVariables::ElasticSearchURL)
-            .expect(&format!(
-                "'{}' variable not set",
-                String::from(ESSearchWorkerEnvironmentVariables::ElasticSearchURL)
-            )),
+            .unwrap_or_else(|_| {
+                panic!(
+                    "'{}' variable not set",
+                    String::from(ESSearchWorkerEnvironmentVariables::ElasticSearchURL)
+                )
+            }),
         config
             .get(ESSearchWorkerEnvironmentVariables::ElasticSearchUsername)
-            .expect(&format!(
-                "'{}' variable not set",
-                String::from(ESSearchWorkerEnvironmentVariables::ElasticSearchUsername)
-            )),
+            .unwrap_or_else(|_| {
+                panic!(
+                    "'{}' variable not set",
+                    String::from(ESSearchWorkerEnvironmentVariables::ElasticSearchUsername)
+                )
+            }),
         config
             .get(ESSearchWorkerEnvironmentVariables::ElasticSearchPassword)
-            .expect(&format!(
-                "'{}' variable not set",
-                String::from(ESSearchWorkerEnvironmentVariables::ElasticSearchPassword)
-            )),
+            .unwrap_or_else(|_| {
+                panic!(
+                    "'{}' variable not set",
+                    String::from(ESSearchWorkerEnvironmentVariables::ElasticSearchPassword)
+                )
+            }),
     )
     .expect("Failed to create Elasticsearch client");
 
@@ -128,8 +136,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let store = MemoryStore::new();
     // let store = PostgresStore::new(PIPELINE_ID, pg_config);
-    let destination = ESSearchDestination::new(search_engine)
-        .expect("Failed to create Elasticsearch destination");
+    let destination = ESSearchDestination::new(search_engine);
 
     println!("Starting pipeline...");
     let mut pipeline = Pipeline::new(config, store, destination);


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.

I know it is experimental, but better to reduce the technical debt the same