### PR TITLE
Add `cargo doc` step to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  clippy_rustfmt:
+  rustfmt-clippy-doc:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,8 +22,8 @@ jobs:
           components: clippy, rustfmt
 
       - name: Run rustfmt
-        run: cargo fmt --all -- --check --verbose
         working-directory: ./backend
+        run: cargo fmt --all -- --check --verbose
 
       - name: Run clippy
         working-directory: ./backend
@@ -65,6 +65,7 @@ jobs:
           -- -Dclippy::all -Dclippy::pedantic
 
       - name: Run cargo doc
+        working-directory: ./backend
         env:
           RUSTDOCFLAGS: "-D warnings"
         run: cargo doc --workspace --no-deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,11 @@ jobs:
           -p haste-x-fhir-query \
           -- -Dclippy::all -Dclippy::pedantic
 
+      - name: Run cargo doc
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --workspace --no-deps
+
   unit-tests:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This PR adds a GitHub Actions step to verify the documentation for each crate in the workspace by running `cargo doc`.
