### PR TITLE
Use FHIR Root as AUD instead of ClientApp ID.

### DIFF
--- a/backend/crates/server/src/auth_n/middleware/jwt.rs
+++ b/backend/crates/server/src/auth_n/middleware/jwt.rs
@@ -1,6 +1,12 @@
 use crate::{
-    auth_n::certificates, config::ServerConfig, extract::bearer_token::AuthBearer,
-    route_path::project_path, services::ServerState,
+    auth_n::certificates,
+    config::ServerConfig,
+    extract::{
+        bearer_token::AuthBearer,
+        path_tenant::{ProjectIdentifier, TenantIdentifier},
+    },
+    route_path::{api_fhir_root_url, project_path},
+    services::ServerState,
 };
 use axum::{
     extract::{OriginalUri, Request, State},
@@ -8,6 +14,7 @@ use axum::{
     middleware::Next,
     response::{IntoResponse as _, Response},
 };
+use axum_extra::extract::Cached;
 use derivative::Derivative;
 use haste_fhir_model::r4::generated::terminology::IssueType;
 use haste_fhir_operation_error::OperationOutcomeError;
@@ -16,10 +23,7 @@ use haste_fhir_terminology::FHIRTerminology;
 use haste_jwt::{ProjectId, TenantId, claims::UserTokenClaims};
 use haste_repository::Repository;
 use jsonwebtoken::Validation;
-use std::{
-    path::PathBuf,
-    sync::{Arc, LazyLock},
-};
+use std::{path::PathBuf, sync::Arc};
 use url::Url;
 
 #[derive(Derivative)]
@@ -31,13 +35,12 @@ pub struct User {
     pub claims: haste_jwt::claims::UserTokenClaims,
 }
 
-static VALIDATION_CONFIG: LazyLock<Validation> = LazyLock::new(|| {
-    let mut config = Validation::new(jsonwebtoken::Algorithm::RS256);
-    config.validate_aud = false;
-    config
-});
-
-fn validate_jwt(config: &ServerConfig, token: &str) -> Result<UserTokenClaims, StatusCode> {
+fn validate_jwt(
+    config: &ServerConfig,
+    tenant: &TenantId,
+    project: &ProjectId,
+    token: &str,
+) -> Result<UserTokenClaims, StatusCode> {
     let header = jsonwebtoken::decode_header(token).map_err(|_| StatusCode::UNAUTHORIZED)?;
 
     let kid = header.kid.ok_or(StatusCode::UNAUTHORIZED)?;
@@ -48,12 +51,17 @@ fn validate_jwt(config: &ServerConfig, token: &str) -> Result<UserTokenClaims, S
         .decoding_key(kid.as_str())
         .map_err(|_| StatusCode::UNAUTHORIZED)?;
 
-    let result = jsonwebtoken::decode::<UserTokenClaims>(
-        token,
-        &decoding_key.decoding_key,
-        &VALIDATION_CONFIG,
-    )
-    .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    // Per SMART on FHIR, `aud` identifies the FHIR resource server a token was
+    // minted for, binding the token to this tenant/project's FHIR endpoint.
+    let expected_audience = api_fhir_root_url(&config.api_uri, tenant, project)
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+    let mut validation = Validation::new(jsonwebtoken::Algorithm::RS256);
+    validation.set_audience(&[expected_audience.as_str()]);
+
+    let result =
+        jsonwebtoken::decode::<UserTokenClaims>(token, &decoding_key.decoding_key, &validation)
+            .map_err(|_| StatusCode::UNAUTHORIZED)?;
 
     Ok(result.claims)
 }
@@ -146,6 +154,8 @@ pub async fn token_verifcation<
     Terminology: FHIRTerminology + Send + Sync + 'static,
 >(
     State(state): State<Arc<ServerState<Repo, Search, Terminology>>>,
+    Cached(TenantIdentifier { tenant }): Cached<TenantIdentifier>,
+    Cached(ProjectIdentifier { project }): Cached<ProjectIdentifier>,
     // run the `HeaderMap` extractor
     AuthBearer(token): AuthBearer,
     // you can also add more extractors here but the last
@@ -163,7 +173,7 @@ pub async fn token_verifcation<
         ));
     };
 
-    match validate_jwt(state.config.as_ref(), &token) {
+    match validate_jwt(state.config.as_ref(), &tenant, &project, &token) {
         Ok(claims) => {
             request.extensions_mut().insert(Arc::new(User {
                 token: Some(token),

--- a/backend/crates/server/src/auth_n/oidc/routes/token.rs
+++ b/backend/crates/server/src/auth_n/oidc/routes/token.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     config::ServerConfig,
     extract::path_tenant::{ProjectIdentifier, TenantIdentifier},
+    route_path::api_fhir_root_url,
     services::ServerState,
 };
 use axum::{
@@ -97,6 +98,11 @@ async fn create_token_response<Repo: Repository>(
     grant_type_used: &schemas::token_body::OAuth2TokenBodyGrantType,
     args: TokenResponseArguments,
 ) -> Result<TokenResponse, OIDCError> {
+    // Per SMART on FHIR, `aud` identifies the FHIR resource server the token is
+    // valid for, binding the token to this tenant/project's FHIR endpoint.
+    let audience = api_fhir_root_url(&config.api_uri, &args.tenant, &args.project)
+        .map_err(|e| OIDCError::new(OIDCErrorCode::ServerError, Some(e.to_string()), None))?;
+
     let cert_provider = get_certification_provider(config);
     let encoding_key = cert_provider.encoding_key().map_err(|_e| {
         OIDCError::new(
@@ -136,7 +142,7 @@ async fn create_token_response<Repo: Repository>(
             sub: AuthorId::new(args.user_id.clone()),
             exp: (chrono::Utc::now() + chrono::Duration::seconds(TOKEN_EXPIRATION as i64))
                 .timestamp() as usize,
-            aud: args.client_id.clone(),
+            aud: audience.to_string(),
             scope: args.scopes.clone(),
             tenant: args.tenant.clone(),
             subscription_tier: SubscriptionTier::try_from(tenant.subscription_tier).map_err(


### PR DESCRIPTION
Stays more inline with SOF and allows cheaper AUD verification to occur.