### PR TITLE
Resolve `clippy` lints for `server` crate (1/N)

### DIFF
--- a/backend/crates/server/src/auth_n/email.rs
+++ b/backend/crates/server/src/auth_n/email.rs
@@ -126,7 +126,7 @@ pub async fn send_password_reset_email<
         &Uri::try_from(api_url.as_str()).map_err(|_| {
             OperationOutcomeError::fatal(IssueType::exception(), "API Url is invalid".to_string())
         })?,
-        html! {
+        &html! {
             @if let Some(message) = message.body {
                 div style="padding-top: 24px;" {
                     (message)

--- a/backend/crates/server/src/auth_n/global/routes/login.rs
+++ b/backend/crates/server/src/auth_n/global/routes/login.rs
@@ -40,7 +40,7 @@ pub async fn global_login_get(
     let global_login_post_uri = "/auth/login";
     let signup_url = "/auth/signup";
 
-    Ok(page_html(html! {
+    Ok(page_html(&html! {
             (banner("Login", None))
             div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow  md:mt-0  xl:p-0" {
                 form class="space-y-4 md:space-y-6" action=(global_login_post_uri) method="POST" {
@@ -103,7 +103,7 @@ pub async fn global_login_post<
         &Uri::try_from(api_url.as_str()).map_err(|_| {
             OperationOutcomeError::fatal(IssueType::exception(), "API Url is invalid".to_string())
         })?,
-        html! {
+        &html! {
             div style="padding-top: 24px;" {
                 "We received a request to log in to your account. If you made this request, click one of the tenants we found associated with your email."
             }
@@ -139,7 +139,7 @@ pub async fn global_login_post<
     Ok(message_html(
         None,
         None,
-        html! { div class="space-y-4 text-slate-900" {
+        &html! { div class="space-y-4 text-slate-900" {
 
                 r#"An email has been sent to your email address "#
                 span class="underline text-brand-600" { (&login_data.email) }

--- a/backend/crates/server/src/auth_n/global/routes/signup.rs
+++ b/backend/crates/server/src/auth_n/global/routes/signup.rs
@@ -41,12 +41,12 @@ pub async fn global_signup_get<
     CSRFToken(csrf_token): CSRFToken,
     State(_app_state): State<Arc<ServerState<Repo, Search, Terminology>>>,
 ) -> Result<Response, OperationOutcomeError> {
-    Ok(page_html(html! {
+    Ok(page_html(&html! {
         (banner("Sign up", None))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow  md:mt-0  xl:p-0 " {
             form class="space-y-4 p-6 sm:p-8" action=("/auth/signup") method="POST" {
                 input type="hidden" name="csrf_token" value=(csrf_token) {}
-                div class="grid grid-cols-4 gap-1 space-y-1" {                
+                div class="grid grid-cols-4 gap-1 space-y-1" {
                     div class="col-span-4" {
                         label for="email" class="block text-sm font-medium text-slate-600 dark:text-white" {
                             "Email address"
@@ -181,7 +181,7 @@ pub async fn global_signup_post<
     Ok(message_html(
 None,
         None,
-        html! {
+        &html! {
             div {
                 span {
                     "Welcome to Haste Health"

--- a/backend/crates/server/src/auth_n/global/routes/tenant_select.rs
+++ b/backend/crates/server/src/auth_n/global/routes/tenant_select.rs
@@ -30,7 +30,7 @@ pub async fn tenant_select_get<
     let signup_url = "/auth/signup";
     let action_url = "/auth/tenant-select";
 
-    Ok(page_html(html! {
+    Ok(page_html(&html! {
         (banner("Enter your tenant identifier", None))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow md:mt-0 xl:p-0 text-slate-700" {
             div class="p-6 space-y-4 md:space-y-6 sm:p-8" {

--- a/backend/crates/server/src/auth_n/mfa/routes/activate.rs
+++ b/backend/crates/server/src/auth_n/mfa/routes/activate.rs
@@ -244,7 +244,7 @@ pub async fn activate_post<
     Ok(message_html(
         Some(&tenant),
         None,
-        html! { span {
+        &html! { span {
                 "MFA has been activated successfully. You can close this window."
             }
         },

--- a/backend/crates/server/src/auth_n/oidc/extract/body.rs
+++ b/backend/crates/server/src/auth_n/oidc/extract/body.rs
@@ -26,7 +26,7 @@ where
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
 
-        let bytes = to_bytes(body, 1000000).await.map_err(|_e| {
+        let bytes = to_bytes(body, 1_000_000).await.map_err(|_e| {
             OperationOutcomeError::fatal(
                 IssueType::exception(),
                 "Failed to extract request body".to_string(),

--- a/backend/crates/server/src/auth_n/oidc/routes/interactions/password_reset.rs
+++ b/backend/crates/server/src/auth_n/oidc/routes/interactions/password_reset.rs
@@ -103,7 +103,7 @@ pub async fn password_reset_initiate_post<
         Ok(message_html(
             Some(&tenant),
             Some(&project_resource.0),
-            html! {"An email will arrive in the next few minutes with the next steps to reset your password."},
+            &html! {"An email will arrive in the next few minutes with the next steps to reset your password."},
             Some(&branding),
         ))
     } else {
@@ -160,7 +160,7 @@ pub async fn password_reset_verify_get<
         Ok(message_html(
             Some(&tenant),
             Some(&project_resource),
-            html! {
+            &html! {
                 div {}
                 h1 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl "{
                     "Set your password"}
@@ -271,7 +271,7 @@ pub async fn password_reset_verify_post<
         Ok(message_html(
             Some(&tenant),
             Some(&project_resource),
-            html! { span {
+            &html! { span {
                     "Password has been reset successfully. "
                     @if let Some(admin_app_url) = admin_app_url {
                         "Go to the Admin App "

--- a/backend/crates/server/src/fhir_client/middleware/auth_z/access_control.rs
+++ b/backend/crates/server/src/fhir_client/middleware/auth_z/access_control.rs
@@ -53,9 +53,8 @@ impl<
                 UserRole::Admin | UserRole::Owner => {
                     if let Some(next) = next {
                         return next(state, context).await;
-                    } else {
-                        Ok(context)
                     }
+                    Ok(context)
                 }
                 UserRole::Member => {
                     let policies = state

--- a/backend/crates/server/src/fhir_client/subscription_limits/rate_limits.rs
+++ b/backend/crates/server/src/fhir_client/subscription_limits/rate_limits.rs
@@ -27,8 +27,8 @@ static OPERATION_POINTS: LazyLock<OperationScoringPoints> =
 
 // Per day Limits
 static DEFAULT_FREE_TIER: usize = 25000;
-static DEFAULT_PRO_TIER: usize = 1000000;
-static DEFAULT_TEAM_TIER: usize = 5000000;
+static DEFAULT_PRO_TIER: usize = 1_000_000;
+static DEFAULT_TEAM_TIER: usize = 5_000_000;
 
 struct SubscriptionTiers {
     free: usize,

--- a/backend/crates/server/src/mcp/operations/initialize.rs
+++ b/backend/crates/server/src/mcp/operations/initialize.rs
@@ -12,9 +12,7 @@ use haste_fhir_client::FHIRClient;
 use haste_fhir_operation_error::OperationOutcomeError;
 use std::sync::Arc;
 
-pub async fn initialize<
-    Client: FHIRClient<Arc<ServerCTX<Client>>, OperationOutcomeError> + 'static,
->(
+pub fn initialize<Client: FHIRClient<Arc<ServerCTX<Client>>, OperationOutcomeError> + 'static>(
     _ctx: Arc<ServerCTX<Client>>,
     _request: &InitializeRequest,
 ) -> Result<InitializeResult, MCPError<serde_json::Value>> {

--- a/backend/crates/server/src/mcp/route.rs
+++ b/backend/crates/server/src/mcp/route.rs
@@ -59,7 +59,7 @@ pub async fn mcp_handler<
 
     match mcp_request {
         MCPRequest::Initialize(initialize_request) => {
-            let result = operations::initialize(ctx, &initialize_request).await?;
+            let result = operations::initialize(ctx, &initialize_request)?;
             Ok(Json(JSONRPCResult {
                 id: initialize_request.id.clone(),
                 result: ServerResult::Initialize(result),

--- a/backend/crates/server/src/middleware/errors.rs
+++ b/backend/crates/server/src/middleware/errors.rs
@@ -50,7 +50,7 @@ pub async fn operation_outcome_error_handle(
             let issue = outcome.issue.first();
             let body_html = error_html(
                 &tenant,
-                html! {
+                &html! {
                     div class ="text-xl font-semibold text-red-600 mb-4" {
                        (issue.as_ref().map(|i| &i.code)
                             .and_then(|s| s.as_str())

--- a/backend/crates/server/src/ui/components/page.rs
+++ b/backend/crates/server/src/ui/components/page.rs
@@ -2,7 +2,7 @@ use maud::{Markup, html};
 
 use crate::static_assets::asset_route;
 
-pub fn page_html(children: Markup) -> Markup {
+pub fn page_html(children: &Markup) -> Markup {
     html! {
         head {
             meta charset="utf-8" {}

--- a/backend/crates/server/src/ui/email/base.rs
+++ b/backend/crates/server/src/ui/email/base.rs
@@ -3,7 +3,7 @@ use maud::{Markup, html};
 
 use crate::static_assets::asset_route;
 
-pub fn base(uri: &Uri, children: Markup) -> Markup {
+pub fn base(uri: &Uri, children: &Markup) -> Markup {
     let img_url = Uri::builder()
         .scheme(uri.scheme().unwrap().clone())
         .authority(uri.authority().unwrap().clone())

--- a/backend/crates/server/src/ui/pages/email_form.rs
+++ b/backend/crates/server/src/ui/pages/email_form.rs
@@ -16,9 +16,9 @@ pub fn email_form_html(
     let project_name = project
         .and_then(|p| p.name.value.as_ref())
         .or_else(|| project.and_then(|p| p.id.as_ref()))
-        .map(|s| s.as_str());
+        .map(std::string::String::as_str);
 
-    page_html(html! {
+    page_html(&html! {
         (page_banner(tenant.as_ref(), project_name, branding))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow  md:mt-0  xl:p-0 " {
             form class="space-y-4 md:space-y-6" action=(email_information.continue_url) method="POST" {

--- a/backend/crates/server/src/ui/pages/error.rs
+++ b/backend/crates/server/src/ui/pages/error.rs
@@ -2,8 +2,8 @@ use crate::ui::components::{TenantName, page_banner, page_html};
 use haste_jwt::TenantId;
 use maud::{Markup, html};
 
-pub fn error_html(tenant: &TenantId, message: Markup, branding: Option<&TenantName>) -> Markup {
-    page_html(html! {
+pub fn error_html(tenant: &TenantId, message: &Markup, branding: Option<&TenantName>) -> Markup {
+    page_html(&html! {
         (page_banner(tenant.as_ref(), None, branding))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow  md:mt-0  xl:p-0 " {
             div class="p-6 space-y-4 md:space-y-6 sm:p-8" {

--- a/backend/crates/server/src/ui/pages/login.rs
+++ b/backend/crates/server/src/ui/pages/login.rs
@@ -17,32 +17,28 @@ pub fn login_form_html(
     errors: Option<Vec<String>>,
 ) -> Markup {
     let project_id = project.id.clone().map(ProjectId::new).unwrap();
-    let project_name = project
-        .name
-        .value
-        .as_ref()
-        .map(|s| Cow::Borrowed(s.as_str()))
-        .unwrap_or_else(|| Cow::Owned(project_id.as_ref().to_string()));
+    let project_name = project.name.value.as_ref().map_or_else(
+        || Cow::Owned(project_id.as_ref().to_string()),
+        |s| Cow::Borrowed(s.as_str()),
+    );
     let password_reset_route =
         oidc_route_string(&context.tenant, &project_id, "interactions/password-reset");
     let password_reset_route_str = password_reset_route
         .to_str()
         .expect("Could not create password reset route.");
-    let client_name = client_app
-        .name
-        .value
-        .as_ref()
-        .map(Cow::Borrowed)
-        .unwrap_or_else(|| {
+    let client_name = client_app.name.value.as_ref().map_or_else(
+        || {
             Cow::Owned(
                 client_app
                     .id
                     .clone()
                     .unwrap_or_else(|| "unknown client".to_string()),
             )
-        });
+        },
+        Cow::Borrowed,
+    );
 
-    page_html(html! {
+    page_html(&html! {
         (page_banner(context.tenant.as_ref(), Some(&project_name), Some(&context.branding)))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow md:mt-0 xl:p-0 text-slate-700" {
             div class="p-6 space-y-4 md:space-y-6 sm:p-8" {

--- a/backend/crates/server/src/ui/pages/message.rs
+++ b/backend/crates/server/src/ui/pages/message.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 pub fn message_html(
     tenant: Option<&TenantId>,
     project: Option<&haste_fhir_model::r4::generated::resources::Project>,
-    message: Markup,
+    message: &Markup,
     branding: Option<&TenantName>,
 ) -> Markup {
     let project_id = project.map(|project| project.id.clone().map(ProjectId::new).unwrap());
@@ -15,8 +15,8 @@ pub fn message_html(
         .map(|s| Cow::Borrowed(s.as_str()))
         .or_else(|| project_id.map(|p_id| Cow::Owned(p_id.as_ref().to_string())));
 
-    page_html(html! {
-        (page_banner(tenant.map(|t| t.as_ref()).unwrap_or(""), project_name.as_ref().map(|p| p.as_ref()), branding))
+    page_html(&html! {
+        (page_banner(tenant.map_or("", |t| t.as_ref()), project_name.as_deref(), branding))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow  md:mt-0  xl:p-0" {
             div class="p-6 space-y-4 md:space-y-6 sm:p-8" {
                 (message)

--- a/backend/crates/server/src/ui/pages/mfa/activate.rs
+++ b/backend/crates/server/src/ui/pages/mfa/activate.rs
@@ -10,7 +10,7 @@ pub fn mfa_activate_html(
     activate_route: &str,
     errors: Option<Vec<String>>,
 ) -> Markup {
-    page_html(html! {
+    page_html(&html! {
         (page_banner(context.tenant.as_ref(), None, Some(&context.branding)))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow md:mt-0 xl:p-0 text-slate-700" {
             div class="p-6 space-y-4 md:space-y-6 sm:p-8" {

--- a/backend/crates/server/src/ui/pages/mfa/admin.rs
+++ b/backend/crates/server/src/ui/pages/mfa/admin.rs
@@ -27,7 +27,7 @@ pub fn mfa_admin_html(
     activate_route: &str,
     branding: Option<&TenantName>,
 ) -> Markup {
-    page_html(html! {
+    page_html(&html! {
         (page_banner(tenant.as_ref(), None, branding))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow md:mt-0 xl:p-0 text-slate-700" {
             div class="p-6 space-y-4 md:space-y-6 sm:p-8" {

--- a/backend/crates/server/src/ui/pages/mfa/select.rs
+++ b/backend/crates/server/src/ui/pages/mfa/select.rs
@@ -26,7 +26,7 @@ pub fn mfa_select_html(
     mfa_select_route: &str,
     branding: Option<&TenantName>,
 ) -> Markup {
-    page_html(html! {
+    page_html(&html! {
         (page_banner(tenant.as_ref(), None, branding))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow md:mt-0 xl:p-0 text-slate-700" {
             @if credentials.is_empty() {

--- a/backend/crates/server/src/ui/pages/mfa/totp_verification.rs
+++ b/backend/crates/server/src/ui/pages/mfa/totp_verification.rs
@@ -10,7 +10,7 @@ pub fn totp_entry_html(
     errors: Option<Vec<String>>,
     branding: Option<&TenantName>,
 ) -> Markup {
-    page_html(html! {
+    page_html(&html! {
         (page_banner(tenant.as_ref(), None, branding))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow md:mt-0 xl:p-0 text-slate-700" {
             div class="p-6 space-y-4 md:space-y-6 sm:p-8" {

--- a/backend/crates/server/src/ui/pages/project_select.rs
+++ b/backend/crates/server/src/ui/pages/project_select.rs
@@ -20,7 +20,7 @@ pub fn project_select_html(
     projects: &[Project],
     branding: Option<&TenantName>,
 ) -> Result<Markup, OperationOutcomeError> {
-    Ok(page_html(html! {
+    Ok(page_html(&html! {
         (page_banner(tenant.as_ref(), None, branding))
         div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow md:mt-0 xl:p-0 text-slate-700" {
             @if projects.is_empty() {
@@ -34,7 +34,7 @@ pub fn project_select_html(
                             @for project
                             in projects.iter() {
                                 div {
-                                    a href=(admin_app::redirect_url(config, tenant, &get_project_id(project)?).unwrap_or("".to_string()))
+                                    a href=(admin_app::redirect_url(config, tenant, &get_project_id(project)?).unwrap_or_default())
                                     class="block w-full rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-center text-sm font-medium text-slate-900 transition-colors hover:bg-brand-50 hover:border-brand-200" {
                                         (project.name.value.as_ref().unwrap_or(&project.id.clone().unwrap_or_else(|| "Unnamed Project".to_string())))
                                     }

--- a/backend/crates/server/src/ui/pages/scope_approval.rs
+++ b/backend/crates/server/src/ui/pages/scope_approval.rs
@@ -23,17 +23,15 @@ pub fn scope_approval_html(
     branding: Option<&TenantName>,
 ) -> Markup {
     let project_id = project.id.clone().map(ProjectId::new).unwrap();
-    let project_name = project
-        .name
-        .value
-        .as_ref()
-        .map(|s| Cow::Borrowed(s.as_str()))
-        .unwrap_or_else(|| Cow::Owned(project_id.as_ref().to_string()));
+    let project_name = project.name.value.as_ref().map_or_else(
+        || Cow::Owned(project_id.as_ref().to_string()),
+        |s| Cow::Borrowed(s.as_str()),
+    );
 
     let scope_route = oidc_route_string(tenant, &project_id, "auth/scope");
     let scope_route_str = scope_route.to_str().expect("Could not create scope route");
 
-    page_html(html! {
+    page_html(&html! {
             (page_banner(tenant.as_ref(), Some(&project_name), branding))
             div class="border border-brand-50 w-full bg-white   bg-white rounded-lg shadow  md:mt-0  xl:p-0" {
                 div class="p-6 space-y-4 md:space-y-6 sm:p-8" {


### PR DESCRIPTION
These lints were generated by running `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`. Fixing them will help reduce technical debt and ensure a cleaner, more straightforward codebase for this repository.

First in a series of small PRs to completely fix all `clippy` lints.

