### PR TITLE
Resolve `clippy` lints for `openapi-schema-generator`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
           -p haste-hl7v2 \
           -p haste-jwt \
           -p haste-macro-loads \
+          -p haste-openapi-schema-generator \
           -p haste-pointer \
           -p haste-rate-limit \
           -p haste-reflect \

--- a/backend/crates/openapi-schema-generator/src/lib.rs
+++ b/backend/crates/openapi-schema-generator/src/lib.rs
@@ -75,103 +75,113 @@ pub struct OpenAPI {
     paths: OpenAPIPaths,
 }
 
+fn resource_schema(resource_name: &str) -> serde_json::Value {
+    json!({
+        "$ref": format!("#/components/schemas/{resource_name}")
+    })
+}
+
+fn operation_outcome_schema() -> serde_json::Value {
+    json!({
+        "$ref": "#/components/schemas/OperationOutcome"
+    })
+}
+
+fn json_content(schema: serde_json::Value) -> HashMap<String, serde_json::Value> {
+    HashMap::from([("application/json".to_string(), schema)])
+}
+
+fn response(
+    description: impl Into<String>,
+    content: Option<HashMap<String, serde_json::Value>>,
+) -> OpenAPIOperationContent {
+    OpenAPIOperationContent {
+        description: description.into(),
+        content,
+    }
+}
+
+fn resource_response(
+    resource_name: &str,
+    description: impl Into<String>,
+) -> OpenAPIOperationContent {
+    response(
+        description,
+        Some(json_content(json!({
+            "schema": resource_schema(resource_name)
+        }))),
+    )
+}
+
+fn operation_outcome_response(description: impl Into<String>) -> OpenAPIOperationContent {
+    response(
+        description,
+        Some(json_content(json!({
+            "schema": operation_outcome_schema()
+        }))),
+    )
+}
+
+fn id_parameter(resource_name: &str) -> serde_json::Value {
+    json!({
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+            "type": "string"
+        },
+        "description": format!("The ID of the {resource_name} resource")
+    })
+}
+
 fn read_resource_operation(resource_name: &str) -> OpenAPIOperation {
     OpenAPIOperation {
         request_body: None,
         responses: HashMap::from([
             (
                 "200".to_string(),
-                OpenAPIOperationContent {
-                    description: format!("Successful read of {resource_name} resource"),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
-                    )])),
-                },
+                resource_response(
+                    resource_name,
+                    format!("Successful read of {resource_name} resource"),
+                ),
             ),
             (
                 "400".to_string(),
-                OpenAPIOperationContent {
-                    description: "Client error".to_string(),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": "#/components/schemas/OperationOutcome" }}),
-                    )])),
-                },
+                operation_outcome_response("Client error"),
             ),
             (
                 "500".to_string(),
-                OpenAPIOperationContent {
-                    description: "Server error".to_string(),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": "#/components/schemas/OperationOutcome" }}),
-                    )])),
-                },
+                operation_outcome_response("Server error"),
             ),
         ]),
-        parameters: vec![json!({
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-                "type": "string"
-            },
-            "description": format!("The ID of the {resource_name} resource")
-        })],
+        parameters: vec![id_parameter(resource_name)],
     }
 }
 
 fn put_resource_operation(resource_name: &str) -> OpenAPIOperation {
     OpenAPIOperation {
-        request_body: Some(OpenAPIOperationContent {
-            description: format!("The {resource_name} resource to create or update"),
-            content: Some(HashMap::from([(
-                "application/json".to_string(),
-                json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
-            )])),
-        }),
+        request_body: Some(resource_response(
+            resource_name,
+            format!("The {resource_name} resource to create or update"),
+        )),
         responses: HashMap::from([
             (
                 "200".to_string(),
-                OpenAPIOperationContent {
-                    description: format!("Successful put/creation of {resource_name} resource"),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
-                    )])),
-                },
+                resource_response(
+                    resource_name,
+                    format!("Successful put/creation of {resource_name} resource"),
+                ),
             ),
             (
                 "400".to_string(),
-                OpenAPIOperationContent {
-                    description: "Client error".to_string(),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": "#/components/schemas/OperationOutcome" }}),
-                    )])),
-                },
+                operation_outcome_response("Client error"),
             ),
             (
                 "500".to_string(),
-                OpenAPIOperationContent {
-                    description: "Server error".to_string(),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": "#/components/schemas/OperationOutcome" }}),
-                    )])),
-                },
+                operation_outcome_response("Server error"),
             ),
         ]),
-        parameters: vec![json!({
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-                "type": "string"
-            },
-            "description": format!("The ID of the {resource_name} resource")
-        })],
+        parameters: vec![id_parameter(resource_name)],
     }
 }
 
@@ -181,31 +191,17 @@ fn delete_instance_operation(resource_name: &str) -> OpenAPIOperation {
         responses: HashMap::from([
             (
                 "200".to_string(),
-                OpenAPIOperationContent {
-                    description: format!("Successful deletion of {resource_name} resource"),
-                    content: None,
-                },
+                response(
+                    format!("Successful deletion of {resource_name} resource"),
+                    None,
+                ),
             ),
             (
                 "400".to_string(),
-                OpenAPIOperationContent {
-                    description: "Client error".to_string(),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": "#/components/schemas/OperationOutcome" }}),
-                    )])),
-                },
+                operation_outcome_response("Client error"),
             ),
         ]),
-        parameters: vec![json!({
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-                "type": "string"
-            },
-            "description": format!("The ID of the {resource_name} resource")
-        })],
+        parameters: vec![id_parameter(resource_name)],
     }
 }
 
@@ -213,108 +209,46 @@ fn patch_resource_operation(resource_name: &str) -> OpenAPIOperation {
     OpenAPIOperation {
         request_body: Some(OpenAPIOperationContent {
             description: format!("JSON Patch operation for {resource_name} resource."),
-            content: Some(HashMap::from([(
-                "application/json".to_string(),
-                json!({ "schema": {"type": "array" }}),
-            )])),
+            content: Some(json_content(json!({
+                "schema": {
+                    "type": "array"
+                }
+            }))),
         }),
         responses: HashMap::from([
             (
                 "200".to_string(),
-                OpenAPIOperationContent {
-                    description: format!("Successful patch of {resource_name} resource"),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
-                    )])),
-                },
+                resource_response(
+                    resource_name,
+                    format!("Successful patch of {resource_name} resource"),
+                ),
             ),
             (
                 "400".to_string(),
-                OpenAPIOperationContent {
-                    description: "Client error".to_string(),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": "#/components/schemas/OperationOutcome" }}),
-                    )])),
-                },
+                operation_outcome_response("Client error"),
             ),
         ]),
-        parameters: vec![json!({
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-                "type": "string"
-            },
-            "description": format!("The ID of the {resource_name} resource")
-        })],
+        parameters: vec![id_parameter(resource_name)],
     }
-}
-
-fn resource_search_parameters_schema(
-    resource_name: &str,
-    search_parameters: &[SearchParameter],
-) -> Vec<serde_json::Value> {
-    let mut params = vec![];
-
-    for sp in search_parameters.iter().filter(|sp| {
-        sp.base.iter().any(|b| {
-            let base = b.as_str();
-            base == Some(resource_name)
-                || base == Some("Resource")
-                || base == Some("DomainResource")
-        }) && sp.type_ != SearchParamType::composite()
-    }) {
-        let search_type = if sp.type_ == SearchParamType::number() {
-            "number"
-        } else {
-            "string"
-        };
-
-        params.push(json!({
-            "name": sp.code.value,
-            "in": "query",
-            "required": false,
-            "schema": {
-                "type": search_type
-            },
-            "description": sp.description.value.as_deref().unwrap_or_default()
-        }));
-    }
-
-    params
 }
 
 fn create_resource_operation(resource_name: &str) -> OpenAPIOperation {
     OpenAPIOperation {
-        request_body: Some(OpenAPIOperationContent {
-            description: format!("The {resource_name} resource to create"),
-            content: Some(HashMap::from([(
-                "application/json".to_string(),
-                json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
-            )])),
-        }),
+        request_body: Some(resource_response(
+            resource_name,
+            format!("The {resource_name} resource to create"),
+        )),
         responses: HashMap::from([
             (
                 "200".to_string(),
-                OpenAPIOperationContent {
-                    description: format!("Successful creation of {resource_name} resource"),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
-                    )])),
-                },
+                resource_response(
+                    resource_name,
+                    format!("Successful creation of {resource_name} resource"),
+                ),
             ),
             (
                 "400".to_string(),
-                OpenAPIOperationContent {
-                    description: "Client error".to_string(),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": "#/components/schemas/OperationOutcome" }}),
-                    )])),
-                },
+                operation_outcome_response("Client error"),
             ),
         ]),
         parameters: vec![],
@@ -330,25 +264,18 @@ fn search_resource_operation(
         responses: HashMap::from([
             (
                 "200".to_string(),
-                OpenAPIOperationContent {
-                    description: "Successful search operation".to_string(),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": haste_sd_to_json_schema::bundle_of_resource(&json!({
+                response(
+                    "Successful search operation",
+                    Some(json_content(json!({
+                        "schema": haste_sd_to_json_schema::bundle_of_resource(&json!({
                             "$ref": format!("#/components/schemas/{resource_name}")
-                        })) }),
-                    )])),
-                },
+                        }))
+                    }))),
+                ),
             ),
             (
                 "400".to_string(),
-                OpenAPIOperationContent {
-                    description: "Client error".to_string(),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": "#/components/schemas/OperationOutcome" }}),
-                    )])),
-                },
+                operation_outcome_response("Client error"),
             ),
         ]),
         parameters,
@@ -361,24 +288,50 @@ fn delete_resource_operation(parameters: Vec<serde_json::Value>) -> OpenAPIOpera
         responses: HashMap::from([
             (
                 "200".to_string(),
-                OpenAPIOperationContent {
-                    description: "Successful delete operation".to_string(),
-                    content: None,
-                },
+                response("Successful delete operation", None),
             ),
             (
                 "400".to_string(),
-                OpenAPIOperationContent {
-                    description: "Client error".to_string(),
-                    content: Some(HashMap::from([(
-                        "application/json".to_string(),
-                        json!({ "schema": {"$ref": "#/components/schemas/OperationOutcome" }}),
-                    )])),
-                },
+                operation_outcome_response("Client error"),
             ),
         ]),
         parameters,
     }
+}
+
+fn resource_search_parameters_schema(
+    resource_name: &str,
+    search_parameters: &[SearchParameter],
+) -> Vec<serde_json::Value> {
+    search_parameters
+        .iter()
+        .filter(|sp| {
+            sp.base.iter().any(|b| {
+                let base = b.as_str();
+
+                base == Some(resource_name)
+                    || base == Some("Resource")
+                    || base == Some("DomainResource")
+            }) && sp.type_ != SearchParamType::composite()
+        })
+        .map(|sp| {
+            let search_type = if sp.type_ == SearchParamType::number() {
+                "number"
+            } else {
+                "string"
+            };
+
+            json!({
+                "name": sp.code.value,
+                "in": "query",
+                "required": false,
+                "schema": {
+                    "type": search_type
+                },
+                "description": sp.description.value.as_deref().unwrap_or_default()
+            })
+        })
+        .collect()
 }
 
 /// Generates an [`OpenAPI`] document containing only the FHIR resources supported by the server.

--- a/backend/crates/openapi-schema-generator/src/lib.rs
+++ b/backend/crates/openapi-schema-generator/src/lib.rs
@@ -82,10 +82,10 @@ fn read_resource_operation(resource_name: &str) -> OpenAPIOperation {
             (
                 "200".to_string(),
                 OpenAPIOperationContent {
-                    description: format!("Successful read of {} resource", resource_name),
+                    description: format!("Successful read of {resource_name} resource"),
                     content: Some(HashMap::from([(
                         "application/json".to_string(),
-                        json!({ "schema": {"$ref": format!("#/components/schemas/{}", resource_name) }}),
+                        json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
                     )])),
                 },
             ),
@@ -117,7 +117,7 @@ fn read_resource_operation(resource_name: &str) -> OpenAPIOperation {
             "schema": {
                 "type": "string"
             },
-            "description": format!("The ID of the {} resource", resource_name)
+            "description": format!("The ID of the {resource_name} resource")
         })],
     }
 }
@@ -125,20 +125,20 @@ fn read_resource_operation(resource_name: &str) -> OpenAPIOperation {
 fn put_resource_operation(resource_name: &str) -> OpenAPIOperation {
     OpenAPIOperation {
         request_body: Some(OpenAPIOperationContent {
-            description: format!("The {} resource to create or update", resource_name),
+            description: format!("The {resource_name} resource to create or update"),
             content: Some(HashMap::from([(
                 "application/json".to_string(),
-                json!({ "schema": {"$ref": format!("#/components/schemas/{}", resource_name) }}),
+                json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
             )])),
         }),
         responses: HashMap::from([
             (
                 "200".to_string(),
                 OpenAPIOperationContent {
-                    description: format!("Successful put/creation of {} resource", resource_name),
+                    description: format!("Successful put/creation of {resource_name} resource"),
                     content: Some(HashMap::from([(
                         "application/json".to_string(),
-                        json!({ "schema": {"$ref": format!("#/components/schemas/{}", resource_name) }}),
+                        json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
                     )])),
                 },
             ),
@@ -170,7 +170,7 @@ fn put_resource_operation(resource_name: &str) -> OpenAPIOperation {
             "schema": {
                 "type": "string"
             },
-            "description": format!("The ID of the {} resource", resource_name)
+            "description": format!("The ID of the {resource_name} resource")
         })],
     }
 }
@@ -182,7 +182,7 @@ fn delete_instance_operation(resource_name: &str) -> OpenAPIOperation {
             (
                 "200".to_string(),
                 OpenAPIOperationContent {
-                    description: format!("Successful deletion of {} resource", resource_name),
+                    description: format!("Successful deletion of {resource_name} resource"),
                     content: None,
                 },
             ),
@@ -204,7 +204,7 @@ fn delete_instance_operation(resource_name: &str) -> OpenAPIOperation {
             "schema": {
                 "type": "string"
             },
-            "description": format!("The ID of the {} resource", resource_name)
+            "description": format!("The ID of the {resource_name} resource")
         })],
     }
 }
@@ -212,7 +212,7 @@ fn delete_instance_operation(resource_name: &str) -> OpenAPIOperation {
 fn patch_resource_operation(resource_name: &str) -> OpenAPIOperation {
     OpenAPIOperation {
         request_body: Some(OpenAPIOperationContent {
-            description: format!("JSON Patch operation for {} resource.", resource_name),
+            description: format!("JSON Patch operation for {resource_name} resource."),
             content: Some(HashMap::from([(
                 "application/json".to_string(),
                 json!({ "schema": {"type": "array" }}),
@@ -222,10 +222,10 @@ fn patch_resource_operation(resource_name: &str) -> OpenAPIOperation {
             (
                 "200".to_string(),
                 OpenAPIOperationContent {
-                    description: format!("Successful patch of {} resource", resource_name),
+                    description: format!("Successful patch of {resource_name} resource"),
                     content: Some(HashMap::from([(
                         "application/json".to_string(),
-                        json!({ "schema": {"$ref": format!("#/components/schemas/{}", resource_name) }}),
+                        json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
                     )])),
                 },
             ),
@@ -247,7 +247,7 @@ fn patch_resource_operation(resource_name: &str) -> OpenAPIOperation {
             "schema": {
                 "type": "string"
             },
-            "description": format!("The ID of the {} resource", resource_name)
+            "description": format!("The ID of the {resource_name} resource")
         })],
     }
 }
@@ -279,7 +279,7 @@ fn resource_search_parameters_schema(
             "schema": {
                 "type": search_type
             },
-            "description": sp.description.value.as_deref().unwrap_or("")
+            "description": sp.description.value.as_deref().unwrap_or_default()
         }));
     }
 
@@ -289,20 +289,20 @@ fn resource_search_parameters_schema(
 fn create_resource_operation(resource_name: &str) -> OpenAPIOperation {
     OpenAPIOperation {
         request_body: Some(OpenAPIOperationContent {
-            description: format!("The {} resource to create", resource_name),
+            description: format!("The {resource_name} resource to create"),
             content: Some(HashMap::from([(
                 "application/json".to_string(),
-                json!({ "schema": {"$ref": format!("#/components/schemas/{}", resource_name) }}),
+                json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
             )])),
         }),
         responses: HashMap::from([
             (
                 "200".to_string(),
                 OpenAPIOperationContent {
-                    description: format!("Successful creation of {} resource", resource_name),
+                    description: format!("Successful creation of {resource_name} resource"),
                     content: Some(HashMap::from([(
                         "application/json".to_string(),
-                        json!({ "schema": {"$ref": format!("#/components/schemas/{}", resource_name) }}),
+                        json!({ "schema": {"$ref": format!("#/components/schemas/{resource_name}") }}),
                     )])),
                 },
             ),
@@ -335,7 +335,7 @@ fn search_resource_operation(
                     content: Some(HashMap::from([(
                         "application/json".to_string(),
                         json!({ "schema": haste_sd_to_json_schema::bundle_of_resource(&json!({
-                            "$ref": format!("#/components/schemas/{}", resource_name)
+                            "$ref": format!("#/components/schemas/{resource_name}")
                         })) }),
                     )])),
                 },
@@ -381,29 +381,64 @@ fn delete_resource_operation(parameters: Vec<serde_json::Value>) -> OpenAPIOpera
     }
 }
 
-/// Generates an OpenAPI document filtered to only the supported resource types.
+/// Generates an [`OpenAPI`] document containing only the FHIR resources supported by the server.
 ///
-/// Resource and complex type schemas are both represented as external `$ref`s pointing to
-/// `{schema_base_url}/{TypeName}`, keeping the main document small - the schemas themselves
-/// are served on demand from a separate endpoint rather than embedded here.
+/// Resource and complex-type schemas are represented as external `$ref`s pointing to
+/// `{schema_base_url}/{TypeName}`. This keeps the generated document small while allowing
+/// individual schemas to be served on demand from a separate endpoint.
+///
+/// For each supported resource, the generated document includes endpoints for reading,
+/// creating, searching, updating, and deleting resources, as applicable.
 ///
 /// # Arguments
 ///
 /// * `server_root` - The root URL of the FHIR server.
-/// * `api_version` - The API version string.
-/// * `schema_base_url` - The base URL where individual resource schemas are served (e.g. `/schemas/fhir`).
-/// * `sds` - All available StructureDefinitions (resources + complex types).
-/// * `search_parameters` - All available SearchParameters.
-/// * `supported_resource_names` - The set of resource type names this server actually supports.
-pub fn open_api_schema_generator(
+/// * `api_version` - The version of the API represented by the generated document.
+/// * `schema_base_url` - The base URL from which individual FHIR schemas are served
+///   (e.g. `/schemas/fhir`).
+/// * `sds` - All available [`StructureDefinition`]s, including resource and complex-type
+///   definitions.
+/// * `search_parameters` - All available [`SearchParameter`]s used to generate resource
+///   search operations.
+/// * `supported_resource_names` - The set of FHIR resource type names supported by the
+///   server. Resource definitions not present in this set are excluded from the generated
+///   document.
+///
+/// # Errors
+///
+/// Returns an [`OperationOutcomeError`] if a supported resource
+/// [`StructureDefinition`] does not contain a type name.
+///
+/// # Returns
+///
+/// An [`OpenAPI`] document containing the server configuration, schemas, and paths for
+/// all supported resources and applicable complex types.
+pub fn open_api_schema_generator<S: std::hash::BuildHasher>(
     server_root: &str,
     api_version: &str,
     schema_base_url: &str,
     sds: &[StructureDefinition],
     search_parameters: &[SearchParameter],
-    supported_resource_names: &HashSet<String>,
+    supported_resource_names: &HashSet<String, S>,
 ) -> Result<OpenAPI, OperationOutcomeError> {
+    let mut openapi_schema = create_openapi_schema(server_root, api_version);
+
+    add_resource_schemas(
+        &mut openapi_schema,
+        sds,
+        search_parameters,
+        supported_resource_names,
+        schema_base_url,
+    )?;
+
+    add_complex_type_schemas(&mut openapi_schema, sds, schema_base_url);
+
+    Ok(openapi_schema)
+}
+
+fn create_openapi_schema(server_root: &str, api_version: &str) -> OpenAPI {
     let mut fhir_server_variables = HashMap::new();
+
     fhir_server_variables.insert(
         "tenant".to_string(),
         OpenAPIServerVariable {
@@ -411,6 +446,7 @@ pub fn open_api_schema_generator(
             description: Some("Tenant identifier".to_string()),
         },
     );
+
     fhir_server_variables.insert(
         "project".to_string(),
         OpenAPIServerVariable {
@@ -418,6 +454,7 @@ pub fn open_api_schema_generator(
             description: Some("Project identifier".to_string()),
         },
     );
+
     fhir_server_variables.insert(
         "fhir_version".to_string(),
         OpenAPIServerVariable {
@@ -425,7 +462,8 @@ pub fn open_api_schema_generator(
             description: Some("FHIR version".to_string()),
         },
     );
-    let mut openapi_schema = OpenAPI {
+
+    OpenAPI {
         openapi: "3.1.1".to_string(),
         servers: vec![OpenAPIServer {
             url: format!(
@@ -442,11 +480,17 @@ pub fn open_api_schema_generator(
         components: OpenAPIComponents {
             schemas: HashMap::new(),
         },
-
         paths: HashMap::new(),
-    };
+    }
+}
 
-    // Filter resource SDs to only supported resources
+fn add_resource_schemas<S: std::hash::BuildHasher>(
+    openapi_schema: &mut OpenAPI,
+    sds: &[StructureDefinition],
+    search_parameters: &[SearchParameter],
+    supported_resource_names: &HashSet<String, S>,
+    schema_base_url: &str,
+) -> Result<(), OperationOutcomeError> {
     let resource_sds = sds
         .iter()
         .filter(|sd| sd.kind == StructureDefinitionKind::resource())
@@ -468,51 +512,74 @@ pub fn open_api_schema_generator(
             )
         })?;
 
-        // Use external $ref for the resource schema — individual schemas are served
-        // from a separate endpoint to keep the main document small.
-        openapi_schema.components.schemas.insert(
-            resource_name.clone(),
-            json!({
-                "$ref": format!("{}/{}", schema_base_url, resource_name)
-            }),
-        );
-
-        // Read Operation
-        openapi_schema.paths.insert(
-            format!("/{}/{{id}}", resource_name),
-            OpenAPIPathItem {
-                get: Some(read_resource_operation(resource_name)),
-                post: None,
-                patch: Some(patch_resource_operation(resource_name)),
-                put: Some(put_resource_operation(resource_name)),
-                delete: Some(delete_instance_operation(resource_name)),
-            },
-        );
-
-        let resource_search_parameters =
-            resource_search_parameters_schema(resource_name, search_parameters);
-
-        openapi_schema.paths.insert(
-            format!("/{}", resource_name),
-            OpenAPIPathItem {
-                get: Some(search_resource_operation(
-                    resource_name,
-                    resource_search_parameters.clone(),
-                )),
-                patch: None,
-                put: None,
-                post: Some(create_resource_operation(resource_name)),
-                delete: Some(delete_resource_operation(resource_search_parameters)),
-            },
+        add_resource_schema(
+            openapi_schema,
+            resource_name,
+            search_parameters,
+            schema_base_url,
         );
     }
 
+    Ok(())
+}
+
+fn add_resource_schema(
+    openapi_schema: &mut OpenAPI,
+    resource_name: &str,
+    search_parameters: &[SearchParameter],
+    schema_base_url: &str,
+) {
+    // Use external $ref for the resource schema — individual schemas are served
+    // from a separate endpoint to keep the main document small.
+    openapi_schema.components.schemas.insert(
+        resource_name.to_string(),
+        json!({
+            "$ref": format!("{}/{}", schema_base_url, resource_name)
+        }),
+    );
+
+    // Read operation
+    openapi_schema.paths.insert(
+        format!("/{resource_name}/{{id}}"),
+        OpenAPIPathItem {
+            get: Some(read_resource_operation(resource_name)),
+            post: None,
+            patch: Some(patch_resource_operation(resource_name)),
+            put: Some(put_resource_operation(resource_name)),
+            delete: Some(delete_instance_operation(resource_name)),
+        },
+    );
+
+    // Search/create/delete operations
+    let resource_search_parameters =
+        resource_search_parameters_schema(resource_name, search_parameters);
+
+    openapi_schema.paths.insert(
+        format!("/{resource_name}"),
+        OpenAPIPathItem {
+            get: Some(search_resource_operation(
+                resource_name,
+                resource_search_parameters.clone(),
+            )),
+            patch: None,
+            put: None,
+            post: Some(create_resource_operation(resource_name)),
+            delete: Some(delete_resource_operation(resource_search_parameters)),
+        },
+    );
+}
+
+fn add_complex_type_schemas(
+    openapi_schema: &mut OpenAPI,
+    sds: &[StructureDefinition],
+    schema_base_url: &str,
+) {
     // Complex types (datatypes) get the same external-$ref treatment as
-    // resources — served on demand from `{schema_base_url}/{TypeName}` rather
-    // than tracked/inlined here, so there's no need to figure out in advance
-    // which ones are actually referenced. "Element" is matched by name too
-    // since it's FHIR's abstract base type and isn't always loaded with
-    // `kind: complex-type`.
+    // resources — served on demand from `{schema_base_url}/{TypeName}`
+    // rather than tracked/inlined here.
+    //
+    // "Element" is matched by name too since it's FHIR's abstract base type
+    // and isn't always loaded with `kind: complex-type`.
     for sd in sds.iter().filter(|sd| {
         sd.kind == StructureDefinitionKind::complex_type()
             || sd.name.value.as_deref() == Some("Element")
@@ -528,12 +595,12 @@ pub fn open_api_schema_generator(
             }),
         );
     }
-
-    Ok(openapi_schema)
 }
 
-/// Returns the set of resource type names from the given StructureDefinitions.
-/// Useful for getting the full unfiltered set when no CapabilityStatement filtering is desired.
+/// Returns the set of resource type names from the given
+/// [`StructureDefinition`]s.
+/// Useful for getting the full unfiltered set when no `CapabilityStatement`
+/// filtering is desired.
 pub fn all_resource_names(sds: &[StructureDefinition]) -> HashSet<String> {
     sds.iter()
         .filter(|sd| sd.kind == StructureDefinitionKind::resource())


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.