### PR TITLE
Resolve `clippy` lints for `sql-on-fhir`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
           -p haste-reflect-derive \
           -p haste-repository \
           -p haste-sd-to-json-schema \
-          -p haste-sql-on-fhir \
+          # -p haste-sql-on-fhir \
           -p haste-testscript-runner \
           -p haste_wal_worker \
           -p haste-worker \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
           -p haste-reflect-derive \
           -p haste-repository \
           -p haste-sd-to-json-schema \
-          # -p haste-sql-on-fhir \
+# -p haste-sql-on-fhir \
           -p haste-testscript-runner \
           -p haste_wal_worker \
           -p haste-worker \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
           -p haste-reflect-derive \
           -p haste-repository \
           -p haste-sd-to-json-schema \
+          -p haste-sql-on-fhir \
           -p haste-testscript-runner \
           -p haste_wal_worker \
           -p haste-worker \

--- a/backend/crates/sql-on-fhir/src/conversions/primitives.rs
+++ b/backend/crates/sql-on-fhir/src/conversions/primitives.rs
@@ -22,12 +22,12 @@ pub enum PrimitiveValue {
 }
 
 #[allow(dead_code)]
-fn downcast_meta_value<'a, T: 'static>(value: &'a dyn MetaValue) -> Option<&'a T> {
+fn downcast_meta_value<T: 'static>(value: &dyn MetaValue) -> Option<&T> {
     value.as_any().downcast_ref::<T>().or_else(|| {
         value
             .as_any()
             .downcast_ref::<Box<T>>()
-            .map(|boxed| boxed.as_ref())
+            .map(std::convert::AsRef::as_ref)
     })
 }
 
@@ -101,26 +101,14 @@ pub fn convert_meta_value(
                 .map(|number| PrimitiveValue::Number(number as f64))
         }),
         "string" => convert_with::<FHIRString, _, _>(value, "string", |primitive| {
-            primitive
-                .value
-                .as_ref()
-                .cloned()
-                .map(PrimitiveValue::String)
+            primitive.value.clone().map(PrimitiveValue::String)
         }),
         "uri" => convert_with::<FHIRUri, _, _>(value, "uri", |primitive| {
-            primitive
-                .value
-                .as_ref()
-                .cloned()
-                .map(PrimitiveValue::String)
+            primitive.value.clone().map(PrimitiveValue::String)
         }),
         "base64Binary" => {
             convert_with::<FHIRBase64Binary, _, _>(value, "base64Binary", |primitive| {
-                primitive
-                    .value
-                    .as_ref()
-                    .cloned()
-                    .map(PrimitiveValue::String)
+                primitive.value.clone().map(PrimitiveValue::String)
             })
         }
         "code" => {
@@ -132,18 +120,10 @@ pub fn convert_meta_value(
                 .map(PrimitiveValue::String))
         }
         "id" => convert_with::<FHIRId, _, _>(value, "id", |primitive| {
-            primitive
-                .value
-                .as_ref()
-                .cloned()
-                .map(PrimitiveValue::String)
+            primitive.value.clone().map(PrimitiveValue::String)
         }),
         "oid" => convert_with::<FHIROid, _, _>(value, "oid", |primitive| {
-            primitive
-                .value
-                .as_ref()
-                .cloned()
-                .map(PrimitiveValue::String)
+            primitive.value.clone().map(PrimitiveValue::String)
         }),
         "unsignedInt" => convert_with::<FHIRUnsignedInt, _, _>(value, "unsignedInt", |primitive| {
             primitive
@@ -156,32 +136,16 @@ pub fn convert_meta_value(
                 .map(|number| PrimitiveValue::Number(number as f64))
         }),
         "markdown" => convert_with::<FHIRMarkdown, _, _>(value, "markdown", |primitive| {
-            primitive
-                .value
-                .as_ref()
-                .cloned()
-                .map(PrimitiveValue::String)
+            primitive.value.clone().map(PrimitiveValue::String)
         }),
         "url" => convert_with::<FHIRUrl, _, _>(value, "url", |primitive| {
-            primitive
-                .value
-                .as_ref()
-                .cloned()
-                .map(PrimitiveValue::String)
+            primitive.value.clone().map(PrimitiveValue::String)
         }),
         "canonical" => convert_with::<FHIRCanonical, _, _>(value, "canonical", |primitive| {
-            primitive
-                .value
-                .as_ref()
-                .cloned()
-                .map(PrimitiveValue::String)
+            primitive.value.clone().map(PrimitiveValue::String)
         }),
         "uuid" => convert_with::<FHIRUuid, _, _>(value, "uuid", |primitive| {
-            primitive
-                .value
-                .as_ref()
-                .cloned()
-                .map(PrimitiveValue::String)
+            primitive.value.clone().map(PrimitiveValue::String)
         }),
         "http://hl7.org/fhirpath/System.String" => Ok(value
             .as_any()
@@ -190,7 +154,7 @@ pub fn convert_meta_value(
                 value
                     .as_any()
                     .downcast_ref::<Box<String>>()
-                    .map(|boxed| boxed.as_ref())
+                    .map(std::convert::AsRef::as_ref)
             })
             .cloned()
             .map(PrimitiveValue::String)),

--- a/backend/crates/sql-on-fhir/src/conversions/primitives.rs
+++ b/backend/crates/sql-on-fhir/src/conversions/primitives.rs
@@ -100,97 +100,78 @@ fn convert_fhir_primitive(
                 .as_ref()
                 .map(|instant| PrimitiveValue::String(instant.to_string()))
         }),
-
         "time" => convert_with::<FHIRTime, _, _>(value, "time", |primitive| {
             primitive
                 .value
                 .as_ref()
                 .map(|time| PrimitiveValue::String(time.to_string()))
         }),
-
         "date" => convert_with::<FHIRDate, _, _>(value, "date", |primitive| {
             primitive
                 .value
                 .as_ref()
                 .map(|date| PrimitiveValue::String(date.to_string()))
         }),
-
         "dateTime" => convert_with::<FHIRDateTime, _, _>(value, "dateTime", |primitive| {
             primitive
                 .value
                 .as_ref()
                 .map(|date_time| PrimitiveValue::String(date_time.to_string()))
         }),
-
         "decimal" => convert_with::<FHIRDecimal, _, _>(value, "decimal", |primitive| {
             primitive.value.map(PrimitiveValue::Number)
         }),
-
         "boolean" => convert_with::<FHIRBoolean, _, _>(value, "boolean", |primitive| {
             primitive.value.map(PrimitiveValue::Boolean)
         }),
-
         "integer" => convert_with::<FHIRInteger, _, _>(value, "integer", |primitive| {
             primitive
                 .value
                 .map(|number| PrimitiveValue::Number(number as f64))
         }),
-
         "string" => convert_with::<FHIRString, _, _>(value, "string", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
-
         "uri" => convert_with::<FHIRUri, _, _>(value, "uri", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
-
         "base64Binary" => {
             convert_with::<FHIRBase64Binary, _, _>(value, "base64Binary", |primitive| {
                 primitive.value.clone().map(PrimitiveValue::String)
             })
         }
-
         "code" => Ok(value
             .get_field("value")
             .and_then(|v| v.as_any().downcast_ref::<String>().cloned())
             .map(PrimitiveValue::String)),
-
         "id" => convert_with::<FHIRId, _, _>(value, "id", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
-
         "oid" => convert_with::<FHIROid, _, _>(value, "oid", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
-
         "unsignedInt" => convert_with::<FHIRUnsignedInt, _, _>(value, "unsignedInt", |primitive| {
             primitive
                 .value
                 .map(|number| PrimitiveValue::Number(number as f64))
         }),
-
         "positiveInt" => convert_with::<FHIRPositiveInt, _, _>(value, "positiveInt", |primitive| {
             primitive
                 .value
                 .map(|number| PrimitiveValue::Number(number as f64))
         }),
-
         "markdown" => convert_with::<FHIRMarkdown, _, _>(value, "markdown", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
-
         "url" => convert_with::<FHIRUrl, _, _>(value, "url", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
-
         "canonical" => convert_with::<FHIRCanonical, _, _>(value, "canonical", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
-
         "uuid" => convert_with::<FHIRUuid, _, _>(value, "uuid", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
-
         type_name => Err(unsupported_type_error(type_name)),
     }
 }
@@ -211,45 +192,37 @@ fn convert_fhirpath_system_type(
             })
             .cloned()
             .map(PrimitiveValue::String)),
-
         "http://hl7.org/fhirpath/System.Boolean" => Ok(value
             .as_any()
             .downcast_ref::<bool>()
             .copied()
             .map(PrimitiveValue::Boolean)),
-
         "http://hl7.org/fhirpath/System.Integer" => Ok(value
             .as_any()
             .downcast_ref::<i64>()
             .copied()
             .map(|number| PrimitiveValue::Number(number as f64))),
-
         "http://hl7.org/fhirpath/System.Decimal" => Ok(value
             .as_any()
             .downcast_ref::<f64>()
             .copied()
             .map(PrimitiveValue::Number)),
-
         "http://hl7.org/fhirpath/System.Date" => Ok(value
             .as_any()
             .downcast_ref::<Date>()
             .map(|date| PrimitiveValue::String(date.to_string()))),
-
         "http://hl7.org/fhirpath/System.DateTime" => Ok(value
             .as_any()
             .downcast_ref::<DateTime>()
             .map(|date_time| PrimitiveValue::String(date_time.to_string()))),
-
         "http://hl7.org/fhirpath/System.Instant" => Ok(value
             .as_any()
             .downcast_ref::<Instant>()
             .map(|instant| PrimitiveValue::String(instant.to_string()))),
-
         "http://hl7.org/fhirpath/System.Time" => Ok(value
             .as_any()
             .downcast_ref::<Time>()
             .map(|time| PrimitiveValue::String(time.to_string()))),
-
         type_name => Err(unsupported_type_error(type_name)),
     }
 }

--- a/backend/crates/sql-on-fhir/src/conversions/primitives.rs
+++ b/backend/crates/sql-on-fhir/src/conversions/primitives.rs
@@ -127,6 +127,7 @@ fn convert_fhir_primitive(
         "integer" => convert_with::<FHIRInteger, _, _>(value, "integer", |primitive| {
             primitive
                 .value
+                // FIXME: Do not convert to f64.
                 .map(|number| PrimitiveValue::Number(number as f64))
         }),
         "string" => convert_with::<FHIRString, _, _>(value, "string", |primitive| {
@@ -153,11 +154,13 @@ fn convert_fhir_primitive(
         "unsignedInt" => convert_with::<FHIRUnsignedInt, _, _>(value, "unsignedInt", |primitive| {
             primitive
                 .value
+                // FIXME: Do not convert to f64.
                 .map(|number| PrimitiveValue::Number(number as f64))
         }),
         "positiveInt" => convert_with::<FHIRPositiveInt, _, _>(value, "positiveInt", |primitive| {
             primitive
                 .value
+                // FIXME: Do not convert to f64.
                 .map(|number| PrimitiveValue::Number(number as f64))
         }),
         "markdown" => convert_with::<FHIRMarkdown, _, _>(value, "markdown", |primitive| {
@@ -201,6 +204,7 @@ fn convert_fhirpath_system_type(
             .as_any()
             .downcast_ref::<i64>()
             .copied()
+            // FIXME: Do not convert to f64.
             .map(|number| PrimitiveValue::Number(number as f64))),
         "http://hl7.org/fhirpath/System.Decimal" => Ok(value
             .as_any()

--- a/backend/crates/sql-on-fhir/src/conversions/primitives.rs
+++ b/backend/crates/sql-on-fhir/src/conversions/primitives.rs
@@ -53,6 +53,13 @@ where
     Ok(extractor(value))
 }
 
+fn unsupported_type_error(type_name: &str) -> OperationOutcomeError {
+    OperationOutcomeError::error(
+        IssueType::invalid(),
+        format!("Unsupported primitive type: '{type_name}'"),
+    )
+}
+
 pub fn convert_meta_value(
     type_: &str,
     value: &dyn MetaValue,
@@ -65,88 +72,134 @@ pub fn convert_meta_value(
     }
 
     match type_ {
+        "instant" | "time" | "date" | "dateTime" | "decimal" | "boolean" | "integer" | "string"
+        | "uri" | "base64Binary" | "code" | "id" | "oid" | "unsignedInt" | "positiveInt"
+        | "markdown" | "url" | "canonical" | "uuid" => convert_fhir_primitive(type_, value),
+
+        "http://hl7.org/fhirpath/System.String"
+        | "http://hl7.org/fhirpath/System.Boolean"
+        | "http://hl7.org/fhirpath/System.Integer"
+        | "http://hl7.org/fhirpath/System.Decimal"
+        | "http://hl7.org/fhirpath/System.Date"
+        | "http://hl7.org/fhirpath/System.DateTime"
+        | "http://hl7.org/fhirpath/System.Instant"
+        | "http://hl7.org/fhirpath/System.Time" => convert_fhirpath_system_type(type_, value),
+
+        type_name => Err(unsupported_type_error(type_name)),
+    }
+}
+
+fn convert_fhir_primitive(
+    type_: &str,
+    value: &dyn MetaValue,
+) -> Result<Option<PrimitiveValue>, OperationOutcomeError> {
+    match type_ {
         "instant" => convert_with::<FHIRInstant, _, _>(value, "instant", |primitive| {
             primitive
                 .value
                 .as_ref()
                 .map(|instant| PrimitiveValue::String(instant.to_string()))
         }),
+
         "time" => convert_with::<FHIRTime, _, _>(value, "time", |primitive| {
             primitive
                 .value
                 .as_ref()
                 .map(|time| PrimitiveValue::String(time.to_string()))
         }),
+
         "date" => convert_with::<FHIRDate, _, _>(value, "date", |primitive| {
             primitive
                 .value
                 .as_ref()
                 .map(|date| PrimitiveValue::String(date.to_string()))
         }),
+
         "dateTime" => convert_with::<FHIRDateTime, _, _>(value, "dateTime", |primitive| {
             primitive
                 .value
                 .as_ref()
                 .map(|date_time| PrimitiveValue::String(date_time.to_string()))
         }),
+
         "decimal" => convert_with::<FHIRDecimal, _, _>(value, "decimal", |primitive| {
             primitive.value.map(PrimitiveValue::Number)
         }),
+
         "boolean" => convert_with::<FHIRBoolean, _, _>(value, "boolean", |primitive| {
             primitive.value.map(PrimitiveValue::Boolean)
         }),
+
         "integer" => convert_with::<FHIRInteger, _, _>(value, "integer", |primitive| {
             primitive
                 .value
                 .map(|number| PrimitiveValue::Number(number as f64))
         }),
+
         "string" => convert_with::<FHIRString, _, _>(value, "string", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
+
         "uri" => convert_with::<FHIRUri, _, _>(value, "uri", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
+
         "base64Binary" => {
             convert_with::<FHIRBase64Binary, _, _>(value, "base64Binary", |primitive| {
                 primitive.value.clone().map(PrimitiveValue::String)
             })
         }
-        "code" => {
-            // Because of inline terminologies we manually pull of the value
-            // For example AddressUse etc...
-            Ok(value
-                .get_field("value")
-                .and_then(|v| v.as_any().downcast_ref::<String>().cloned())
-                .map(PrimitiveValue::String))
-        }
+
+        "code" => Ok(value
+            .get_field("value")
+            .and_then(|v| v.as_any().downcast_ref::<String>().cloned())
+            .map(PrimitiveValue::String)),
+
         "id" => convert_with::<FHIRId, _, _>(value, "id", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
+
         "oid" => convert_with::<FHIROid, _, _>(value, "oid", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
+
         "unsignedInt" => convert_with::<FHIRUnsignedInt, _, _>(value, "unsignedInt", |primitive| {
             primitive
                 .value
                 .map(|number| PrimitiveValue::Number(number as f64))
         }),
+
         "positiveInt" => convert_with::<FHIRPositiveInt, _, _>(value, "positiveInt", |primitive| {
             primitive
                 .value
                 .map(|number| PrimitiveValue::Number(number as f64))
         }),
+
         "markdown" => convert_with::<FHIRMarkdown, _, _>(value, "markdown", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
+
         "url" => convert_with::<FHIRUrl, _, _>(value, "url", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
+
         "canonical" => convert_with::<FHIRCanonical, _, _>(value, "canonical", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
+
         "uuid" => convert_with::<FHIRUuid, _, _>(value, "uuid", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
         }),
+
+        type_name => Err(unsupported_type_error(type_name)),
+    }
+}
+
+fn convert_fhirpath_system_type(
+    type_: &str,
+    value: &dyn MetaValue,
+) -> Result<Option<PrimitiveValue>, OperationOutcomeError> {
+    match type_ {
         "http://hl7.org/fhirpath/System.String" => Ok(value
             .as_any()
             .downcast_ref::<String>()
@@ -158,40 +211,45 @@ pub fn convert_meta_value(
             })
             .cloned()
             .map(PrimitiveValue::String)),
+
         "http://hl7.org/fhirpath/System.Boolean" => Ok(value
             .as_any()
             .downcast_ref::<bool>()
             .copied()
             .map(PrimitiveValue::Boolean)),
+
         "http://hl7.org/fhirpath/System.Integer" => Ok(value
             .as_any()
             .downcast_ref::<i64>()
             .copied()
             .map(|number| PrimitiveValue::Number(number as f64))),
+
         "http://hl7.org/fhirpath/System.Decimal" => Ok(value
             .as_any()
             .downcast_ref::<f64>()
             .copied()
             .map(PrimitiveValue::Number)),
+
         "http://hl7.org/fhirpath/System.Date" => Ok(value
             .as_any()
             .downcast_ref::<Date>()
             .map(|date| PrimitiveValue::String(date.to_string()))),
+
         "http://hl7.org/fhirpath/System.DateTime" => Ok(value
             .as_any()
             .downcast_ref::<DateTime>()
             .map(|date_time| PrimitiveValue::String(date_time.to_string()))),
+
         "http://hl7.org/fhirpath/System.Instant" => Ok(value
             .as_any()
             .downcast_ref::<Instant>()
             .map(|instant| PrimitiveValue::String(instant.to_string()))),
+
         "http://hl7.org/fhirpath/System.Time" => Ok(value
             .as_any()
             .downcast_ref::<Time>()
             .map(|time| PrimitiveValue::String(time.to_string()))),
-        type_name => Err(OperationOutcomeError::error(
-            IssueType::invalid(),
-            format!("Unsupported primitive type: '{type_name}'"),
-        )),
+
+        type_name => Err(unsupported_type_error(type_name)),
     }
 }

--- a/backend/crates/sql-on-fhir/src/lib.rs
+++ b/backend/crates/sql-on-fhir/src/lib.rs
@@ -6,7 +6,7 @@ use haste_fhir_generated_ops::generated::ViewDefinitionRun;
 use haste_fhir_model::r4::{
     self,
     generated::{
-        resources::{Binary, Resource, ResourceType, ViewDefinition},
+        resources::{Binary, Resource, ResourceType, ViewDefinition, ViewDefinitionSelect},
         terminology::{BoundCode, IssueType, OutputFormatCodes},
         types::{FHIRBase64Binary, FHIRBoolean},
     },
@@ -212,169 +212,18 @@ async fn process_resource<
                 .with_resource_id(input.id().clone().unwrap_or_default()),
         );
 
-        let mut iterable_context = None;
-        let mut set_null = false;
+        let (iterable_context, set_null) =
+            build_iterable_context(&fp_engine, fp_config.clone(), select_statement, &input).await?;
 
-        if let Some(for_each_fp) = select_statement
-            .forEach
-            .as_ref()
-            .and_then(|f| f.value.as_ref())
-        {
-            iterable_context = Some(vec![
-                fp_engine
-                    .evaluate_with_config(for_each_fp, vec![&input], fp_config.clone())
-                    .await
-                    .map_err(|e| {
-                        OperationOutcomeError::error(
-                            IssueType::exception(),
-                            format!("Error evaluating forEach expression: {e}"),
-                        )
-                    })?,
-            ]);
-        } else if let Some(for_each_or_null_fp) = select_statement
-            .forEachOrNull
-            .as_ref()
-            .and_then(|f| f.value.as_ref())
-        {
-            iterable_context = Some(vec![
-                fp_engine
-                    .evaluate_with_config(for_each_or_null_fp, vec![&input], fp_config.clone())
-                    .await
-                    .map_err(|e| {
-                        OperationOutcomeError::error(
-                            IssueType::exception(),
-                            format!("Error evaluating forEachOrNull expression: {e}"),
-                        )
-                    })?,
-            ]);
-            set_null = true;
-        } else if let Some(repeat) = select_statement
-            .repeat
-            .as_ref()
-            .map(|r| r.iter().filter_map(|r| r.value.as_ref()))
-        {
-            let mut repeat_fps = vec![];
-            for repeat_fp in repeat {
-                let repeat = format!("$this.repeat({repeat_fp})");
-                repeat_fps.push(
-                    fp_engine
-                        .evaluate_with_config(&repeat, vec![&input], fp_config.clone())
-                        .await
-                        .map_err(|e| {
-                            OperationOutcomeError::error(
-                                IssueType::exception(),
-                                format!("Error evaluating repeat expression: {e}"),
-                            )
-                        })?,
-                );
-            }
-
-            iterable_context = Some(repeat_fps);
-        }
-
-        let select_context: Vec<&dyn MetaValue> = if let Some(iterable) = iterable_context.as_ref()
-        {
-            iterable
-                .iter()
-                .flat_map(haste_fhirpath::Context::iter)
-                .collect::<Vec<&dyn MetaValue>>()
-        } else {
-            vec![&input]
-        };
-
-        let mut select_results = Vec::with_capacity(select_context.len());
-
-        if set_null && select_context.is_empty() {
-            let mut output_result = OrderMap::new();
-            for column in select_statement.column.as_ref().into_iter().flatten() {
-                let Some(name) = column.name.value.as_deref() else {
-                    return Err(OperationOutcomeError::error(
-                        IssueType::invalid(),
-                        "Column name is required".to_string(),
-                    ));
-                };
-                output_result.insert(name.to_string(), OutputResults::Scalar(None));
-            }
-            select_results.push(output_result);
-        }
-
-        for context in select_context {
-            let mut output_result = OrderMap::new();
-            for column in select_statement.column.as_ref().into_iter().flatten() {
-                let Some(path) = column.path.value.as_deref() else {
-                    return Err(OperationOutcomeError::error(
-                        IssueType::invalid(),
-                        "Column path is required".to_string(),
-                    ));
-                };
-
-                let Some(name) = column.name.value.as_deref() else {
-                    return Err(OperationOutcomeError::error(
-                        IssueType::invalid(),
-                        "Column name is required".to_string(),
-                    ));
-                };
-
-                let result = fp_engine
-                    .evaluate_with_config(path, vec![context; 1], fp_config.clone())
-                    .await
-                    .map_err(|e| {
-                        OperationOutcomeError::error(
-                            IssueType::exception(),
-                            format!("Error evaluating expression: {e}"),
-                        )
-                    })?;
-
-                let column_type = column
-                    .type_
-                    .as_ref()
-                    .and_then(|t| t.value.as_deref())
-                    // Default to string.
-                    .unwrap_or(
-                        // If column type is not set than assume it's the first values fhir_type
-                        // or default to string if there are no values.
-                        result
-                            .iter()
-                            .peekable()
-                            .next()
-                            .map_or("string", haste_reflect::MetaValue::fhir_type),
-                    );
-
-                let mut column_result = result
-                    .iter()
-                    .map(|value| conversions::primitives::convert_meta_value(column_type, value))
-                    .collect::<Result<Vec<Option<PrimitiveValue>>, OperationOutcomeError>>()?;
-
-                let is_collection = column
-                    .collection
-                    .as_ref()
-                    .and_then(|c| c.value)
-                    .unwrap_or(false);
-
-                let insert_value = if is_collection {
-                    OutputResults::Collection(column_result)
-                } else {
-                    if column_result.len() > 1 {
-                        return Err(OperationOutcomeError::error(
-                            IssueType::invalid(),
-                            "Column result is a collection but the column is not marked as a collection"
-                                .to_string(),
-                        ));
-                    }
-
-                    let mut singular_value = None;
-
-                    if let Some(first_value) = column_result.get_mut(0) {
-                        std::mem::swap(&mut singular_value, first_value);
-                    }
-
-                    OutputResults::Scalar(singular_value)
-                };
-
-                output_result.insert(name.to_string(), insert_value);
-            }
-            select_results.push(output_result);
-        }
+        let select_results = process_select_statement(
+            &fp_engine,
+            fp_config,
+            select_statement,
+            &input,
+            iterable_context,
+            set_null,
+        )
+        .await?;
 
         select_statement_results.push(select_results);
     }
@@ -382,6 +231,212 @@ async fn process_resource<
     let output_results = cartesian_product(select_statement_results);
 
     Ok(output_results)
+}
+
+async fn build_iterable_context<'a>(
+    fp_engine: &FPEngine,
+    fp_config: Arc<Config<'a>>,
+    select_statement: &'a ViewDefinitionSelect,
+    input: &'a Resource,
+) -> Result<(Option<Vec<haste_fhirpath::Context<'a>>>, bool), OperationOutcomeError> {
+    let mut iterable_context = None;
+    let mut set_null = false;
+
+    if let Some(for_each_fp) = select_statement
+        .forEach
+        .as_ref()
+        .and_then(|f| f.value.as_ref())
+    {
+        iterable_context = Some(vec![
+            fp_engine
+                .evaluate_with_config(for_each_fp, vec![input], fp_config.clone())
+                .await
+                .map_err(|e| {
+                    OperationOutcomeError::error(
+                        IssueType::exception(),
+                        format!("Error evaluating forEach expression: {e}"),
+                    )
+                })?,
+        ]);
+    } else if let Some(for_each_or_null_fp) = select_statement
+        .forEachOrNull
+        .as_ref()
+        .and_then(|f| f.value.as_ref())
+    {
+        iterable_context = Some(vec![
+            fp_engine
+                .evaluate_with_config(for_each_or_null_fp, vec![input], fp_config.clone())
+                .await
+                .map_err(|e| {
+                    OperationOutcomeError::error(
+                        IssueType::exception(),
+                        format!("Error evaluating forEachOrNull expression: {e}"),
+                    )
+                })?,
+        ]);
+
+        set_null = true;
+    } else if let Some(repeat) = select_statement
+        .repeat
+        .as_ref()
+        .map(|r| r.iter().filter_map(|r| r.value.as_ref()))
+    {
+        let mut repeat_fps = vec![];
+
+        for repeat_fp in repeat {
+            let repeat = format!("$this.repeat({repeat_fp})");
+
+            repeat_fps.push(
+                fp_engine
+                    .evaluate_with_config(&repeat, vec![input], fp_config.clone())
+                    .await
+                    .map_err(|e| {
+                        OperationOutcomeError::error(
+                            IssueType::exception(),
+                            format!("Error evaluating repeat expression: {e}"),
+                        )
+                    })?,
+            );
+        }
+
+        iterable_context = Some(repeat_fps);
+    }
+
+    Ok((iterable_context, set_null))
+}
+
+async fn process_select_statement<'a>(
+    fp_engine: &FPEngine,
+    fp_config: Arc<Config<'a>>,
+    select_statement: &'a ViewDefinitionSelect,
+    input: &'a Resource,
+    iterable_context: Option<Vec<haste_fhirpath::Context<'a>>>,
+    set_null: bool,
+) -> Result<Vec<OrderMap<String, OutputResults>>, OperationOutcomeError> {
+    let select_context: Vec<&dyn MetaValue> = if let Some(iterable) = iterable_context.as_ref() {
+        iterable
+            .iter()
+            .flat_map(haste_fhirpath::Context::iter)
+            .collect()
+    } else {
+        vec![input]
+    };
+
+    let mut select_results = Vec::with_capacity(select_context.len());
+
+    if set_null && select_context.is_empty() {
+        let output_result = build_null_result(select_statement)?;
+        select_results.push(output_result);
+    }
+
+    for context in select_context {
+        let output_result =
+            process_select_context(fp_engine, fp_config.clone(), select_statement, context).await?;
+
+        select_results.push(output_result);
+    }
+
+    Ok(select_results)
+}
+
+fn build_null_result(
+    select_statement: &ViewDefinitionSelect,
+) -> Result<OrderMap<String, OutputResults>, OperationOutcomeError> {
+    let mut output_result = OrderMap::new();
+
+    for column in select_statement.column.as_ref().into_iter().flatten() {
+        let Some(name) = column.name.value.as_deref() else {
+            return Err(OperationOutcomeError::error(
+                IssueType::invalid(),
+                "Column name is required".to_string(),
+            ));
+        };
+
+        output_result.insert(name.to_string(), OutputResults::Scalar(None));
+    }
+
+    Ok(output_result)
+}
+
+async fn process_select_context<'a>(
+    fp_engine: &FPEngine,
+    fp_config: Arc<Config<'a>>,
+    select_statement: &'a ViewDefinitionSelect,
+    context: &'a dyn MetaValue,
+) -> Result<OrderMap<String, OutputResults>, OperationOutcomeError> {
+    let mut output_result = OrderMap::new();
+
+    for column in select_statement.column.as_ref().into_iter().flatten() {
+        let Some(path) = column.path.value.as_deref() else {
+            return Err(OperationOutcomeError::error(
+                IssueType::invalid(),
+                "Column path is required".to_string(),
+            ));
+        };
+
+        let Some(name) = column.name.value.as_deref() else {
+            return Err(OperationOutcomeError::error(
+                IssueType::invalid(),
+                "Column name is required".to_string(),
+            ));
+        };
+
+        let result = fp_engine
+            .evaluate_with_config(path, vec![context], fp_config.clone())
+            .await
+            .map_err(|e| {
+                OperationOutcomeError::error(
+                    IssueType::exception(),
+                    format!("Error evaluating expression: {e}"),
+                )
+            })?;
+
+        let column_type = column
+            .type_
+            .as_ref()
+            .and_then(|t| t.value.as_deref())
+            .unwrap_or_else(|| {
+                result
+                    .iter()
+                    .next()
+                    .map_or("string", haste_reflect::MetaValue::fhir_type)
+            });
+
+        let mut column_result = result
+            .iter()
+            .map(|value| conversions::primitives::convert_meta_value(column_type, value))
+            .collect::<Result<Vec<Option<PrimitiveValue>>, OperationOutcomeError>>()?;
+
+        let is_collection = column
+            .collection
+            .as_ref()
+            .and_then(|c| c.value)
+            .unwrap_or(false);
+
+        let insert_value = if is_collection {
+            OutputResults::Collection(column_result)
+        } else {
+            if column_result.len() > 1 {
+                return Err(OperationOutcomeError::error(
+                    IssueType::invalid(),
+                    "Column result is a collection but the column is not marked as a collection"
+                        .to_string(),
+                ));
+            }
+
+            let mut singular_value = None;
+
+            if let Some(first_value) = column_result.get_mut(0) {
+                std::mem::swap(&mut singular_value, first_value);
+            }
+
+            OutputResults::Scalar(singular_value)
+        };
+
+        output_result.insert(name.to_string(), insert_value);
+    }
+
+    Ok(output_result)
 }
 
 fn flatten_results(resource: Vec<Resource>) -> Vec<Resource> {

--- a/backend/crates/sql-on-fhir/src/lib.rs
+++ b/backend/crates/sql-on-fhir/src/lib.rs
@@ -76,10 +76,7 @@ async fn resolve_view_definition<
             .ok_or_else(|| {
                 OperationOutcomeError::error(
                     IssueType::not_found(),
-                    format!(
-                        "ViewDefinition not found with id '{:?}'",
-                        view_definition_id
-                    ),
+                    format!("ViewDefinition not found with id '{view_definition_id:?}'"),
                 )
             })?;
 
@@ -127,7 +124,7 @@ async fn get_resources_to_process<
         let resource_type = ResourceType::try_from(resource_type).map_err(|e| {
             OperationOutcomeError::error(
                 IssueType::invalid(),
-                format!("Invalid resource type: {}", e),
+                format!("Invalid resource type: {e}"),
             )
         })?;
 
@@ -147,9 +144,7 @@ async fn get_resources_to_process<
     }
 }
 
-fn build_hashmap_fp_variables<'a>(
-    viewdefinition: &'a ViewDefinition,
-) -> HashMap<String, &'a dyn MetaValue> {
+fn build_hashmap_fp_variables(viewdefinition: &ViewDefinition) -> HashMap<String, &dyn MetaValue> {
     let mut hashmap = HashMap::new();
 
     if let Some(constants) = &viewdefinition.constant {
@@ -202,19 +197,19 @@ async fn process_resource<
     _client: Arc<Client>,
     variables: Arc<HashMap<String, &dyn MetaValue>>,
     view_definition: &ViewDefinition,
-    input: Box<Resource>,
+    input: Resource,
 ) -> Result<Vec<OrderMap<String, OutputResults>>, OperationOutcomeError> {
     let fp_engine = FPEngine::new();
 
     let mut select_statement_results = Vec::with_capacity(view_definition.select.len());
 
-    for select_statement in view_definition.select.iter() {
+    for select_statement in &view_definition.select {
         let fp_config = Arc::new(
             Config::builder()
                 .with_variable_resolver(haste_fhirpath::ExternalConstantResolver::Variable(
                     variables.clone(),
                 ))
-                .with_resource_id(input.id().clone().unwrap_or("".to_string())),
+                .with_resource_id(input.id().clone().unwrap_or_default()),
         );
 
         let mut iterable_context = None;
@@ -232,7 +227,7 @@ async fn process_resource<
                     .map_err(|e| {
                         OperationOutcomeError::error(
                             IssueType::exception(),
-                            format!("Error evaluating forEach expression: {}", e),
+                            format!("Error evaluating forEach expression: {e}"),
                         )
                     })?,
             ]);
@@ -248,19 +243,19 @@ async fn process_resource<
                     .map_err(|e| {
                         OperationOutcomeError::error(
                             IssueType::exception(),
-                            format!("Error evaluating forEachOrNull expression: {}", e),
+                            format!("Error evaluating forEachOrNull expression: {e}"),
                         )
                     })?,
             ]);
             set_null = true;
-        } else if let Some(_repeat) = select_statement
+        } else if let Some(repeat) = select_statement
             .repeat
             .as_ref()
             .map(|r| r.iter().filter_map(|r| r.value.as_ref()))
         {
             let mut repeat_fps = vec![];
-            for repeat_fp in _repeat {
-                let repeat = format!("$this.repeat({})", repeat_fp);
+            for repeat_fp in repeat {
+                let repeat = format!("$this.repeat({repeat_fp})");
                 repeat_fps.push(
                     fp_engine
                         .evaluate_with_config(&repeat, vec![&input], fp_config.clone())
@@ -268,7 +263,7 @@ async fn process_resource<
                         .map_err(|e| {
                             OperationOutcomeError::error(
                                 IssueType::exception(),
-                                format!("Error evaluating repeat expression: {}", e),
+                                format!("Error evaluating repeat expression: {e}"),
                             )
                         })?,
                 );
@@ -281,7 +276,7 @@ async fn process_resource<
         {
             iterable
                 .iter()
-                .flat_map(|item| item.iter())
+                .flat_map(haste_fhirpath::Context::iter)
                 .collect::<Vec<&dyn MetaValue>>()
         } else {
             vec![&input]
@@ -292,7 +287,7 @@ async fn process_resource<
         if set_null && select_context.is_empty() {
             let mut output_result = OrderMap::new();
             for column in select_statement.column.as_ref().into_iter().flatten() {
-                let Some(name) = column.name.value.as_ref().map(|n| n.as_str()) else {
+                let Some(name) = column.name.value.as_deref() else {
                     return Err(OperationOutcomeError::error(
                         IssueType::invalid(),
                         "Column name is required".to_string(),
@@ -306,14 +301,14 @@ async fn process_resource<
         for context in select_context {
             let mut output_result = OrderMap::new();
             for column in select_statement.column.as_ref().into_iter().flatten() {
-                let Some(path) = column.path.value.as_ref().map(|p| p.as_str()) else {
+                let Some(path) = column.path.value.as_deref() else {
                     return Err(OperationOutcomeError::error(
                         IssueType::invalid(),
                         "Column path is required".to_string(),
                     ));
                 };
 
-                let Some(name) = column.name.value.as_ref().map(|n| n.as_str()) else {
+                let Some(name) = column.name.value.as_deref() else {
                     return Err(OperationOutcomeError::error(
                         IssueType::invalid(),
                         "Column name is required".to_string(),
@@ -326,15 +321,14 @@ async fn process_resource<
                     .map_err(|e| {
                         OperationOutcomeError::error(
                             IssueType::exception(),
-                            format!("Error evaluating expression: {}", e),
+                            format!("Error evaluating expression: {e}"),
                         )
                     })?;
 
                 let column_type = column
                     .type_
                     .as_ref()
-                    .and_then(|t| t.value.as_ref())
-                    .map(|t| t.as_str())
+                    .and_then(|t| t.value.as_deref())
                     // Default to string.
                     .unwrap_or(
                         // If column type is not set than assume it's the first values fhir_type
@@ -343,8 +337,7 @@ async fn process_resource<
                             .iter()
                             .peekable()
                             .next()
-                            .map(|v| v.fhir_type())
-                            .unwrap_or("string"),
+                            .map_or("string", haste_reflect::MetaValue::fhir_type),
                     );
 
                 let mut column_result = result
@@ -391,19 +384,19 @@ async fn process_resource<
     Ok(output_results)
 }
 
-fn flatten_results(resource: Vec<Resource>) -> Vec<Box<Resource>> {
+fn flatten_results(resource: Vec<Resource>) -> Vec<Resource> {
     let mut resources = Vec::new();
     for resource in resource {
         match resource {
             Resource::Bundle(bundle) => {
                 for entry in bundle.entry.into_iter().flatten() {
                     if let Some(resource) = entry.resource {
-                        resources.push(resource);
+                        resources.push(*resource);
                     }
                 }
             }
             _ => {
-                resources.push(Box::new(resource));
+                resources.push(resource);
             }
         }
     }
@@ -430,7 +423,7 @@ async fn passes_where_clauses(
             .map_err(|e| {
                 OperationOutcomeError::error(
                     IssueType::exception(),
-                    format!("Error evaluating where clause expression: {}", e),
+                    format!("Error evaluating where clause expression: {e}"),
                 )
             })?;
 
@@ -455,7 +448,7 @@ async fn passes_where_clauses(
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        if bool_results.iter().any(|v| **v == false) {
+        if bool_results.iter().any(|v| !**v) {
             return Ok(false);
         }
     }
@@ -477,7 +470,7 @@ async fn process_view_definition<
     let _limit = input
         ._limit
         .as_ref()
-        .and_then(|limit| limit.value.clone())
+        .and_then(|limit| limit.value)
         .unwrap_or(1000);
 
     let input_ = flatten_results(
@@ -489,13 +482,11 @@ async fn process_view_definition<
     let where_clauses = view_definition
         .where_
         .as_ref()
-        .map(|w| Cow::Borrowed(w))
-        .unwrap_or_else(|| Cow::Owned(vec![]));
+        .map_or_else(|| Cow::Owned(Vec::new()), Cow::Borrowed);
 
     let where_fp_clauses = where_clauses
         .iter()
-        .filter_map(|w| w.path.value.as_ref())
-        .map(|s| s.as_str())
+        .filter_map(|w| w.path.value.as_deref())
         .collect::<Vec<_>>();
 
     for resource in input_ {
@@ -503,7 +494,7 @@ async fn process_view_definition<
             &FPEngine::new(),
             variables.clone(),
             where_fp_clauses.as_slice(),
-            resource.as_ref(),
+            &resource,
         )
         .await?
         {
@@ -530,7 +521,7 @@ async fn process_view_definition<
 
     match output_format {
         binding if binding == &OutputFormatCodes::csv() => {
-            let data = output::csv::csv(results)?;
+            let data = output::csv::csv(&results)?;
 
             let base64_string: String = general_purpose::STANDARD.encode(&data);
 
@@ -543,7 +534,7 @@ async fn process_view_definition<
             })
         }
         binding if binding == &OutputFormatCodes::json() => {
-            let data = output::json::json(results)?;
+            let data = output::json::json(&results)?;
 
             let base64_string: String = general_purpose::STANDARD.encode(&data);
 
@@ -569,11 +560,22 @@ async fn process_view_definition<
         }
         _ => Err(OperationOutcomeError::error(
             IssueType::not_supported(),
-            format!("Output format '{:?}' is not supported", output_format),
+            format!("Output format '{output_format:?}' is not supported"),
         )),
     }
 }
 
+/// Runs a FHIR `ViewDefinition` and returns the generated result in the requested
+/// output format.
+///
+/// The output format is read from the `_format` input parameter. If `_format` is
+/// absent or does not contain a recognized [`OutputFormatCodes`] value, CSV is
+/// used as the default format.
+///
+/// # Errors
+///
+/// Returns [`OperationOutcomeError`] if the view definition cannot be resolved
+/// or if processing the view definition fails.
 pub async fn view_definition_run<
     CTX: Send + Sync + Clone + 'static,
     Client: FHIRClient<CTX, OperationOutcomeError> + Send + Sync + 'static,
@@ -590,14 +592,14 @@ pub async fn view_definition_run<
         .unwrap_or(OutputFormatCodes::csv());
 
     let view_definition =
-        Arc::new(resolve_view_definition(context.clone(), client.as_ref(), &input).await?);
+        Arc::new(resolve_view_definition(context.clone(), client.as_ref(), input).await?);
 
     let output = process_view_definition(
         context,
         &output_format,
         client,
         view_definition.as_ref(),
-        &input,
+        input,
     )
     .await?;
 

--- a/backend/crates/sql-on-fhir/src/output/csv.rs
+++ b/backend/crates/sql-on-fhir/src/output/csv.rs
@@ -19,16 +19,14 @@ fn append_primitive_value(buffer: &mut String, value: &PrimitiveValue) {
     }
 }
 
-pub fn csv(
-    results: Vec<OrderMap<String, OutputResults>>,
-) -> Result<Vec<u8>, OperationOutcomeError> {
+pub fn csv(results: &[OrderMap<String, OutputResults>]) -> Result<Vec<u8>, OperationOutcomeError> {
     let mut byte_vector = Vec::new();
     let mut writer = csv::WriterBuilder::new()
         .has_headers(false)
         .from_writer(&mut byte_vector);
     let mut column_names = Vec::new();
 
-    if let Some(header_col) = results.get(0) {
+    if let Some(header_col) = results.first() {
         column_names = header_col.keys().cloned().collect();
 
         writer.write_record(column_names.iter()).map_err(|_e| {
@@ -42,10 +40,10 @@ pub fn csv(
     let mut row = csv::StringRecord::new();
     let mut cell_buffer = String::new();
 
-    for result in &results {
+    for result in results {
         row.clear();
 
-        for key in column_names.iter() {
+        for key in &column_names {
             cell_buffer.clear();
 
             if let Some(value) = result.get(key) {

--- a/backend/crates/sql-on-fhir/src/output/json.rs
+++ b/backend/crates/sql-on-fhir/src/output/json.rs
@@ -4,9 +4,7 @@ use ordermap::OrderMap;
 
 use crate::OutputResults;
 
-pub fn json(
-    results: Vec<OrderMap<String, OutputResults>>,
-) -> Result<Vec<u8>, OperationOutcomeError> {
+pub fn json(results: &[OrderMap<String, OutputResults>]) -> Result<Vec<u8>, OperationOutcomeError> {
     let mut byte_vector = Vec::new();
 
     serde_json::to_writer(&mut byte_vector, &results).map_err(|_e| {


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.