### PR TITLE
Resolve missing `clippy` lints for some crates (1/2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
           -p haste-reflect-derive \
           -p haste-repository \
           -p haste-sd-to-json-schema \
+          -p haste-testscript-runner \
           -p haste_wal_worker \
           -p haste-worker \
           -p haste-x-fhir-query \

--- a/backend/crates/fhir-client/src/http.rs
+++ b/backend/crates/fhir-client/src/http.rs
@@ -576,6 +576,7 @@ fn request_from_invocation_system(
     build_post(state, request_url, body)
 }
 
+#[derive(Clone, Copy)]
 enum FHIRResponseRequest<'a> {
     Read,
     Create,

--- a/backend/crates/testscript-runner/src/lib.rs
+++ b/backend/crates/testscript-runner/src/lib.rs
@@ -1035,56 +1035,52 @@ async fn run_assertion(
 
     // Keep all uses of `source` inside this scope so the immutable borrow
     // of `state_guard` ends before we mutate `state_guard`.
-    let failure_message = {
-        if let Some(message) =
-            evaluate_resource_assertion(assertion, pointer.path(), source, operator)
-        {
-            Some(message)
-        } else if let Some(expression) =
-            assertion.expression.as_ref().and_then(|e| e.value.as_ref())
-        {
-            evaluate_expression_assertion(
-                &state_guard,
-                assertion,
-                pointer.path(),
-                source,
-                operator,
-                expression,
-            )
-            .await?
-        } else {
-            None
-        }
+    let failure_message = if let Some(message) =
+        evaluate_resource_assertion(assertion, pointer.path(), source, operator)
+    {
+        Some(message)
+    } else if let Some(expression) = assertion.expression.as_ref().and_then(|e| e.value.as_ref()) {
+        evaluate_expression_assertion(
+            &state_guard,
+            assertion,
+            pointer.path(),
+            source,
+            operator,
+            expression,
+        )
+        .await?
+    } else {
+        None
     };
 
-    Ok(if let Some(message) = failure_message {
-        tracing::error!(
-            assert.label = assert_label(assertion),
-            path = pointer.path(),
-            "{message}"
-        );
+    let (result, message) = match failure_message {
+        Some(message) => {
+            tracing::error!(
+                assert.label = assert_label(assertion),
+                path = pointer.path(),
+                "{message}"
+            );
 
-        state_guard.result = ReportResultCodes::fail();
+            state_guard.result = ReportResultCodes::fail();
 
-        TestResult {
-            state: state.clone(),
-            value: TestReportSetupActionAssert {
-                result: ReportActionResultCodes::fail(),
-                message: Some(Box::new(FHIRMarkdown {
+            (
+                ReportActionResultCodes::fail(),
+                Some(Box::new(FHIRMarkdown {
                     value: Some(message),
                     ..Default::default()
                 })),
-                ..Default::default()
-            },
+            )
         }
-    } else {
-        TestResult {
-            state: state.clone(),
-            value: TestReportSetupActionAssert {
-                result: ReportActionResultCodes::pass(),
-                ..Default::default()
-            },
-        }
+        None => (ReportActionResultCodes::pass(), None),
+    };
+
+    Ok(TestResult {
+        state: state.clone(),
+        value: TestReportSetupActionAssert {
+            result,
+            message,
+            ..Default::default()
+        },
     })
 }
 

--- a/backend/crates/testscript-runner/src/lib.rs
+++ b/backend/crates/testscript-runner/src/lib.rs
@@ -1094,9 +1094,7 @@ fn evaluate_resource_assertion(
     source: &dyn MetaValue,
     operator: &BoundCode<AssertOperatorCodes>,
 ) -> Option<String> {
-    let resource = assertion.resource.as_ref()?;
-
-    let resource_string = resource.as_str().unwrap_or("");
+    let resource_string = assertion.resource.as_ref()?.as_str()?;
 
     let operation_evaluation_result = evaluate_operator(
         operator,

--- a/backend/crates/testscript-runner/src/lib.rs
+++ b/backend/crates/testscript-runner/src/lib.rs
@@ -1029,119 +1029,145 @@ async fn run_assertion(
             pointer.path()
         )));
     };
+
     let default = AssertOperatorCodes::equals();
     let operator = assertion.operator.as_ref().unwrap_or(&default);
 
-    if assertion.resource.is_some() {
-        let resource_string = assertion
-            .resource
-            .as_ref()
-            .and_then(haste_fhir_model::r4::generated::terminology::BoundCode::as_str)
-            .unwrap_or("");
+    // Keep all uses of `source` inside this scope so the immutable borrow
+    // of `state_guard` ends before we mutate `state_guard`.
+    let failure_message = {
+        if let Some(message) =
+            evaluate_resource_assertion(assertion, pointer.path(), source, operator)
+        {
+            Some(message)
+        } else if let Some(expression) =
+            assertion.expression.as_ref().and_then(|e| e.value.as_ref())
+        {
+            evaluate_expression_assertion(
+                &state_guard,
+                assertion,
+                pointer.path(),
+                source,
+                operator,
+                expression,
+            )
+            .await?
+        } else {
+            None
+        }
+    };
 
-        let operation_evaluation_result = evaluate_operator(
-            operator,
-            &vec![conversion::ConvertedValue::String(
-                resource_string.to_string(),
-            )],
-            &vec![conversion::ConvertedValue::String(
-                source.fhir_type().to_string(),
-            )],
+    Ok(if let Some(message) = failure_message {
+        tracing::error!(
+            assert.label = assert_label(assertion),
+            path = pointer.path(),
+            "{message}"
         );
-        if !operation_evaluation_result {
-            let message = format!(
-                "Assertion '{}' at '{}' failed: resource type '{resource_string}' does not match '{}'.",
-                assert_label(assertion),
-                pointer.path(),
-                source.fhir_type()
-            );
-            tracing::error!(
-                assert.label = assert_label(assertion),
-                path = pointer.path(),
-                "{message}"
-            );
 
-            state_guard.result = ReportResultCodes::fail();
-            return Ok(TestResult {
-                state: state.clone(),
-                value: TestReportSetupActionAssert {
-                    result: ReportActionResultCodes::fail(),
-                    message: Some(Box::new(FHIRMarkdown {
-                        value: Some(message),
-                        ..Default::default()
-                    })),
+        state_guard.result = ReportResultCodes::fail();
+
+        TestResult {
+            state: state.clone(),
+            value: TestReportSetupActionAssert {
+                result: ReportActionResultCodes::fail(),
+                message: Some(Box::new(FHIRMarkdown {
+                    value: Some(message),
                     ..Default::default()
-                },
-            });
+                })),
+                ..Default::default()
+            },
         }
-    }
-    if let Some(expression) = assertion.expression.as_ref().and_then(|e| e.value.as_ref()) {
-        let comparison_to = derive_comparison_to(&state_guard, assertion).await?;
-
-        let Ok(result) = state_guard
-            .fp_engine
-            .evaluate(expression, vec![source])
-            .await
-        else {
-            tracing::error!(
-                assert.label = assert_label(assertion),
-                path = pointer.path(),
-                expression = expression.as_str(),
-                "Assertion '{}' at '{}' failed: FHIRPath expression '{expression}' failed to evaluate.",
-                assert_label(assertion),
-                pointer.path(),
-            );
-
-            state_guard.result = ReportResultCodes::fail();
-            return Err(TestScriptError::ExecutionError(format!(
-                "Assertion '{}' at '{}': FHIRPath expression '{expression}' failed to evaluate.",
-                assert_label(assertion),
-                pointer.path(),
-            )));
-        };
-
-        let converted_values = result
-            .iter()
-            .map(conversion::convert_meta_value)
-            .collect::<Vec<_>>();
-
-        let operation_evaluation_result =
-            evaluate_operator(operator, &converted_values, &comparison_to);
-
-        if !operation_evaluation_result {
-            let message = format!(
-                "Assertion '{}' at '{}' failed: '{converted_values:?}' {operator:?} '{comparison_to:?}'.",
-                assert_label(assertion),
-                pointer.path(),
-            );
-            tracing::error!(
-                assert.label = assert_label(assertion),
-                path = pointer.path(),
-                "{message}"
-            );
-
-            state_guard.result = ReportResultCodes::fail();
-            return Ok(TestResult {
-                state: state.clone(),
-                value: TestReportSetupActionAssert {
-                    result: ReportActionResultCodes::fail(),
-                    message: Some(Box::new(FHIRMarkdown {
-                        value: Some(message),
-                        ..Default::default()
-                    })),
-                    ..Default::default()
-                },
-            });
+    } else {
+        TestResult {
+            state: state.clone(),
+            value: TestReportSetupActionAssert {
+                result: ReportActionResultCodes::pass(),
+                ..Default::default()
+            },
         }
-    }
-
-    Ok(TestResult {
-        state: state.clone(),
-        value: TestReportSetupActionAssert {
-            result: ReportActionResultCodes::pass(),
-            ..Default::default()
-        },
     })
+}
+
+fn evaluate_resource_assertion(
+    assertion: &TestScriptSetupActionAssert,
+    path: &str,
+    source: &dyn MetaValue,
+    operator: &BoundCode<AssertOperatorCodes>,
+) -> Option<String> {
+    let resource = assertion.resource.as_ref()?;
+
+    let resource_string = resource.as_str().unwrap_or("");
+
+    let operation_evaluation_result = evaluate_operator(
+        operator,
+        &vec![conversion::ConvertedValue::String(
+            resource_string.to_string(),
+        )],
+        &vec![conversion::ConvertedValue::String(
+            source.fhir_type().to_string(),
+        )],
+    );
+
+    if operation_evaluation_result {
+        return None;
+    }
+
+    Some(format!(
+        "Assertion '{}' at '{}' failed: resource type '{resource_string}' does not match '{}'.",
+        assert_label(assertion),
+        path,
+        source.fhir_type()
+    ))
+}
+
+async fn evaluate_expression_assertion(
+    state_guard: &TestState,
+    assertion: &TestScriptSetupActionAssert,
+    path: &str,
+    source: &dyn MetaValue,
+    operator: &BoundCode<AssertOperatorCodes>,
+    expression: &str,
+) -> Result<Option<String>, TestScriptError> {
+    let comparison_to = derive_comparison_to(state_guard, assertion).await?;
+
+    let Ok(result) = state_guard
+        .fp_engine
+        .evaluate(expression, vec![source])
+        .await
+    else {
+        tracing::error!(
+            assert.label = assert_label(assertion),
+            path = path,
+            expression = expression,
+            "Assertion '{}' at '{}' failed: FHIRPath expression '{expression}' failed to evaluate.",
+            assert_label(assertion),
+            path,
+        );
+
+        return Err(TestScriptError::ExecutionError(format!(
+            "Assertion '{}' at '{}': FHIRPath expression '{expression}' failed to evaluate.",
+            assert_label(assertion),
+            path,
+        )));
+    };
+
+    let converted_values = result
+        .iter()
+        .map(conversion::convert_meta_value)
+        .collect::<Vec<_>>();
+
+    let operation_evaluation_result =
+        evaluate_operator(operator, &converted_values, &comparison_to);
+
+    if operation_evaluation_result {
+        return Ok(None);
+    }
+
+    Ok(Some(format!(
+        "Assertion '{}' at '{}' failed: '{converted_values:?}' {operator:?} '{comparison_to:?}'.",
+        assert_label(assertion),
+        path,
+    )))
 }
 
 async fn run_action<CTX, Client: FHIRClient<CTX, OperationOutcomeError>>(


### PR DESCRIPTION
Resolve other small `clippy` lints for `fhir-client` and `testscript-runner` crates