### PR TITLE
Resolve `clippy` lints for `operation-executor` crate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,7 @@ jobs:
           -p haste-jwt \
           -p haste-macro-loads \
           -p haste-openapi-schema-generator \
+          -p haste-operation-executor \
           -p haste-pointer \
           -p haste-rate-limit \
           -p haste-reflect \

--- a/backend/crates/operation_executor/src/providers/deno_embedded/mod.rs
+++ b/backend/crates/operation_executor/src/providers/deno_embedded/mod.rs
@@ -5,7 +5,7 @@ pub mod pool;
 
 use deno_core::{
     Extension, GarbageCollected, ModuleLoadOptions, ModuleLoadReferrer, ModuleLoader, ModuleSource,
-    ModuleType, OpState, op2, resolve_import, serde_json, v8,
+    ModuleType, OpState, PollEventLoopOptions, op2, resolve_import, serde_json, v8,
 };
 // main.rs
 use deno_core::error::AnyError;
@@ -46,8 +46,8 @@ fn transpile_code_to_js(
 ) -> Result<(ModuleType, String), JsErrorBox> {
     let (module_type, should_transpile) = match media_type {
         MediaType::JavaScript | MediaType::Mjs | MediaType::Cjs => (ModuleType::JavaScript, false),
-        MediaType::Jsx => (ModuleType::JavaScript, true),
-        MediaType::TypeScript
+        MediaType::Jsx
+        | MediaType::TypeScript
         | MediaType::Mts
         | MediaType::Cts
         | MediaType::Dts
@@ -57,8 +57,7 @@ fn transpile_code_to_js(
         MediaType::Json => (ModuleType::Json, false),
         _ => {
             return Err(JsErrorBox::generic(format!(
-                "Unknown extension {:?}",
-                media_type
+                "Unknown extension {media_type:?}",
             )));
         }
     };
@@ -116,12 +115,12 @@ impl ModuleLoader for TsModuleLoader {
         fn load(module_specifier: &ModuleSpecifier) -> Result<ModuleSource, ModuleLoaderError> {
             let path = module_specifier
                 .to_file_path()
-                .map_err(|_| JsErrorBox::generic("Only file:// URLs are supported."))?;
+                .map_err(|()| JsErrorBox::generic("Only file:// URLs are supported."))?;
 
             let code = std::fs::read_to_string(&path).map_err(JsErrorBox::from_err)?;
             let path = module_specifier
                 .to_file_path()
-                .map_err(|_| JsErrorBox::generic("Only file:// URLs are supported."))?;
+                .map_err(|()| JsErrorBox::generic("Only file:// URLs are supported."))?;
             let media_type = MediaType::from_path(&path);
             let (module_type, code) = transpile_code_to_js(module_specifier, media_type, &code)?;
 
@@ -221,7 +220,7 @@ pub async fn fhir_read_resource<
         )
         .await
         .map_err(|e| {
-            println!("Error reading resource: {:?}", e);
+            println!("Error reading resource: {e:?}");
             deno_error::JsErrorBox::type_error("Failed to read resource")
         })?;
 
@@ -324,7 +323,7 @@ async fn run_code<
     let user_module_specifier = ModuleSpecifier::parse("memo://user.ts").unwrap();
 
     let (_module_type, js_code) =
-        transpile_code_to_js(&user_module_specifier, media_type.into(), &code).unwrap();
+        transpile_code_to_js(&user_module_specifier, media_type.into(), code).unwrap();
 
     let user_mod_id = deno_runtime
         .load_side_es_module_from_code(&user_module_specifier, js_code)
@@ -342,7 +341,9 @@ async fn run_code<
     let user_module_load = deno_runtime.mod_evaluate(user_mod_id);
     let main_module_load = deno_runtime.mod_evaluate(main_mod_id);
 
-    deno_runtime.run_event_loop(Default::default()).await?;
+    deno_runtime
+        .run_event_loop(PollEventLoopOptions::default())
+        .await?;
 
     user_module_load.await?;
     main_module_load.await?;

--- a/backend/crates/operation_executor/src/providers/deno_embedded/pool.rs
+++ b/backend/crates/operation_executor/src/providers/deno_embedded/pool.rs
@@ -26,6 +26,25 @@ pub struct DenoPool {
 }
 
 impl DenoPool {
+    /// Creates a new [`DenoPool`] with the specified number of worker threads.
+    ///
+    /// Each worker is spawned during construction. If any worker fails to start, all workers
+    /// that were successfully spawned up to that point are shut down before the error is
+    /// returned.
+    ///
+    /// # Arguments
+    ///
+    /// * `thread_count` - The number of worker threads to create. Must be greater than zero.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// * `thread_count` is zero.
+    /// * A worker thread fails to spawn.
+    ///
+    /// If worker creation fails partway through initialization, all previously spawned workers
+    /// are shut down before the error is returned.
     pub fn new(thread_count: usize) -> Result<Self, AnyError> {
         if thread_count == 0 {
             return Err(io::Error::other("DenoPool requires at least one worker thread").into());
@@ -98,7 +117,7 @@ impl Drop for DenoPool {
     }
 }
 
-fn get_parameters<'a>(input: &'a InvocationRequest) -> &'a Parameters {
+fn get_parameters(input: &InvocationRequest) -> &Parameters {
     match input {
         InvocationRequest::Instance(instance_request) => &instance_request.parameters,
         InvocationRequest::Type(type_request) => &type_request.parameters,
@@ -145,7 +164,7 @@ impl OperationExecutor for DenoPool {
     ) -> Result<Parameters, OperationOutcomeError> {
         validate_parameters(
             get_parameters(input),
-            &operation.parameter.as_deref().unwrap_or_default(),
+            operation.parameter.as_deref().unwrap_or_default(),
             &OperationParameterUse::in_(),
         )?;
 
@@ -154,8 +173,7 @@ impl OperationExecutor for DenoPool {
                 OperationOutcomeError::error(
                     IssueType::invalid(),
                     format!(
-                        "OperationDefinition missing custom code extension metadata '{}'",
-                        CUSTOM_CODE_EXTENSION_URL
+                        "OperationDefinition missing custom code extension metadata '{CUSTOM_CODE_EXTENSION_URL}'"
                     ),
                 )
             })?;
@@ -193,7 +211,7 @@ impl OperationExecutor for DenoPool {
 
         validate_parameters(
             &output,
-            &operation.parameter.as_deref().unwrap_or_default(),
+            operation.parameter.as_deref().unwrap_or_default(),
             &OperationParameterUse::out(),
         )?;
 

--- a/backend/crates/operation_executor/src/validate.rs
+++ b/backend/crates/operation_executor/src/validate.rs
@@ -21,14 +21,39 @@ fn create_issue(
     diagnostics: String,
 ) -> OperationOutcomeIssue {
     OperationOutcomeIssue {
-        severity: severity,
+        severity,
         code: type_,
         diagnostics: Some(Box::new(diagnostics.into())),
         ..Default::default()
     }
 }
 
-/// Validate Parameters against the corresponding OperationDefinitionParameter definitions for the specified direction.
+/// Validates supplied [`Parameters`] against the [`OperationDefinitionParameter`] definitions
+/// for the specified operation direction.
+///
+/// The validation checks parameter cardinality, validates the type of supplied values or
+/// resources against the expected parameter type, recursively validates nested parts, and
+/// reports parameters that are not defined for the specified direction.
+///
+/// # Arguments
+///
+/// * `parameters` - The parameters supplied for the operation.
+/// * `operation_params` - The parameter definitions from the operation's
+///   [`OperationDefinitionParameter`].
+/// * `direction` - The operation parameter direction to validate, such as `in` or `out`.
+///
+/// # Errors
+///
+/// Returns an [`OperationOutcomeError`] containing one or more issues if:
+///
+/// * A parameter has fewer occurrences than its minimum cardinality.
+/// * A parameter exceeds its maximum cardinality.
+/// * A supplied parameter has a different type than the type defined by the operation.
+/// * A nested parameter part does not satisfy its corresponding definition.
+/// * A supplied parameter is not defined for the specified operation direction.
+///
+/// Multiple validation failures are collected and returned together in a single
+/// [`OperationOutcomeError`].
 pub fn validate_parameters(
     parameters: &Parameters,
     operation_params: &[OperationDefinitionParameter],
@@ -46,9 +71,8 @@ pub fn validate_parameters(
 
     // --- Check each definition against what was supplied ---
     for parameter_definition in &parameter_definitions {
-        let name = match parameter_definition.name.value.as_deref() {
-            Some(n) => n,
-            None => continue,
+        let Some(name) = parameter_definition.name.value.as_deref() else {
+            continue;
         };
 
         let found_parameters: Vec<&ParametersParameter> = parameters_to_validate
@@ -56,34 +80,30 @@ pub fn validate_parameters(
             .filter(|p| p.name.value.as_deref() == Some(name))
             .collect();
 
-        let count = found_parameters.len() as i64;
+        let count = found_parameters.len() as u64;
 
         // Minimum cardinality
-        let min = parameter_definition.min.value.unwrap_or(0);
+        let min = parameter_definition.min.value.unwrap_or(0).cast_unsigned();
         if count < min {
             issues.push(create_issue(
                 IssueSeverity::error(),
                 IssueType::invariant(),
                 format!(
-                    "Parameter '{}' requires at least {} occurrence(s) but only {} were supplied.",
-                    name, min, count
+                    "Parameter '{name}' requires at least {min} occurrence(s) but only {count} were supplied."
                 ),
             ));
         }
 
         // Maximum cardinality ("*" means unbounded)
-        if let Some(max_str) = parameter_definition.max.value.as_deref() {
-            if max_str != "*" {
-                if let Ok(max) = max_str.parse::<i64>() {
-                    if count > max {
-                        issues.push(create_issue(IssueSeverity::error(), IssueType::invariant(),
+        if let Some(max_str) = parameter_definition.max.value.as_deref()
+            && max_str != "*"
+            && let Ok(max) = max_str.parse::<u64>()
+            && count > max
+        {
+            issues.push(create_issue(IssueSeverity::error(), IssueType::invariant(),
                         format!(
-                                "Parameter '{}' allows a maximum of {} occurrence(s) but {} were supplied.",
-                                name, max, count
+                                "Parameter '{name}' allows a maximum of {max} occurrence(s) but {count} were supplied."
                             )));
-                    }
-                }
-            }
         }
 
         // Validate type if specified. The type of a supplied parameter is determined by:
@@ -91,22 +111,20 @@ pub fn validate_parameters(
         // 2. Otherwise, use the type of the `value` field.
         if let Some(parameter_def_type) = &parameter_definition.type_ {
             let type_name = parameter_def_type.as_str();
-            for found_parameter in found_parameters.iter() {
+            for found_parameter in &found_parameters {
                 let type_ = if let Some(resource) = found_parameter.resource.as_ref() {
                     resource.fhir_type()
                 } else {
                     found_parameter.value.fhir_type()
                 };
 
-                if type_ != type_name.as_deref().unwrap_or_default() {
+                if type_ != type_name.unwrap_or_default() {
                     issues.push(create_issue(
                         IssueSeverity::error(),
                         IssueType::invalid(),
                         format!(
-                            "Parameter '{}' expects type '{}' but found '{}'.",
-                            name,
-                            type_name.as_deref().unwrap_or("<unknown>"),
-                            type_
+                            "Parameter '{name}' expects type '{}' but found '{type_}'.",
+                            type_name.unwrap_or("<unknown>"),
                         ),
                     ));
                 }
@@ -122,7 +140,7 @@ pub fn validate_parameters(
                         parameter: Some(supplied_parts.clone()),
                         ..Default::default()
                     };
-                    validate_parameters(&parts_as_parameters, part_defs, &direction)?;
+                    validate_parameters(&parts_as_parameters, part_defs, direction)?;
                 }
             }
         }
@@ -142,7 +160,7 @@ pub fn validate_parameters(
                 format!(
                     "Parameter '{}' is not defined for the '{}' direction.",
                     name,
-                    display_direction.as_deref().unwrap_or("<unknown>")
+                    display_direction.unwrap_or("<unknown>")
                 ),
             ));
         }
@@ -194,7 +212,7 @@ mod tests {
                 value: Some(max.to_string()),
                 ..Default::default()
             }),
-            type_: type_,
+            type_,
             ..Default::default()
         }
     }


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.