### PR TITLE
Resolve missing `clippy` lints for some crates (2/2)

### DIFF
--- a/backend/crates/hl7v2/benches/hl7v2_serialization_bench.rs
+++ b/backend/crates/hl7v2/benches/hl7v2_serialization_bench.rs
@@ -6,17 +6,16 @@ fn hl7_single_message_parse(c: &mut Criterion) {
 
     c.bench_function("simple message", |b| {
         b.iter(|| {
-            let _message = ParsedHL7V2Message::try_from(hl7v2_message);
-            _message.expect("Failed to parse HL7v2 message");
-        })
+            ParsedHL7V2Message::try_from(hl7v2_message).expect("Failed to parse HL7v2 message");
+        });
     });
 
     c.bench_function("simple message round trip", |b| {
         b.iter(|| {
             let message =
                 ParsedHL7V2Message::try_from(hl7v2_message).expect("Failed to parse HL7v2 message");
-            let _message: String = (SerializeMessage(&message.0)).into();
-        })
+            let _ = std::convert::Into::<SerializeMessage<'_>>::into(SerializeMessage(&message.0));
+        });
     });
 }
 

--- a/backend/crates/hl7v2/src/parser.rs
+++ b/backend/crates/hl7v2/src/parser.rs
@@ -199,7 +199,7 @@ mod tests {
 
         let message = result.unwrap();
         let json = serde_json::to_string_pretty(&message.0).unwrap();
-        println!("{}", json);
+        println!("{json}");
         let deserialized: HL7V2 = serde_json::from_str(&json).unwrap();
         let serialized: String = (SerializeMessage(&deserialized)).into();
 

--- a/backend/crates/jwt/src/scopes.rs
+++ b/backend/crates/jwt/src/scopes.rs
@@ -538,26 +538,17 @@ mod tests {
 
     #[test]
     fn invalid_order() {
-        assert_eq!(
-            Scopes::try_from("launch/encounter   system/Patient.duc").is_err(),
-            true
-        );
+        assert!(Scopes::try_from("launch/encounter   system/Patient.duc").is_err());
     }
 
     #[test]
     fn invalid_system() {
-        assert_eq!(
-            Scopes::try_from("launch/encounter   sytem/Patient.cud").is_err(),
-            true
-        );
+        assert!(Scopes::try_from("launch/encounter   sytem/Patient.cud").is_err());
     }
 
     #[test]
     fn unknown_scope() {
-        assert_eq!(
-            Scopes::try_from("badscope  sytem/Patient.cud").is_err(),
-            true
-        );
+        assert!(Scopes::try_from("badscope  sytem/Patient.cud").is_err());
     }
 
     #[test]

--- a/backend/crates/sd-to-json-schema/src/lib.rs
+++ b/backend/crates/sd-to-json-schema/src/lib.rs
@@ -423,21 +423,21 @@ mod test {
     fn test_sd_to_json_schema() {
         let patient_sd = RESOURCE_SDS
             .iter()
-            .find(|v| v.type_.value.as_ref().map(|s| s.as_str()) == Some("Patient"))
+            .find(|v| v.type_.value.as_deref() == Some("Patient"))
             .unwrap();
 
         let schema = self_contained_schema(&*FHIR_COMPLEX_TYPE_DEFINITIONS, patient_sd).unwrap();
 
         println!("{}", serde_json::to_string_pretty(&schema).unwrap());
 
-        assert_eq!(true, !serde_json::to_string(&schema).unwrap().is_empty());
+        assert!(!serde_json::to_string(&schema).unwrap().is_empty());
     }
 
     #[test]
     fn patient_sd_test() {
         let patient_sd = RESOURCE_SDS
             .iter()
-            .find(|v| v.type_.value.as_ref().map(|s| s.as_str()) == Some("Patient"))
+            .find(|v| v.type_.value.as_deref() == Some("Patient"))
             .unwrap();
 
         let schema = self_contained_schema(&*FHIR_COMPLEX_TYPE_DEFINITIONS, patient_sd).unwrap();
@@ -462,20 +462,20 @@ mod test {
 
         let mut patient_json = serde_json::from_str(&patient_data).unwrap();
         let result = jsonschema::validate(&schema, &patient_json);
-        assert_eq!(result.is_ok(), true);
+        assert!(result.is_ok());
 
         patient_json["name"][0]["_given"] = json!("This is not a valid value");
         let result = jsonschema::validate(&schema, &patient_json);
-        assert_eq!(result.is_err(), true);
+        assert!(result.is_err());
 
         patient_json["name"][0]["_given"] = json!([{"id": "1"}]);
         let result = jsonschema::validate(&schema, &patient_json);
-        println!("{:?}", result);
-        assert_eq!(result.is_ok(), true);
+        println!("{result:?}");
+        assert!(result.is_ok());
 
         patient_json["name"] = json!("This is not a valid value");
         let result = jsonschema::validate(&schema, &patient_json);
 
-        assert_eq!(result.is_err(), true);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Resolve other small `clippy` lints for `hl7v2`, `jwt`, and `sd-to-json-schema` crates