### PR TITLE
Resolve last `clippy` lints for `sql-on-fhir`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
           -p haste-reflect-derive \
           -p haste-repository \
           -p haste-sd-to-json-schema \
+          -p haste-sql-on-fhir \
           -p haste-testscript-runner \
           -p haste-wal-worker \
           -p haste-worker \

--- a/backend/crates/sql-on-fhir/src/conversions/primitives.rs
+++ b/backend/crates/sql-on-fhir/src/conversions/primitives.rs
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 #[serde(untagged)]
 pub enum PrimitiveValue {
     Boolean(bool),
-    Number(f64),
+    U64(u64),
+    I64(i64),
+    F64(f64),
     String(String),
 }
 
@@ -119,16 +121,13 @@ fn convert_fhir_primitive(
                 .map(|date_time| PrimitiveValue::String(date_time.to_string()))
         }),
         "decimal" => convert_with::<FHIRDecimal, _, _>(value, "decimal", |primitive| {
-            primitive.value.map(PrimitiveValue::Number)
+            primitive.value.map(PrimitiveValue::F64)
         }),
         "boolean" => convert_with::<FHIRBoolean, _, _>(value, "boolean", |primitive| {
             primitive.value.map(PrimitiveValue::Boolean)
         }),
         "integer" => convert_with::<FHIRInteger, _, _>(value, "integer", |primitive| {
-            primitive
-                .value
-                // FIXME: Do not convert to f64.
-                .map(|number| PrimitiveValue::Number(number as f64))
+            primitive.value.map(PrimitiveValue::I64)
         }),
         "string" => convert_with::<FHIRString, _, _>(value, "string", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
@@ -152,16 +151,10 @@ fn convert_fhir_primitive(
             primitive.value.clone().map(PrimitiveValue::String)
         }),
         "unsignedInt" => convert_with::<FHIRUnsignedInt, _, _>(value, "unsignedInt", |primitive| {
-            primitive
-                .value
-                // FIXME: Do not convert to f64.
-                .map(|number| PrimitiveValue::Number(number as f64))
+            primitive.value.map(PrimitiveValue::U64)
         }),
         "positiveInt" => convert_with::<FHIRPositiveInt, _, _>(value, "positiveInt", |primitive| {
-            primitive
-                .value
-                // FIXME: Do not convert to f64.
-                .map(|number| PrimitiveValue::Number(number as f64))
+            primitive.value.map(PrimitiveValue::U64)
         }),
         "markdown" => convert_with::<FHIRMarkdown, _, _>(value, "markdown", |primitive| {
             primitive.value.clone().map(PrimitiveValue::String)
@@ -204,13 +197,12 @@ fn convert_fhirpath_system_type(
             .as_any()
             .downcast_ref::<i64>()
             .copied()
-            // FIXME: Do not convert to f64.
-            .map(|number| PrimitiveValue::Number(number as f64))),
+            .map(PrimitiveValue::I64)),
         "http://hl7.org/fhirpath/System.Decimal" => Ok(value
             .as_any()
             .downcast_ref::<f64>()
             .copied()
-            .map(PrimitiveValue::Number)),
+            .map(PrimitiveValue::F64)),
         "http://hl7.org/fhirpath/System.Date" => Ok(value
             .as_any()
             .downcast_ref::<Date>()

--- a/backend/crates/sql-on-fhir/src/lib.rs
+++ b/backend/crates/sql-on-fhir/src/lib.rs
@@ -223,7 +223,7 @@ async fn get_resources_to_process<
     if !patient_references.is_empty() {
         let last_updated_filter = since_instant
             .as_ref()
-            .map(|since| format!("gt{since}"));
+            .map(|since| format!("gt{since:?}"));
 
         return compartment::resources_for_patients(
             context,

--- a/backend/crates/sql-on-fhir/src/lib.rs
+++ b/backend/crates/sql-on-fhir/src/lib.rs
@@ -41,7 +41,7 @@ fn reference_value(reference: &Reference) -> Result<String, OperationOutcomeErro
 /// Resolves the `patient` and `group` input parameters into a flat,
 /// de-duplicated list of patient reference strings (e.g. `"Patient/123"`).
 /// `group` members that aren't Patient references are skipped, since
-/// non-Patient compartments (Practitioner, Device, RelatedPerson) aren't
+/// non-Patient compartments `(Practitioner, Device, RelatedPerson)` aren't
 /// supported yet.
 async fn resolve_patient_references<
     CTX: Send + Sync + Clone + 'static,
@@ -223,7 +223,7 @@ async fn get_resources_to_process<
     if !patient_references.is_empty() {
         let last_updated_filter = since_instant
             .as_ref()
-            .map(|since| format!("gt{}", since.to_string()));
+            .map(|since| format!("gt{since}"));
 
         return compartment::resources_for_patients(
             context,
@@ -237,9 +237,9 @@ async fn get_resources_to_process<
 
     let since = since_instant.unwrap_or(r4::datetime::Instant::Iso8601(Utc::now()));
 
-    let resource_limit = requested_limit(input)
-        .map(|limit| limit.min(MAX_RESOURCES_PER_RUN))
-        .unwrap_or(MAX_RESOURCES_PER_RUN);
+    let resource_limit = requested_limit(input).map_or(MAX_RESOURCES_PER_RUN, |limit| {
+        limit.min(MAX_RESOURCES_PER_RUN)
+    });
 
     let mut combined: Option<Bundle> = None;
     let mut offset = 0u32;

--- a/backend/crates/sql-on-fhir/src/lib.rs
+++ b/backend/crates/sql-on-fhir/src/lib.rs
@@ -221,9 +221,7 @@ async fn get_resources_to_process<
     let patient_references = resolve_patient_references(context.clone(), client, input).await?;
 
     if !patient_references.is_empty() {
-        let last_updated_filter = since_instant
-            .as_ref()
-            .map(|since| format!("gt{since:?}"));
+        let last_updated_filter = since_instant.as_ref().map(|since| format!("gt{since:?}"));
 
         return compartment::resources_for_patients(
             context,

--- a/backend/crates/sql-on-fhir/src/output/csv.rs
+++ b/backend/crates/sql-on-fhir/src/output/csv.rs
@@ -10,9 +10,16 @@ fn append_primitive_value(buffer: &mut String, value: &PrimitiveValue) {
         PrimitiveValue::Boolean(b) => {
             let _ = write!(buffer, "{b}");
         }
-        PrimitiveValue::Number(n) => {
-            let _ = write!(buffer, "{n}");
+        PrimitiveValue::U64(u) => {
+            let _ = write!(buffer, "{u}");
         }
+        PrimitiveValue::I64(i) => {
+            let _ = write!(buffer, "{i}");
+        }
+        PrimitiveValue::F64(f) => {
+            let _ = write!(buffer, "{f}");
+        }
+
         PrimitiveValue::String(s) => {
             buffer.push_str(s);
         }


### PR DESCRIPTION
This PR resolves last `clippy` lints for `sql-on-fhir` and enables their checks in CI.

It fixes #930 