### PR TITLE
Resolve `clippy` lints for `fhir-profiling` crate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
           -p haste-fhir-operation-error-derive \
           -p haste-fhir-ops \
           -p haste-fhir-ops-derive \
+          -p haste-fhir-profiling \
           -p haste-fhir-search \
           -p haste-fhir-serialization-json \
           -p haste-fhir-serialization-json-derive \

--- a/backend/crates/fhir-profiling/src/element.rs
+++ b/backend/crates/fhir-profiling/src/element.rs
@@ -18,7 +18,7 @@ use crate::{
 
 fn conformant_to_type(type_to_check: Option<&str>, type_: Option<&str>) -> bool {
     match type_to_check {
-        Some("Resource | DomainResource") => true,
+        Some("Resource" | "DomainResource") => true,
         _ => type_ == type_to_check,
     }
 }

--- a/backend/crates/fhir-profiling/src/element.rs
+++ b/backend/crates/fhir-profiling/src/element.rs
@@ -18,7 +18,7 @@ use crate::{
 
 fn conformant_to_type(type_to_check: Option<&str>, type_: Option<&str>) -> bool {
     match type_to_check {
-        Some("Resource") | Some("DomainResource") => true,
+        Some("Resource | DomainResource") => true,
         _ => type_ == type_to_check,
     }
 }
@@ -28,11 +28,11 @@ fn conformant_to_type(type_to_check: Option<&str>, type_: Option<&str>) -> bool 
 ///
 /// # Arguments
 ///
-/// * `ctx` - The FHIRProfileCTX containing the profile and root data.
-/// * `element` - ElementDefinition to check
+/// * `ctx` - The [`FHIRProfileCTX`] containing the profile and root data.
+/// * `element` - [`ElementDefinition`] to check
 /// * `type_` - The type found on the element
-async fn validate_types_and_profiles_if_present<'a>(
-    ctx: Arc<FHIRProfileCTX<'a, impl CanonicalResolver>>,
+async fn validate_types_and_profiles_if_present(
+    ctx: Arc<FHIRProfileCTX<'_, impl CanonicalResolver>>,
     element: &ElementDefinition,
     value_pointer: &Path,
     type_: Option<&str>,
@@ -46,32 +46,31 @@ async fn validate_types_and_profiles_if_present<'a>(
         // As you could end up treating FHIRString for a primitive string type as a complex type with all the extra fields that FHIRString has compared to a primitive string.
         return Ok(vec![]);
     }
-    let Some(types) = &element.type_ else {
+    let Some(element_types) = &element.type_ else {
         return Ok(vec![]);
     };
 
-    if let Some(profile_type) = types
+    if let Some(profile_type) = element_types
         .iter()
-        .find(|t| conformant_to_type(t.code.value.as_ref().map(|s| s.as_str()), type_))
+        .find(|t| conformant_to_type(t.code.value.as_deref(), type_))
     {
         let mut issues = vec![];
 
         if let Some(profiles_to_check) = profile_type.profile.as_ref() {
-            for profile_canonical in profiles_to_check.iter() {
+            for profile_canonical in profiles_to_check {
                 if let Some(profile_canonical) = profile_canonical.value.as_ref() {
-                    let resolved_resource = ctx
-                        .resolver
-                        .resolve(ResourceType::StructureDefinition, profile_canonical)
-                        .await?
-                        .ok_or_else(|| {
-                            OperationOutcomeError::error(
-                                IssueType::exception(),
-                                format!(
-                                    "Failed to resolve profile canonical: {}",
-                                    profile_canonical
-                                ),
-                            )
-                        })?;
+                    let resolved_resource =
+                        ctx.resolver
+                            .resolve(ResourceType::StructureDefinition, profile_canonical)
+                            .await?
+                            .ok_or_else(|| {
+                                OperationOutcomeError::error(
+                                    IssueType::exception(),
+                                    format!(
+                                        "Failed to resolve profile canonical: {profile_canonical}",
+                                    ),
+                                )
+                            })?;
 
                     issues.extend(
                         validate_element(
@@ -101,7 +100,7 @@ async fn validate_types_and_profiles_if_present<'a>(
             format!(
                 "Type '{}' is not allowed for element '{}'",
                 type_.unwrap_or("unknown"),
-                element.id.as_ref().map(|s| s.as_str()).unwrap_or("unknown")
+                element.id.as_deref().unwrap_or("unknown")
             ),
         )])
     }
@@ -114,22 +113,22 @@ pub fn outcome_issue(
     diagnostic: String,
 ) -> OperationOutcomeIssue {
     OperationOutcomeIssue {
-        severity: severity,
-        code: code,
+        severity,
+        code,
         diagnostics: Some(Box::new(FHIRString {
             value: Some(diagnostic),
             ..Default::default()
         })),
         location: Some(vec![FHIRString {
-            value: Some(format!("{}", value_location)),
+            value: Some(value_location.to_string()),
             ..Default::default()
         }]),
         ..Default::default()
     }
 }
 
-pub async fn validate_singular_element<'a>(
-    ctx: Arc<FHIRProfileCTX<'a, impl CanonicalResolver>>,
+pub async fn validate_singular_element(
+    ctx: Arc<FHIRProfileCTX<'_, impl CanonicalResolver>>,
     element_path: &Path,
     value_path: &Path,
 ) -> Result<Vec<OperationOutcomeIssue>, OperationOutcomeError> {
@@ -138,21 +137,21 @@ pub async fn validate_singular_element<'a>(
         .ok_or_else(|| {
             OperationOutcomeError::error(
                 IssueType::exception(),
-                format!("Invalid elements path: {}", element_path),
+                format!("Invalid elements path: {element_path}"),
             )
         })?;
 
     let Some(value) = value_path.get(ctx.root) else {
         return Err(OperationOutcomeError::error(
             IssueType::exception(),
-            format!("Invalid value path: {}", value_path),
+            format!("Invalid value path: {value_path}"),
         ));
     };
-    let mut issues = vec![];
+    let mut issues = Vec::new();
     let Some((elements_pointer, Key::Index(index))) = element_path.ascend() else {
         return Err(OperationOutcomeError::error(
             IssueType::exception(),
-            format!("Invalid element path: {}", element_path),
+            format!("Invalid element path: {element_path}"),
         ));
     };
 
@@ -161,7 +160,7 @@ pub async fn validate_singular_element<'a>(
         .ok_or_else(|| {
             OperationOutcomeError::error(
                 IssueType::exception(),
-                format!("Invalid elements path: {}", elements_pointer),
+                format!("Invalid elements path: {elements_pointer}"),
             )
         })?;
 
@@ -170,7 +169,7 @@ pub async fn validate_singular_element<'a>(
 
     // Includes all of slice descriptors which is how to split (the descriptor)
     // and the slices that belong to that descriptor (the slices).
-    let slice_descriptors = get_slice_descriptors(elements, &children)?;
+    let slice_descriptors = get_slice_descriptors(elements, &children);
 
     let slice_indices_set = slice_descriptors
         .iter()
@@ -183,7 +182,7 @@ pub async fn validate_singular_element<'a>(
         .copied()
         .collect::<std::collections::HashSet<usize>>();
 
-    for descriptor in slice_descriptors.iter() {
+    for descriptor in &slice_descriptors {
         issues.extend(
             Box::pin(validate_slicing_descriptor(
                 ctx.clone(),
@@ -198,7 +197,7 @@ pub async fn validate_singular_element<'a>(
         validate_types_and_profiles_if_present(
             ctx.clone(),
             element,
-            &value_path,
+            value_path,
             Some(value.fhir_type()),
         )
         .await?,
@@ -211,7 +210,7 @@ pub async fn validate_singular_element<'a>(
             value_path,
             IssueSeverity::error(),
             IssueType::value(),
-            format!("Value does not match pattern: {:?}", pattern),
+            format!("Value does not match pattern: {pattern:?}"),
         ));
     }
 
@@ -222,7 +221,7 @@ pub async fn validate_singular_element<'a>(
             value_path,
             IssueSeverity::error(),
             IssueType::value(),
-            format!("Value does not match fixed value: {:?}", fixed_value),
+            format!("Value does not match fixed value: {fixed_value:?}"),
         ));
     }
 
@@ -232,15 +231,8 @@ pub async fn validate_singular_element<'a>(
         .filter(|child_index| !slice_indices_set.contains(child_index))
     {
         let child_element = &elements[*child];
-        let field_name = extract::field_name(
-            child_element
-                .path
-                .value
-                .as_ref()
-                .map(|s| s.as_str())
-                .unwrap_or(""),
-        );
-        let child_element_pointer = elements_pointer.descend(&format!("{}", child));
+        let field_name = extract::field_name(child_element.path.value.as_deref().unwrap_or(""));
+        let child_element_pointer = elements_pointer.descend(&child.to_string());
         let child_value_pointer = value_path.descend(&field_name);
         let child_issues = Box::pin(validate_element(
             ctx.clone(),
@@ -254,8 +246,8 @@ pub async fn validate_singular_element<'a>(
     Ok(issues)
 }
 
-pub async fn validate_element<'a>(
-    ctx: Arc<FHIRProfileCTX<'a, impl CanonicalResolver>>,
+pub async fn validate_element(
+    ctx: Arc<FHIRProfileCTX<'_, impl CanonicalResolver>>,
     element_pointer: &Path,
     value_pointer: &Path,
 ) -> Result<Vec<OperationOutcomeIssue>, OperationOutcomeError> {
@@ -263,7 +255,7 @@ pub async fn validate_element<'a>(
     let Some(element) = element_pointer.get_typed::<ElementDefinition>(ctx.profile()) else {
         return Err(OperationOutcomeError::error(
             IssueType::exception(),
-            format!("Invalid element path: {}", element_pointer),
+            format!("Invalid element path: {element_pointer}"),
         ));
     };
 
@@ -271,9 +263,9 @@ pub async fn validate_element<'a>(
 
     issues.extend(validate_cardinality(
         ctx.clone(),
-        &value_pointer,
+        value_pointer,
         element,
-        &value,
+        value,
     )?);
 
     if let Some(value) = value {
@@ -283,7 +275,7 @@ pub async fn validate_element<'a>(
                     Box::pin(validate_singular_element(
                         ctx.clone(),
                         element_pointer,
-                        &value_pointer.descend(&format!("{}", i)),
+                        &value_pointer.descend(&i.to_string()),
                     ))
                     .await?,
                 );

--- a/backend/crates/fhir-profiling/src/lib.rs
+++ b/backend/crates/fhir-profiling/src/lib.rs
@@ -33,6 +33,12 @@ pub struct FHIRProfileCTX<'a, Resolver: CanonicalResolver> {
 }
 
 impl<'a, Resolver: CanonicalResolver> FHIRProfileCTX<'a, Resolver> {
+    /// Creates a new FHIR profile context.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OperationOutcomeError`] if `profile` is not a
+    /// [`StructureDefinition`] resource.
     pub fn new(
         resolver: Arc<Resolver>,
         profile: Arc<Resource>,
@@ -51,6 +57,12 @@ impl<'a, Resolver: CanonicalResolver> FHIRProfileCTX<'a, Resolver> {
         }
     }
 
+    /// Returns the [`StructureDefinition`] associated with this profile context.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the profile is not a [`Resource::StructureDefinition`].
+    #[must_use]
     pub fn profile(&'a self) -> &'a StructureDefinition {
         match self.profile.as_ref() {
             Resource::StructureDefinition(sd) => sd,
@@ -61,8 +73,15 @@ impl<'a, Resolver: CanonicalResolver> FHIRProfileCTX<'a, Resolver> {
     }
 }
 
-pub async fn validate_profile<'a>(
-    ctx: Arc<FHIRProfileCTX<'a, impl CanonicalResolver>>,
+/// Validates the profile represented by the given context.
+///
+/// # Errors
+///
+/// Returns [`OperationOutcomeError`] if:
+/// - validating an element fails; or
+/// - the profile does not have a derivation of `constraint`.
+pub async fn validate_profile(
+    ctx: Arc<FHIRProfileCTX<'_, impl CanonicalResolver>>,
 ) -> Result<OperationOutcome, OperationOutcomeError> {
     let mut outcome = OperationOutcome::default();
     match ctx.profile().derivation.as_ref() {
@@ -88,17 +107,23 @@ pub async fn validate_profile<'a>(
     Ok(outcome)
 }
 
-pub async fn validate_profile_by_url<'a>(
+/// Validates a value against the profile identified by its canonical URL.
+///
+/// # Errors
+///
+/// Returns [`OperationOutcomeError`] if resolving the profile fails, if the
+/// resolved resource is not a supported profile, or if profile validation fails.
+pub async fn validate_profile_by_url(
     args: FHIRProfileArguments<impl CanonicalResolver>,
     canonical_url: &str,
-    value: &'a dyn MetaValue,
+    value: &dyn MetaValue,
 ) -> Result<OperationOutcome, OperationOutcomeError> {
     let Some(profile) = args
         .resolver
         .resolve(ResourceType::StructureDefinition, canonical_url)
         .await?
     else {
-        tracing::warn!("Profile with url '{}' not found", canonical_url);
+        tracing::warn!("Profile with url '{canonical_url}' not found");
         return Ok(OperationOutcome::default());
     };
 

--- a/backend/crates/fhir-profiling/src/slicing/mod.rs
+++ b/backend/crates/fhir-profiling/src/slicing/mod.rs
@@ -41,11 +41,11 @@ pub struct SlicingDescriptor {
 /// Return child elements that are slice element definitions.
 pub fn get_slice_descriptors(
     elements: &[ElementDefinition],
-    children: &Vec<usize>,
-) -> Result<Vec<SlicingDescriptor>, OperationOutcomeError> {
+    children: &[usize],
+) -> Vec<SlicingDescriptor> {
     let mut i = 0;
 
-    let mut slice_indices = vec![];
+    let mut slice_indices = Vec::new();
 
     while i < children.len() {
         let child_index = children[i];
@@ -55,7 +55,7 @@ pub fn get_slice_descriptors(
         if is_slice(element) {
             let mut slice_index = SlicingDescriptor {
                 discriminator: child_index,
-                slices: vec![],
+                slices: Vec::new(),
             };
 
             // SliceName indicates that it's a part of the slice (upper discriminator).
@@ -75,7 +75,7 @@ pub fn get_slice_descriptors(
         }
     }
 
-    Ok(slice_indices)
+    slice_indices
 }
 
 struct FoundDiscriminator<'a, Resolver: CanonicalResolver> {
@@ -87,8 +87,10 @@ struct FoundDiscriminator<'a, Resolver: CanonicalResolver> {
 /// The discriminator element specifies a path from which to compare with.
 /// To know how split should be done though we need the constant pattern etc... from that path.
 /// For example Extension.url could be the discriminator, but
-/// We need to pull from for example https://build.fhir.org/ig/HL7/US-Core/StructureDefinition-us-core-race.html
-///  the actual value of the pattern to know how to split the slice. Which would be "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+/// We need to pull from for example
+/// <https://build.fhir.org/ig/HL7/US-Core/StructureDefinition-us-core-race.html>
+///  the actual value of the pattern to know how to split the slice. Which would
+///  be <http://hl7.org/fhir/us/core/StructureDefinition/us-core-race>
 async fn find_element_definition_for_discriminator<'a, Resolver: CanonicalResolver>(
     ctx: Arc<FHIRProfileCTX<'a, Resolver>>,
     search_for_path: &str,
@@ -103,16 +105,11 @@ async fn find_element_definition_for_discriminator<'a, Resolver: CanonicalResolv
         .ok_or_else(|| {
             OperationOutcomeError::error(
                 IssueType::exception(),
-                format!("Invalid element index: {}", current_index),
+                format!("Invalid element index: {current_index}"),
             )
         })?;
 
-    let element_path = element_to_check
-        .path
-        .value
-        .as_ref()
-        .map(|s| s.as_str())
-        .unwrap_or("");
+    let element_path = element_to_check.path.value.as_deref().unwrap_or("");
 
     let current_element_path = if let Some(parent_path) = parent_path {
         utilities::join_paths(
@@ -141,8 +138,8 @@ async fn find_element_definition_for_discriminator<'a, Resolver: CanonicalResolv
                 .collect::<Vec<_>>()
         }) && !profiles.is_empty()
         {
-            for profile in profiles.iter() {
-                if let Some(canonical) = profile.value.as_ref().map(|c| c.as_str()) {
+            for profile in &profiles {
+                if let Some(canonical) = profile.value.as_deref() {
                     let resolved_profile = ctx
                         .resolver
                         .resolve(ResourceType::StructureDefinition, canonical)
@@ -150,7 +147,7 @@ async fn find_element_definition_for_discriminator<'a, Resolver: CanonicalResolv
                         .ok_or_else(|| {
                             OperationOutcomeError::error(
                                 IssueType::exception(),
-                                format!("Failed to resolve profile canonical: {}", canonical),
+                                format!("Failed to resolve profile canonical: {canonical}"),
                             )
                         })?;
 
@@ -173,14 +170,13 @@ async fn find_element_definition_for_discriminator<'a, Resolver: CanonicalResolv
             }
         }
 
-        let default = vec![];
+        let default = Vec::new();
 
         let child_indices = ele_index_to_child_indices(
             ctx.profile()
                 .snapshot
                 .as_ref()
-                .map(|s| s.element.as_ref())
-                .unwrap_or(&default),
+                .map_or(&default, |s| s.element.as_ref()),
             current_index,
         )
         .map_err(|err| OperationOutcomeError::error(IssueType::exception(), err))?;
@@ -198,44 +194,36 @@ async fn find_element_definition_for_discriminator<'a, Resolver: CanonicalResolv
                 return Ok(Some(v));
             }
         }
-    };
+    }
 
     Ok(None)
 }
 
 /// Returns all the slice locs that are relevant to the given discriminator.
-fn get_slice_value_locs<'a>(
-    ctx: Arc<FHIRProfileCTX<'a, impl CanonicalResolver>>,
+fn get_slice_value_locs(
+    ctx: &Arc<FHIRProfileCTX<'_, impl CanonicalResolver>>,
     discriminator_element: &ElementDefinition,
     value_path: &Path,
-) -> Result<Vec<Path>, OperationOutcomeError> {
-    let field = field_name(
-        discriminator_element
-            .path
-            .value
-            .as_ref()
-            .map(|s| s.as_str())
-            .unwrap_or(""),
-    );
+) -> Vec<Path> {
+    let field = field_name(discriminator_element.path.value.as_deref().unwrap_or(""));
 
     let slice_path = value_path.descend(&field);
     let Some(v) = slice_path.get(ctx.root) else {
-        return Ok(vec![]);
+        return Vec::new();
     };
 
     if v.is_many() {
-        Ok(v.flatten()
+        v.flatten()
             .iter()
             .enumerate()
-            .map(|(i, _)| slice_path.descend(&format!("{}", i)))
-            .collect())
+            .map(|(i, _)| slice_path.descend(&i.to_string()))
+            .collect()
     } else {
-        Ok(vec![slice_path])
+        vec![slice_path]
     }
 }
 
-static FP_ENGINE: LazyLock<haste_fhirpath::FPEngine> =
-    LazyLock::new(|| haste_fhirpath::FPEngine::new());
+static FP_ENGINE: LazyLock<haste_fhirpath::FPEngine> = LazyLock::new(haste_fhirpath::FPEngine::new);
 
 async fn is_conformant_to_slice_descriptor(
     discriminator: &ElementDefinitionSlicingDiscriminator,
@@ -249,24 +237,17 @@ async fn is_conformant_to_slice_descriptor(
             "Value for discriminator not found at path".to_string(),
         )
     })?;
+
     let values = FP_ENGINE
         .evaluate(
-            discriminator
-                .path
-                .value
-                .as_ref()
-                .map(|s| s.as_str())
-                .unwrap_or("$this"),
+            discriminator.path.value.as_deref().unwrap_or("$this"),
             vec![value],
         )
         .await
         .map_err(|err| {
             OperationOutcomeError::error(
                 IssueType::exception(),
-                format!(
-                    "Failed to evaluate FHIRPath expression for discriminator: {}",
-                    err
-                ),
+                format!("Failed to evaluate FHIRPath expression for discriminator: {err}"),
             )
         })?;
 
@@ -274,21 +255,10 @@ async fn is_conformant_to_slice_descriptor(
 
     match &discriminator.type_ {
         discriminator_type if discriminator_type == &DiscriminatorType::exists() => {
-            Ok(values.len() > 0)
+            Ok(!values.is_empty())
         }
         discriminator_type if discriminator_type == &DiscriminatorType::pattern() => {
-            let pattern = slice_value_element_definition.pattern.as_ref().ok_or_else(|| OperationOutcomeError::error(
-                IssueType::invalid(),
-                "Slice value element definition must have a pattern for pattern discriminator".to_string(),
-            ))?;
-
-            for value in values.iter() {
-                if validate_pattern(*value, pattern)? {
-                    return Ok(true);
-                }
-            }
-
-            return Ok(false);
+            is_conformant_to_pattern_discriminator(&values, slice_value_element_definition)
         }
         discriminator_type if discriminator_type == &DiscriminatorType::profile() => {
             Err(OperationOutcomeError::error(
@@ -297,90 +267,11 @@ async fn is_conformant_to_slice_descriptor(
             ))
         }
         discriminator_type if discriminator_type == &DiscriminatorType::type_() => {
-            let expected_types =
-                slice_value_element_definition
-                    .type_
-                    .as_ref()
-                    .ok_or_else(|| {
-                        OperationOutcomeError::error(
-                            IssueType::invalid(),
-                            "Slice value element definition must have types for type discriminator"
-                                .to_string(),
-                        )
-                    })?;
-
-            let types = values.iter().map(|v| v.fhir_type()).collect::<HashSet<_>>();
-
-            let result = expected_types.iter().find(|t| {
-                if let Some(type_name) = t.code.value.as_ref().map(|c| c.as_str()) {
-                    types.contains(type_name)
-                } else {
-                    false
-                }
-            });
-
-            Ok(result.is_some())
+            is_conformant_to_type_discriminator(&values, slice_value_element_definition)
         }
         // Observation us-core has pattern even though it's value based slicing
         discriminator_type if discriminator_type == &DiscriminatorType::value() => {
-            if let Some(fixed_value) = slice_value_element_definition.fixed.as_ref() {
-                for value in values.iter() {
-                    if is_equal(*value, fixed_value)? {
-                        return Ok(true);
-                    }
-                }
-            } else if let Some(pattern) = slice_value_element_definition.pattern.as_ref() {
-                for value in values.iter() {
-                    if validate_pattern(*value, pattern)? {
-                        return Ok(true);
-                    }
-                }
-            } else if let Some(binding) = slice_value_element_definition.binding.as_ref() {
-                let value_set = binding
-                    .valueSet
-                    .as_ref()
-                    .and_then(|vs| vs.value.as_ref())
-                    .and_then(|s| s.split('|').next());
-
-                let coding_pattern = Coding {
-                    system: value_set.map(|s| {
-                        Box::new(FHIRUri {
-                            value: Some(s.to_string()),
-                            ..Default::default()
-                        })
-                    }),
-                    ..Default::default()
-                };
-
-                let codeable_concept_pattern = CodeableConcept {
-                    coding: Some(vec![coding_pattern.clone()]),
-                    ..Default::default()
-                };
-
-                for value in values.iter() {
-                    match value.fhir_type() {
-                        "Coding" => {
-                            if validate_pattern(*value, &coding_pattern)? {
-                                return Ok(true);
-                            }
-                        }
-                        "CodeableConcept" => {
-                            if validate_pattern(*value, &codeable_concept_pattern)? {
-                                return Ok(true);
-                            }
-                        }
-                        // Not supporting coding for now as it would require validating terminology which not yet supported.
-                        "code" | _ => {}
-                    }
-                }
-            } else {
-                return Err(OperationOutcomeError::error(
-                    IssueType::invalid(),
-                    "Slice value element definition must have either a fixed value or a pattern for value discriminator".to_string(),
-                ));
-            }
-
-            return Ok(false);
+            is_conformant_to_value_discriminator(&values, slice_value_element_definition)
         }
         discriminator_type if discriminator_type == &DiscriminatorType::null() => {
             Err(OperationOutcomeError::error(
@@ -395,14 +286,134 @@ async fn is_conformant_to_slice_descriptor(
     }
 }
 
+fn is_conformant_to_pattern_discriminator(
+    values: &[&dyn MetaValue],
+    element: &ElementDefinition,
+) -> Result<bool, OperationOutcomeError> {
+    let pattern = element.pattern.as_ref().ok_or_else(|| {
+        OperationOutcomeError::error(
+            IssueType::invalid(),
+            "Slice value element definition must have a pattern for pattern discriminator"
+                .to_string(),
+        )
+    })?;
+
+    for value in values {
+        if validate_pattern(*value, pattern)? {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn is_conformant_to_type_discriminator(
+    values: &[&dyn MetaValue],
+    element: &ElementDefinition,
+) -> Result<bool, OperationOutcomeError> {
+    let expected_types = element.type_.as_ref().ok_or_else(|| {
+        OperationOutcomeError::error(
+            IssueType::invalid(),
+            "Slice value element definition must have types for type discriminator".to_string(),
+        )
+    })?;
+
+    let types = values
+        .iter()
+        .map(|value| value.fhir_type())
+        .collect::<HashSet<_>>();
+
+    let result = expected_types.iter().find(|type_| {
+        if let Some(type_name) = type_.code.value.as_deref() {
+            types.contains(type_name)
+        } else {
+            false
+        }
+    });
+
+    Ok(result.is_some())
+}
+
+fn is_conformant_to_value_discriminator(
+    values: &[&dyn MetaValue],
+    element: &ElementDefinition,
+) -> Result<bool, OperationOutcomeError> {
+    if let Some(fixed_value) = element.fixed.as_ref() {
+        for value in values {
+            if is_equal(*value, fixed_value)? {
+                return Ok(true);
+            }
+        }
+
+        return Ok(false);
+    }
+
+    if let Some(pattern) = element.pattern.as_ref() {
+        for value in values {
+            if validate_pattern(*value, pattern)? {
+                return Ok(true);
+            }
+        }
+
+        return Ok(false);
+    }
+
+    if let Some(binding) = element.binding.as_ref() {
+        let value_set = binding
+            .valueSet
+            .as_ref()
+            .and_then(|vs| vs.value.as_ref())
+            .and_then(|s| s.split('|').next());
+
+        let coding_pattern = Coding {
+            system: value_set.map(|s| {
+                Box::new(FHIRUri {
+                    value: Some(s.to_string()),
+                    ..Default::default()
+                })
+            }),
+            ..Default::default()
+        };
+
+        let codeable_concept_pattern = CodeableConcept {
+            coding: Some(vec![coding_pattern.clone()]),
+            ..Default::default()
+        };
+
+        for value in values {
+            match value.fhir_type() {
+                "Coding" => {
+                    if validate_pattern(*value, &coding_pattern)? {
+                        return Ok(true);
+                    }
+                }
+                "CodeableConcept" if validate_pattern(*value, &codeable_concept_pattern)? => {
+                    return Ok(true);
+                }
+                // Not supporting coding for now as it would require validating
+                // terminology which is not yet supported.
+                _ => {}
+            }
+        }
+
+        return Ok(false);
+    }
+
+    Err(OperationOutcomeError::error(
+        IssueType::invalid(),
+        "Slice value element definition must have either a fixed value or a pattern for value discriminator"
+            .to_string(),
+    ))
+}
+
 #[derive(Debug)]
 struct SplitSlicing(HashMap<usize, Vec<Path>>);
 
-async fn is_conformant_to_discriminators<'a>(
-    ctx: Arc<FHIRProfileCTX<'a, impl CanonicalResolver>>,
+async fn is_conformant_to_discriminators(
+    ctx: Arc<FHIRProfileCTX<'_, impl CanonicalResolver>>,
     slice_index: &usize,
-    discriminators: &Vec<ElementDefinitionSlicingDiscriminator>,
-    discriminator_element_paths: &Vec<String>,
+    discriminators: &[ElementDefinitionSlicingDiscriminator],
+    discriminator_element_paths: &[String],
     parent_path: Option<&str>,
     loc: &Path,
 ) -> Result<bool, OperationOutcomeError> {
@@ -422,11 +433,7 @@ async fn is_conformant_to_discriminators<'a>(
                 IssueType::invalid(),
                 format!(
                     "'{}' Failed to find element definition for discriminator path '{}'",
-                    ctx.profile()
-                        .id
-                        .as_ref()
-                        .map(|s| s.as_str())
-                        .unwrap_or("unknown"),
+                    ctx.profile().id.as_deref().unwrap_or("unknown"),
                     discriminator_element_path
                 ),
             ));
@@ -439,7 +446,7 @@ async fn is_conformant_to_discriminators<'a>(
                 slice_descriminator_value_definition.discriminator_element_index,
             )?,
             ctx.root,
-            &loc,
+            loc,
         )
         .await?
         {
@@ -451,8 +458,8 @@ async fn is_conformant_to_discriminators<'a>(
 }
 
 /// Splits the given values into slices according to the discriminator.
-async fn split_slicing<'a>(
-    ctx: Arc<FHIRProfileCTX<'a, impl CanonicalResolver>>,
+async fn split_slicing(
+    ctx: Arc<FHIRProfileCTX<'_, impl CanonicalResolver>>,
     slicing_descriptor: &SlicingDescriptor,
     mut locs: Vec<Path>,
 ) -> Result<SplitSlicing, OperationOutcomeError> {
@@ -476,8 +483,7 @@ async fn split_slicing<'a>(
     let parent_path = discriminator_element_definition
         .path
         .value
-        .as_ref()
-        .map(|s| s.as_str())
+        .as_deref()
         .and_then(utilities::ascend_element_path)
         .map(utilities::remove_type_on_path);
 
@@ -490,7 +496,7 @@ async fn split_slicing<'a>(
         let mut remainder_locs = vec![];
         let mut slice_locations = vec![];
 
-        for loc in locs.iter() {
+        for loc in &locs {
             if is_conformant_to_discriminators(
                 ctx.clone(),
                 slice_index,
@@ -514,10 +520,10 @@ async fn split_slicing<'a>(
     Ok(slices_split)
 }
 
-fn get_element<'a>(
-    profile: &'a StructureDefinition,
+fn get_element(
+    profile: &StructureDefinition,
     element_index: usize,
-) -> Result<&'a ElementDefinition, OperationOutcomeError> {
+) -> Result<&ElementDefinition, OperationOutcomeError> {
     let element = profile
         .snapshot
         .as_ref()
@@ -525,7 +531,7 @@ fn get_element<'a>(
         .ok_or_else(|| {
             OperationOutcomeError::error(
                 IssueType::exception(),
-                format!("Invalid slicing discriminator index: {}", element_index),
+                format!("Invalid slicing discriminator index: {element_index}"),
             )
         })?;
 
@@ -535,21 +541,21 @@ fn get_element<'a>(
 fn validate_slice_cardinality(
     profile: &StructureDefinition,
     slice_element_definition: &ElementDefinition,
-    slice_locs: &Vec<Path>,
-) -> Result<Vec<OperationOutcomeIssue>, OperationOutcomeError> {
+    slice_locs: &[Path],
+) -> Vec<OperationOutcomeIssue> {
     let (min, max) = cardinality(slice_element_definition);
 
-    let mut issues = vec![];
+    let mut issues = Vec::new();
 
-    if slice_locs.len() < min as usize {
+    if (slice_locs.len() as u64) < min {
         issues.push(outcome_issue(
             slice_locs.first().unwrap_or(&Path::new()),
             IssueSeverity::error(),
             IssueType::value(),
             format!(
                  "Profile: '{}' Element: '{}' Minimum number of required values not met expected at least '{}', found '{}'",
-                profile.id.as_ref().map(|s| s.as_str()).unwrap_or("unknown"),
-                slice_element_definition.id.as_ref().map(|s| s.as_str()).unwrap_or("unknown"),
+                profile.id.as_deref().unwrap_or("unknown"),
+                slice_element_definition.id.as_deref().unwrap_or("unknown"),
                 min,
                 slice_locs.len()
             ),
@@ -558,7 +564,7 @@ fn validate_slice_cardinality(
 
     match max {
         Max::Fixed(fixed_max) => {
-            if slice_locs.len() > fixed_max as usize {
+            if (slice_locs.len() as u64) > fixed_max {
                 issues.push(outcome_issue(
                     slice_locs.first().unwrap_or(&Path::new()),
                     IssueSeverity::error(),
@@ -575,28 +581,28 @@ fn validate_slice_cardinality(
         Max::Unlimited => {}
     }
 
-    Ok(issues)
+    issues
 }
 
-pub async fn validate_slicing_descriptor<'a>(
-    ctx: Arc<FHIRProfileCTX<'a, impl CanonicalResolver>>,
+pub async fn validate_slicing_descriptor(
+    ctx: Arc<FHIRProfileCTX<'_, impl CanonicalResolver>>,
     slicing_descriptor: &SlicingDescriptor,
     value_path: &Path,
 ) -> Result<Vec<OperationOutcomeIssue>, OperationOutcomeError> {
     let profile = ctx.profile();
     let discriminator_element = get_element(profile, slicing_descriptor.discriminator)?;
-    let all_slice_locs = get_slice_value_locs(ctx.clone(), discriminator_element, value_path)?;
+    let all_slice_locs = get_slice_value_locs(&ctx, discriminator_element, value_path);
 
     let split_slices = split_slicing(ctx.clone(), slicing_descriptor, all_slice_locs).await?;
 
-    let mut issues = vec![];
+    let mut issues = Vec::new();
     let elements_pointer = Path::new().descend("snapshot").descend("element");
 
-    for slice in slicing_descriptor.slices.iter() {
+    for slice in &slicing_descriptor.slices {
         let slice_locs = split_slices.0.get(slice).ok_or_else(|| {
             OperationOutcomeError::error(
                 IssueType::exception(),
-                format!("Missing slice locations for slice index: {}", slice),
+                format!("Missing slice locations for slice index: {slice}"),
             )
         })?;
 
@@ -606,13 +612,13 @@ pub async fn validate_slicing_descriptor<'a>(
             profile,
             slice_element_definition,
             slice_locs,
-        )?);
+        ));
 
-        for slice_loc in slice_locs.iter() {
+        for slice_loc in slice_locs {
             issues.extend(
                 validate_singular_element(
                     ctx.clone(),
-                    &elements_pointer.descend(&format!("{}", slice)),
+                    &elements_pointer.descend(&slice.to_string()),
                     slice_loc,
                 )
                 .await?,

--- a/backend/crates/fhir-profiling/src/utilities.rs
+++ b/backend/crates/fhir-profiling/src/utilities.rs
@@ -5,11 +5,10 @@ use haste_fhir_model::r4::generated::{
 use haste_fhir_operation_error::OperationOutcomeError;
 
 /// Various utilities for working with FHIR profiles.
-
 pub fn remove_type_on_path(path: &str) -> &str {
     let first_dot = path.find('.');
     // If first element this would be the entire path as no subfield.
-    &path[first_dot.map(|i| i + 1).unwrap_or(path.len())..]
+    &path[first_dot.map_or(path.len(), |i| i + 1)..]
 }
 
 // Removes the last element on the path, returning the parent path. If there is no parent, returns None.
@@ -40,10 +39,7 @@ pub fn convert_discriminator_to_path(
     {
         return Err(OperationOutcomeError::error(
             IssueType::not_supported(),
-            format!(
-                "Discriminator path '{}' is not supported",
-                discriminator_path
-            ),
+            format!("Discriminator path '{discriminator_path}' is not supported"),
         ));
     }
 
@@ -53,7 +49,7 @@ pub fn convert_discriminator_to_path(
     if path.is_empty() {
         Ok(parent_path.to_string())
     } else {
-        Ok(format!("{}.{}", parent_path, path))
+        Ok(format!("{parent_path}.{path}"))
     }
 }
 
@@ -63,6 +59,6 @@ pub fn join_paths(parent: &str, child: &str) -> String {
     } else if child.is_empty() {
         parent.to_string()
     } else {
-        format!("{}.{}", parent, child)
+        format!("{parent}.{child}")
     }
 }

--- a/backend/crates/fhir-profiling/src/validators/cardinality.rs
+++ b/backend/crates/fhir-profiling/src/validators/cardinality.rs
@@ -12,11 +12,11 @@ use haste_reflect::MetaValue;
 
 use crate::{FHIRProfileCTX, element::outcome_issue};
 
-fn _validate_cardinality(
+fn run_validate_cardinality(
     element: &ElementDefinition,
     value_location: &Path,
-    value_cardinality: usize,
-    (min, max): (usize, Option<&str>),
+    value_cardinality: u64,
+    (min, max): (u64, Option<&str>),
 ) -> Result<Vec<OperationOutcomeIssue>, OperationOutcomeError> {
     if value_cardinality < min {
         return Ok(vec![outcome_issue(
@@ -24,37 +24,33 @@ fn _validate_cardinality(
             IssueSeverity::error(),
             IssueType::required(),
             format!(
-                "Element: '{}' Minimum number of required values not met expected at least '{}', found '{}'",
-                element.id.as_ref().map(|s| s.as_str()).unwrap_or("unknown"),
-                min,
-                value_cardinality
+                "Element: '{}' Minimum number of required values not met expected at least '{min}', found '{value_cardinality}'",
+                element.id.as_deref().unwrap_or("unknown"),
             ),
         )]);
     }
 
     match max {
         // "*" means unbounded upper cardinality.
-        None | Some("*") => Ok(vec![]),
+        None | Some("*") => Ok(Vec::new()),
         Some(max) => {
-            let Ok(max) = max.parse::<usize>() else {
+            let Ok(max) = max.parse::<u64>() else {
                 return Err(OperationOutcomeError::error(
                     IssueType::exception(),
-                    format!("Invalid max cardinality: {}", max),
+                    format!("Invalid max cardinality: {max}"),
                 ));
             };
 
             if value_cardinality <= max {
-                Ok(vec![])
+                Ok(Vec::new())
             } else {
                 Ok(vec![outcome_issue(
                     value_location,
                     IssueSeverity::error(),
                     IssueType::required(),
                     format!(
-                        "Element: '{}' Too many values: expected at most '{}', found '{}'",
-                        element.id.as_ref().map(|s| s.as_str()).unwrap_or("unknown"),
-                        max,
-                        value_cardinality
+                        "Element: '{}' Too many values: expected at most '{max}', found '{value_cardinality}'",
+                        element.id.as_deref().unwrap_or("unknown"),
                     ),
                 )])
             }
@@ -66,26 +62,23 @@ pub fn validate_cardinality<'a>(
     _ctx: Arc<FHIRProfileCTX<'a, impl CanonicalResolver>>,
     value_location: &Path,
     element: &ElementDefinition,
-    value: &Option<&'a dyn MetaValue>,
+    value: Option<&'a dyn MetaValue>,
 ) -> Result<Vec<OperationOutcomeIssue>, OperationOutcomeError> {
     let element_cardinalities = (
-        element.min.as_ref().and_then(|v| v.value).unwrap_or(0) as usize,
-        element
-            .max
-            .as_ref()
-            .and_then(|v| v.value.as_ref().map(|s| s.as_str())),
+        element.min.as_ref().and_then(|v| v.value).unwrap_or(0),
+        element.max.as_ref().and_then(|v| v.value.as_deref()),
     );
 
     match value {
         Some(v) => {
-            let value_cardinality = v.flatten().len();
-            _validate_cardinality(
+            let value_cardinality = v.flatten().len() as u64;
+            run_validate_cardinality(
                 element,
                 value_location,
                 value_cardinality,
                 element_cardinalities,
             )
         }
-        None => _validate_cardinality(element, value_location, 0, element_cardinalities),
+        None => run_validate_cardinality(element, value_location, 0, element_cardinalities),
     }
 }

--- a/backend/crates/fhir-profiling/src/validators/fixed_value.rs
+++ b/backend/crates/fhir-profiling/src/validators/fixed_value.rs
@@ -9,39 +9,38 @@ use crate::validators::utilities;
 pub fn is_equal(v1: &dyn MetaValue, v2: &dyn MetaValue) -> Result<bool, OperationOutcomeError> {
     if PRIMITIVE_TYPES.contains(v1.fhir_type()) {
         return Ok(utilities::primitive_conversion(v1)? == utilities::primitive_conversion(v2)?);
-    } else {
-        if v1.fhir_type() != v2.fhir_type() {
-            return Ok(false);
-        }
-        for key in v1.fields() {
-            let v1 = v1.get_field(key);
-            let v2 = v2.get_field(key);
+    }
+    if v1.fhir_type() != v2.fhir_type() {
+        return Ok(false);
+    }
+    for key in v1.fields() {
+        let v1 = v1.get_field(key);
+        let v2 = v2.get_field(key);
 
-            if let Some(v1) = v1
-                && let Some(v2) = v2
-            {
-                let v1_values = v1.flatten();
-                let v2_values = v2.flatten();
+        if let Some(v1) = v1
+            && let Some(v2) = v2
+        {
+            let v1_values = v1.flatten();
+            let v2_values = v2.flatten();
 
-                // Could be an array so flatten the values and confirm length than iterate over them.
-                if v1_values.len() != v2_values.len() {
-                    return Ok(false);
-                }
-                for (v1_value, v2_value) in v1_values.iter().zip(v2_values.iter()) {
-                    if !is_equal(*v1_value, *v2_value)? {
-                        return Ok(false);
-                    }
-                }
-            } else {
-                // If one of the values is none verify that both are none in this case.
-                if v1.is_some() != v2.is_some() {
+            // Could be an array so flatten the values and confirm length than iterate over them.
+            if v1_values.len() != v2_values.len() {
+                return Ok(false);
+            }
+            for (v1_value, v2_value) in v1_values.iter().zip(v2_values.iter()) {
+                if !is_equal(*v1_value, *v2_value)? {
                     return Ok(false);
                 }
             }
+        } else {
+            // If one of the values is none verify that both are none in this case.
+            if v1.is_some() != v2.is_some() {
+                return Ok(false);
+            }
         }
-
-        Ok(true)
     }
+
+    Ok(true)
 }
 
 #[cfg(test)]

--- a/backend/crates/fhir-profiling/src/validators/pattern.rs
+++ b/backend/crates/fhir-profiling/src/validators/pattern.rs
@@ -13,10 +13,10 @@ pub fn validate_pattern(
 
     let pattern_fields = pattern.fields();
 
-    if pattern_fields.len() == 0 {
+    if pattern_fields.is_empty() {
         utilities::check_bare_primitive_pattern(value, pattern)
     } else {
-        for key in pattern_fields.iter() {
+        for key in &pattern_fields {
             if let Some(pattern_value) = pattern.get_field(key) {
                 let Some(data_value) = value.get_field(key) else {
                     return Ok(false);
@@ -29,7 +29,7 @@ pub fn validate_pattern(
                     return Ok(false);
                 }
 
-                for pattern_value in pattern_values.iter() {
+                for pattern_value in &pattern_values {
                     let found = values
                         .iter()
                         .find(|v| validate_pattern(**v, *pattern_value).unwrap_or(false));

--- a/backend/crates/fhir-profiling/src/validators/utilities.rs
+++ b/backend/crates/fhir-profiling/src/validators/utilities.rs
@@ -9,19 +9,14 @@ use haste_fhir_model::r4::{
 use haste_fhir_operation_error::OperationOutcomeError;
 use haste_reflect::MetaValue;
 
-/**
- * 067  public static final String FP_String = "http://hl7.org/fhirpath/System.String";
- * 068  public static final String FP_Boolean = "http://hl7.org/fhirpath/System.Boolean";
- * 069  public static final String FP_Integer = "http://hl7.org/fhirpath/System.Integer";
- * 070  public static final String FP_Decimal = "http://hl7.org/fhirpath/System.Decimal";
- * 071  public static final String FP_Quantity = "http://hl7.org/fhirpath/System.Quantity";
- * 072  public static final String FP_DateTime = "http://hl7.org/fhirpath/System.DateTime";
- * 073  public static final String FP_Time = "http://hl7.org/fhirpath/System.Time";
- */
-
-fn downcast_meta_value<'a, T: 'static>(
-    value: &'a dyn MetaValue,
-) -> Result<&'a T, OperationOutcomeError> {
+/// 067  public static final String `FP_String` = <http://hl7.org/fhirpath/System.String>;
+/// 068  public static final String `FP_Boolean` = <http://hl7.org/fhirpath/System.Boolean>;
+/// 069  public static final String `FP_Integer` = <http://hl7.org/fhirpath/System.Integer>;
+/// 070  public static final String `FP_Decimal` = <http://hl7.org/fhirpath/System.Decimal>;
+/// 071  public static final String `FP_Quantity` = <http://hl7.org/fhirpath/System.Quantity>;
+/// 072  public static final String `FP_DateTime` = <http://hl7.org/fhirpath/System.DateTime>;
+/// 073  public static final String `FP_Time` = <http://hl7.org/fhirpath/System.Time>;
+fn downcast_meta_value<T: 'static>(value: &dyn MetaValue) -> Result<&T, OperationOutcomeError> {
     value.as_any().downcast_ref::<T>().ok_or_else(|| {
         OperationOutcomeError::fatal(
             IssueType::invalid(),
@@ -47,7 +42,7 @@ pub fn primitive_conversion(
                 |e| {
                     OperationOutcomeError::fatal(
                         IssueType::invalid(),
-                        format!("Failed to downcast value to string: {}", e),
+                        format!("Failed to downcast value to string: {e}"),
                     )
                 },
             )?)))
@@ -56,7 +51,7 @@ pub fn primitive_conversion(
                 |e| {
                     OperationOutcomeError::fatal(
                         IssueType::invalid(),
-                        format!("Failed to downcast value to number: {}", e),
+                        format!("Failed to downcast value to number: {e}"),
                     )
                 },
             )?)))
@@ -65,7 +60,7 @@ pub fn primitive_conversion(
                 |e| {
                     OperationOutcomeError::fatal(
                         IssueType::invalid(),
-                        format!("Failed to downcast value to boolean: {}", e),
+                        format!("Failed to downcast value to boolean: {e}"),
                     )
                 },
             )?)))
@@ -74,14 +69,14 @@ pub fn primitive_conversion(
                 |e| {
                     OperationOutcomeError::fatal(
                         IssueType::invalid(),
-                        format!("Failed to downcast value to string: {}", e),
+                        format!("Failed to downcast value to string: {e}"),
                     )
                 },
             )?)))
         } else {
             Err(OperationOutcomeError::fatal(
                 IssueType::invalid(),
-                format!("Unsupported primitive type: {}", type_name),
+                format!("Unsupported primitive type: {type_name}"),
             ))
         }
     } else {
@@ -111,14 +106,16 @@ pub fn check_bare_primitive_pattern(
             Ok(pattern_boolean == value_boolean)
         }
         "http://hl7.org/fhirpath/System.Integer" => {
-            let pattern_integer = match pattern.type_id() == std::any::TypeId::of::<i64>() {
-                true => *(downcast_meta_value::<i64>(pattern)?),
-                false => *(downcast_meta_value::<u64>(pattern)?) as i64,
+            let pattern_integer = if pattern.type_id() == std::any::TypeId::of::<i64>() {
+                *(downcast_meta_value::<i64>(pattern)?)
+            } else {
+                (*(downcast_meta_value::<u64>(pattern)?)).cast_signed()
             };
 
-            let value_integer = match data_to_check.type_id() == std::any::TypeId::of::<i64>() {
-                true => *(downcast_meta_value::<i64>(data_to_check)?),
-                false => *(downcast_meta_value::<u64>(data_to_check)?) as i64,
+            let value_integer = if data_to_check.type_id() == std::any::TypeId::of::<i64>() {
+                *(downcast_meta_value::<i64>(data_to_check)?)
+            } else {
+                (*(downcast_meta_value::<u64>(data_to_check)?)).cast_signed()
             };
 
             Ok(pattern_integer == value_integer)
@@ -128,7 +125,8 @@ pub fn check_bare_primitive_pattern(
             let Ok(value_decimal) = downcast_meta_value::<f64>(data_to_check) else {
                 return Ok(false);
             };
-            Ok(pattern_decimal == value_decimal)
+
+            Ok((pattern_decimal - value_decimal).abs() < f64::EPSILON)
         }
 
         "http://hl7.org/fhirpath/System.Date" => {


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.